### PR TITLE
docs: resolve renderer stash cleanup

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -30,7 +30,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Docs updated | `README.md`, `PLAN.md`, `ARCHITECTURE.md`, `TODO.md`, `CHECKLIST.md` updated | Done |
 | CTO worktree cleanup | `git worktree list` shows only main worktree | Done |
 | Clean main worktree | `git status --short --branch` shows clean `main` | Done |
-| Abandoned renderer stash | `stash@{0}` inspected; touches only `src/renderer/App.tsx` and `src/renderer/styles.css`; current `main` has newer renderer behavior including draft recovery and mask alpha validation; archived non-destructively to `origin/archive/abandoned-renderer-stash`; tracked in GitHub issue #2 | Archived; local stash delete/keep decision still needs user confirmation |
+| Abandoned renderer stash | `stash@{0}` inspected; touched only `src/renderer/App.tsx` and `src/renderer/styles.css`; current `main` has newer renderer behavior including draft recovery and mask alpha validation; archived non-destructively to `origin/archive/abandoned-renderer-stash`; local stash dropped after verifying the archive commit matched | Resolved; tracked in GitHub issue #2 |
 | Remote/PR parity | private GitHub `origin` configured at `https://github.com/Bliveren/image2tools.git`; `main` pushed and tracks `origin/main`; `git ls-remote --heads origin main` matches local pushed history | Done for current `main`; future subtask branches can use PR flow |
 | Real API generation/edit/inpaint | `pnpm verify:real-api` provides a cost-confirmed real API acceptance path for generation, single-image edit, multi-image edit, and inpaint; no real API key was provided or used; tracked in GitHub issue #1 | External/manual pending |
 | Signed installable distribution | Unsigned macOS dmg/zip generated; `pnpm verify:signing-ready` checks code signing identity, notarization env vars, and signing config without exposing secrets; no certificate/notarization available; tracked in GitHub issue #3 | External/manual pending |
@@ -70,17 +70,18 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `git remote -v`: `origin` is `https://github.com/Bliveren/image2tools.git` for fetch and push.
 - `git ls-remote --heads origin main`: remote `main` exists and matched the pushed local history when checked.
 - `gh repo view Bliveren/image2tools --json nameWithOwner,visibility,url,defaultBranchRef`: repository exists as private GitHub repo with default branch `main`.
-- `gh issue list --repo Bliveren/image2tools --state open --limit 10`: external blockers are tracked as issues #1 through #5.
+- `gh issue list --repo Bliveren/image2tools --state open --limit 10`: remaining external blockers are tracked as issues #1 and #3 through #5.
 - GitHub milestone `v0.1.0 external acceptance`: tracks the open external blocker issues at https://github.com/Bliveren/image2tools/milestone/1.
 - `git stash show --stat stash@{0}` and `git show stash@{0}:...`: stash inspected; it is an old alternate renderer experiment and is not part of `main`.
-- `git branch archive/abandoned-renderer-stash stash@{0}` and `git push origin archive/abandoned-renderer-stash`: non-destructive archive branch created at `78b2c683fc180c8e511d1802b37545fd48c8c887`; `stash@{0}` was intentionally left in place.
+- `git branch archive/abandoned-renderer-stash stash@{0}` and `git push origin archive/abandoned-renderer-stash`: non-destructive archive branch created at `78b2c683fc180c8e511d1802b37545fd48c8c887`.
+- `git rev-parse stash@{0}`, `git rev-parse archive/abandoned-renderer-stash`, and `git ls-remote --heads origin archive/abandoned-renderer-stash`: local stash, local archive branch, and remote archive branch all matched `78b2c683fc180c8e511d1802b37545fd48c8c887`.
+- `git stash drop stash@{0}` and `git stash list`: local duplicate stash was dropped after archive verification; no local stash entries remain.
 
 ## Remaining External Work
 
 GitHub milestone: https://github.com/Bliveren/image2tools/milestone/1
 
 - Use a real Image 2 API key to manually verify text generation, single-image edit, multi-image edit, and inpainting: GitHub issue #1.
-- Confirm whether to delete or keep local `stash@{0}` now that it is archived to `origin/archive/abandoned-renderer-stash`: GitHub issue #2.
 - Add signing identity, notarization, and formal release metadata: GitHub issue #3.
 - Validate non-macOS target platforms: GitHub issue #4.
 - Resolve GitHub Actions billing/spending limit so CI can execute: GitHub issue #5.

--- a/PLAN.md
+++ b/PLAN.md
@@ -104,7 +104,7 @@
 - 已创建 private GitHub 远程 `origin`：`https://github.com/Bliveren/image2tools.git`，当前 `main` 已推送并跟踪 `origin/main`。
 - 后续子任务恢复“分支推送 -> PR -> CTO 审核 -> 合并”的完整流程；远程创建前完成的本地分支工作已由 CTO 本地审核合并后推送为 `main` 基线。
 - 本轮已交付可运行 MVP：配置、连接测试、文生图、图像编辑、mask 编辑、下载、历史、错误提示、基础测试、草稿/异常恢复、macOS 本地打包配置。
-- 当前本地 worktree 已清理完毕，仅保留 `main`。被放弃的 renderer 实验已保存在 `stash@{0}`，并已非破坏性归档到远程分支 `origin/archive/abandoned-renderer-stash`。该实验已评估为旧版 UI 实验，未合入 `main`，待用户确认后删除或继续保留本地 stash。
+- 当前本地 worktree 已清理完毕，仅保留 `main`。被放弃的 renderer 实验已非破坏性归档到远程分支 `origin/archive/abandoned-renderer-stash`，本地 stash 已删除。该实验已评估为旧版 UI 实验，未合入 `main`。
 
 ## 7. 里程碑拆解
 

--- a/TODO.md
+++ b/TODO.md
@@ -107,7 +107,7 @@ GitHub milestone: https://github.com/Bliveren/image2tools/milestone/1
 - [ ] 非 macOS 平台安装验证（GitHub issue #4）
 - [x] 已评估 `stash@{0}` 中未合并的 renderer 实验；当前 `main` 已覆盖其核心能力并包含更新的草稿恢复、mask 校验和打包配置
 - [x] 已将 `stash@{0}` 非破坏性归档到 `origin/archive/abandoned-renderer-stash`
-- [ ] 经用户确认后删除或保留本地 `stash@{0}`（GitHub issue #2）
+- [x] 本地 `stash@{0}` 已在确认远程归档后删除（GitHub issue #2）
 
 ## 建议优先级
 


### PR DESCRIPTION
## Summary\n- records that the abandoned renderer stash was archived to origin/archive/abandoned-renderer-stash\n- records that the duplicate local stash entry was dropped after archive verification\n- removes issue #2 from remaining external work\n\n## Verification\n- git diff --check