### PR TITLE
Expand mock Image API verifier coverage

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -24,7 +24,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Local file save and download | Base64 output saved under Electron `userData`; download dialog copies selected asset | Done |
 | History and reuse | JSON history, search, reuse, copy prompt, open folder, delete, clear | Done |
 | Recovery | Atomic state writes with `.bak`, interrupted job recovery, workspace draft autosave/restore | Done |
-| Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, and SSE events; `pnpm verify:mock-api` probes all mock routes | Done |
+| Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, and SSE events; `pnpm verify:mock-api` probes models, JSON generation, streaming generation, multipart edit, multi-image mask edit/inpaint, and streaming edit | Done |
 | Tests | `pnpm build` passed with 3 test files and 15 tests | Done |
 | Packaging | `electron-builder` config includes main, preload, shared, and renderer runtime outputs; project icons in `build/`; `pnpm package:dir`; `pnpm package:mac`; local app; dmg-copy launch; two-cycle reinstall smoke tests; `pnpm verify:release:mac` confirms the app process and main window; private GitHub pre-release `v0.1.0-mac-unsigned` | Done for unsigned macOS local/pre-release artifacts |
 | Remote CI | `.github/workflows/ci.yml` runs build + mock API verifier on Ubuntu and macOS, Windows, and Linux package gates for push/PR/manual dispatch; runs are blocked before job steps by GitHub billing/spending limit | Configured; external billing blocker tracked in GitHub issue #5 |
@@ -65,6 +65,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the `7b3b9bc` tree.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the `39f4a3d` tree.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the `8f437e2` tree.
+- `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the mock verifier coverage tree; it now checks JSON generation, streaming generation, single-image multipart edit, multi-image mask edit/inpaint, and streaming edit against the local mock.
 - `pnpm verify:real-api`: without an API key, exits before making real API calls.
 - `IMAGE2TOOLS_API_KEY=sk-test-no-call pnpm verify:real-api`: exits before making real API calls unless `IMAGE2TOOLS_REAL_API_ACCEPT_COST=1` is explicitly set.
 - `IMAGE2TOOLS_API_KEY=sk-mock-image2tools IMAGE2TOOLS_BASE_URL=http://127.0.0.1:8788/v1 IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 pnpm verify:real-api`: passed against the local mock API, covering the script's generation, single-edit, multi-edit, and inpaint request paths; temporary artifacts and mock process were cleaned up.

--- a/scripts/mock-openai-image-api.mjs
+++ b/scripts/mock-openai-image-api.mjs
@@ -13,6 +13,29 @@ function sendJson(response, status, payload) {
   response.end(`${JSON.stringify(payload)}\n`);
 }
 
+function hasField(bodyText, name) {
+  if (bodyText.includes(`name="${name}"`)) return true;
+  try {
+    const payload = JSON.parse(bodyText);
+    return Object.hasOwn(payload, name);
+  } catch {
+    return false;
+  }
+}
+
+function validateImageRequest(pathname, bodyText) {
+  if (!hasField(bodyText, "model")) {
+    return "Missing model field";
+  }
+  if (!hasField(bodyText, "prompt")) {
+    return "Missing prompt field";
+  }
+  if (pathname.endsWith("/edits") && !hasField(bodyText, "image[]") && !hasField(bodyText, "image") && !hasField(bodyText, "images")) {
+    return "Missing edit image field";
+  }
+  return null;
+}
+
 function sendSse(response, prefix) {
   response.writeHead(200, {
     "content-type": "text/event-stream",
@@ -56,6 +79,11 @@ const server = http.createServer(async (request, response) => {
 
     if (request.method === "POST" && (url.pathname === "/v1/images/generations" || url.pathname === "/v1/images/edits")) {
       const bodyText = await readText(request);
+      const validationError = validateImageRequest(url.pathname, bodyText);
+      if (validationError) {
+        sendJson(response, 400, { error: { message: validationError } });
+        return;
+      }
       const prefix = url.pathname.endsWith("/edits") ? "image_edit" : "image_generation";
       if (wantsStream(request, bodyText)) {
         sendSse(response, prefix);

--- a/scripts/verify-mock-api.mjs
+++ b/scripts/verify-mock-api.mjs
@@ -104,6 +104,48 @@ async function verifyMultipartEdit() {
   assert(payload.data?.[0]?.b64_json?.startsWith(tinyPngPrefix), "multipart edit did not return a PNG b64_json");
 }
 
+async function verifyMultipartInpaint() {
+  const form = new FormData();
+  form.append("model", "gpt-image-2");
+  form.append("prompt", "mock inpaint with multiple image references");
+  form.append("stream", "false");
+  form.append("image[]", new Blob([Buffer.from("mock-source-a")], { type: "image/png" }), "source-a.png");
+  form.append("image[]", new Blob([Buffer.from("mock-source-b")], { type: "image/png" }), "source-b.png");
+  form.append("mask", new Blob([Buffer.from("mock-mask")], { type: "image/png" }), "mask.png");
+
+  const response = await fetch(`${baseURL}/images/edits`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form
+  });
+  assert(response.ok, `multipart inpaint failed with HTTP ${response.status}`);
+  const payload = await response.json();
+  assert(payload.data?.[0]?.b64_json?.startsWith(tinyPngPrefix), "multipart inpaint did not return a PNG b64_json");
+}
+
+async function verifySseEdit() {
+  const form = new FormData();
+  form.append("model", "gpt-image-2");
+  form.append("prompt", "mock streaming edit");
+  form.append("stream", "true");
+  form.append("partial_images", "2");
+  form.append("image[]", new Blob([Buffer.from("mock-source")], { type: "image/png" }), "source.png");
+
+  const response = await fetch(`${baseURL}/images/edits`, {
+    method: "POST",
+    headers: {
+      accept: "text/event-stream",
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: form
+  });
+  assert(response.ok, `sse edit failed with HTTP ${response.status}`);
+  const text = await response.text();
+  assert(text.includes("image_edit.partial_image"), "sse edit missing partial event");
+  assert(text.includes("image_edit.completed"), "sse edit missing completed event");
+  assert(text.includes(tinyPngPrefix), "sse edit missing PNG payload");
+}
+
 async function main() {
   const { server, getOutput } = startMockServer();
   try {
@@ -112,6 +154,8 @@ async function main() {
     await verifyJsonGeneration();
     await verifySseGeneration();
     await verifyMultipartEdit();
+    await verifyMultipartInpaint();
+    await verifySseEdit();
     console.log("Mock OpenAI Image API verification passed.");
   } catch (error) {
     console.error(getOutput());


### PR DESCRIPTION
## Summary
- make the mock Image API reject malformed generation/edit requests missing required fields
- extend `pnpm verify:mock-api` to cover single edit, multi-image mask edit/inpaint, and streaming edit
- update completion audit evidence for the broader no-key regression path

## Verification
- `pnpm verify:mock-api`
- `pnpm build`
- `git diff --check`

## Notes
GitHub Actions is still expected to fail before job steps until issue #5 is unblocked.