### PR TITLE
docs: stabilize completion audit metadata

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,7 +2,8 @@
 
 Date: 2026-05-18
 Branch: `main`
-Latest audited implementation commit: `eb40efd`
+Runtime/config evidence through: `8f437e2`
+Docs and external-blocker evidence: current `main` revision
 
 ## Objective Restated
 


### PR DESCRIPTION
## Summary\n- replace the fragile latest-commit audit header with stable runtime/config and docs/blocker evidence scope\n\n## Verification\n- git diff --check