### PR TITLE
Clean up release verifier app on failure

### DIFF
--- a/scripts/verify-mac-release.mjs
+++ b/scripts/verify-mac-release.mjs
@@ -123,12 +123,15 @@ async function runInstallCycle(mountPoint, tempRoot, cycle) {
   const executablePath = path.join(appPath, appExecutable);
   await rm(appPath, { recursive: true, force: true });
   await cp(path.join(mountPoint, appName), appPath, { recursive: true });
-  await run("open", ["-n", appPath]);
-  const pids = await waitForLaunch(executablePath);
-  const windowPid = await waitForMainWindow(pids);
-  console.log(`Cycle ${cycle}: launched ${appPath} with pid ${pids.join(",")} and showed a main window on pid ${windowPid}.`);
-  await stopApp(executablePath);
-  await rm(appPath, { recursive: true, force: true });
+  try {
+    await run("open", ["-n", appPath]);
+    const pids = await waitForLaunch(executablePath);
+    const windowPid = await waitForMainWindow(pids);
+    console.log(`Cycle ${cycle}: launched ${appPath} with pid ${pids.join(",")} and showed a main window on pid ${windowPid}.`);
+  } finally {
+    await stopApp(executablePath);
+    await rm(appPath, { recursive: true, force: true });
+  }
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- ensure `verify:release:mac` stops the copied app and removes the temp app path even when launch/window checks fail

## Verification
- pnpm package:mac
- pnpm verify:release:mac
- confirmed no Image2Tools release-test app process remained after verifier exit