### PR TITLE
Record mac verifier fix evidence

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-18
 Branch: `main`
-Runtime/config evidence through: `a4b15de`
+Runtime/config evidence through: `246604a`
 Docs and external-blocker evidence: current `main` revision
 
 ## Objective Restated
@@ -62,6 +62,10 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `shasum -a 256 release/Image2Tools-0.1.0-mac-arm64.dmg release/Image2Tools-0.1.0-mac-arm64.zip`: local SHA256 values match GitHub asset digests (`a04cc4568a5010ca99a00df747d0317203b56fc86724ab116491c96472b31c96` for dmg, `75e0da8fe7181e3c515fcf8babb49da43acafa199e2cb7737b54601b48c9fd41` for zip).
 - Packaged app UI mock smoke on 2026-05-18: launched `release/mac-arm64/Image2Tools.app`, saved fake key `sk-mock-image2tools` and `http://127.0.0.1:8787/v1`, confirmed connection success in the UI, ran Generate through the UI, observed `Generate finished.`, history/result controls, a partial preview, and result files under Electron `userData`.
 - `pnpm package:mac` and `pnpm verify:release:mac`: passed on 2026-05-18 after hardening the release verifier so failed launch/window checks still stop the copied app and remove the temporary app path.
+- `pnpm verify:release:mac`: failed on 2026-05-18 for the current unsigned dmg because the old verifier held a stale launch pid and reported `Packaged app launched but did not show a main window`; manual investigation showed the packaged `Image2Tools` process was alive and System Events could see one window, so this was a verifier false negative rather than an app launch failure.
+- PR #24 updated `scripts/verify-mac-release.mjs` to refresh `Image2Tools` pids while waiting for the main window and to fall back to System Events process-name window detection for Electron/macOS pid churn.
+- `node ../image2tools-mac-verifier/scripts/verify-mac-release.mjs`: fixed verifier passed against the current dmg before PR #24 merge, completing two copy/launch/window/remove cycles.
+- `pnpm verify:release:mac`: passed on merged `main` at `246604a` after PR #24; it completed two copy/launch/window/remove cycles and detected the main window via the process-name fallback.
 - `pnpm mock:openai`: local mock API server starts at `http://127.0.0.1:8787/v1`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the `947450a` tree.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the `7b3b9bc` tree.


### PR DESCRIPTION
## Summary
- update completion audit runtime evidence through `246604a`
- record the macOS release verifier false negative, PR #24 fix, and post-merge verifier pass

## Verification
- `git diff --check`
- `pnpm verify:release:mac` passed on merged `main` at `246604a` before this docs PR
