### PR TITLE
Update completion audit evidence

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-18
 Branch: `main`
-Runtime/config evidence through: `8f437e2`
+Runtime/config evidence through: `224bcd4`
 Docs and external-blocker evidence: current `main` revision
 
 ## Objective Restated
@@ -69,6 +69,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm verify:signing-ready`: reported no valid code signing identities, `build.mac.identity` set to `null`, and notarization env vars unset; no signing or notarization was attempted.
 - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`: GitHub Actions workflow YAML parsed locally after adding Windows/Linux package jobs and manual dispatch.
 - `gh run view 26011616452 --repo Bliveren/image2tools`: CI was triggered but both jobs were blocked before starting because GitHub reported account payment/spending-limit restrictions.
+- `gh run view 26015867159 --json databaseId,status,conclusion,jobs,headSha,event,createdAt,updatedAt,url`: latest `main` CI run on `f2fc05b` still failed before any workflow job steps executed; all jobs had empty `steps` arrays, and this evidence was added to GitHub issue #5.
 - `curl` checks against the mock passed for `/models`, JSON `/images/generations`, SSE `/images/generations`, and multipart `/images/edits`.
 - `git status --short --branch`: clean `main`.
 - `git worktree list`: only `/Users/alive/projects/image2tools`.


### PR DESCRIPTION
## Summary
- update runtime/config evidence pointer after the packaged runtime fix
- add the latest main CI blocker run evidence to the completion audit

## Verification
- git diff --check
- gh run view 26015867159 confirmed all jobs still failed with empty steps arrays