### PR TITLE
docs: add external acceptance runbook

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -29,6 +29,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Packaging | `electron-builder` config includes main, preload, shared, and renderer runtime outputs; project icons in `build/`; `pnpm package:dir`; `pnpm package:mac`; local app; dmg-copy launch; two-cycle reinstall smoke tests; `pnpm verify:release:mac` confirms the app process and main window; private GitHub pre-release `v0.1.0-mac-unsigned` | Done for unsigned macOS local/pre-release artifacts |
 | Remote CI | `.github/workflows/ci.yml` runs build + mock API verifier on Ubuntu and macOS, Windows, and Linux package gates for push/PR/manual dispatch; runs are blocked before job steps by GitHub billing/spending limit | Configured; external billing blocker tracked in GitHub issue #5 |
 | Docs updated | `README.md`, `PLAN.md`, `ARCHITECTURE.md`, `TODO.md`, `CHECKLIST.md` updated | Done |
+| External acceptance runbook | `EXTERNAL_ACCEPTANCE.md` consolidates the remaining real API, signing/notarization, Windows/Linux, and CI billing gates with commands and evidence requirements | Done |
 | CTO worktree cleanup | `git worktree list` shows only main worktree | Done |
 | Clean main worktree | `git status --short --branch` shows clean `main` | Done |
 | Abandoned renderer stash | `stash@{0}` inspected; touched only `src/renderer/App.tsx` and `src/renderer/styles.css`; current `main` has newer renderer behavior including draft recovery and mask alpha validation; archived non-destructively to `origin/archive/abandoned-renderer-stash`; local stash dropped after verifying the archive commit matched | Resolved; tracked in GitHub issue #2 |
@@ -113,6 +114,8 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 ## Remaining External Work
 
 GitHub milestone: https://github.com/Bliveren/image2tools/milestone/1
+
+Runbook: [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md)
 
 - Use a real Image 2 API key to manually verify text generation, single-image edit, multi-image edit, and inpainting: GitHub issue #1.
 - Confirm the OpenAI organization behind the real API key has GPT Image organization verification before manual acceptance: GitHub issue #1.

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -1,0 +1,164 @@
+# Image2Tools External Acceptance Runbook
+
+This runbook covers the work that cannot be completed from the current local
+macOS development environment. Do not paste API keys, Apple credentials, or
+GitHub billing details into issues, PRs, or logs.
+
+## Baseline
+
+Start from the latest `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+pnpm install --frozen-lockfile
+pnpm build
+pnpm verify:mock-api
+```
+
+Current tracking milestone:
+https://github.com/Bliveren/image2tools/milestone/1
+
+## 1. Real Image 2 API Acceptance
+
+Tracked by GitHub issue #1.
+
+Prerequisites:
+
+- Real API key with access to `gpt-image-2`
+- Base URL, normally `https://api.openai.com/v1`
+- OpenAI organization verification completed for GPT Image access
+- Explicit cost approval for real image calls
+
+Core acceptance:
+
+```bash
+IMAGE2TOOLS_API_KEY=... \
+IMAGE2TOOLS_BASE_URL=https://api.openai.com/v1 \
+IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 \
+pnpm verify:real-api
+```
+
+Optional streaming acceptance, only when the extra partial-image token cost is
+approved:
+
+```bash
+IMAGE2TOOLS_API_KEY=... \
+IMAGE2TOOLS_BASE_URL=https://api.openai.com/v1 \
+IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 \
+IMAGE2TOOLS_REAL_API_ACCEPT_STREAM_COST=1 \
+pnpm verify:real-api
+```
+
+Expected coverage:
+
+- text-to-image generation
+- single-image edit
+- multi-image reference edit
+- mask-based inpaint
+- optional streaming generation and edit partial/final events
+
+Artifacts are written to ignored `real-api-artifacts/`. After success, update
+`CHECKLIST.md`, `TODO.md`, and `COMPLETION_AUDIT.md`, then close issue #1.
+
+## 2. GitHub Actions Billing Gate
+
+Tracked by GitHub issue #5.
+
+Do not rerun known-failing workflows until the account billing or spending-limit
+restriction is fixed. The current failure signature is jobs that fail before
+workflow steps execute, with empty `steps` arrays.
+
+After billing is fixed, rerun the latest failed workflow from the GitHub Actions
+UI or use a fresh PR/push if rerun is unavailable. Acceptance requires:
+
+- Build and mock API verifier job starts and passes
+- macOS package job starts and passes, or a runner-policy issue is documented
+- Windows package job starts and passes, or a runner-policy issue is documented
+- Linux package job starts and passes, or a runner-policy issue is documented
+
+Record the green run URL in `COMPLETION_AUDIT.md` and close issue #5 when CI
+can execute normally.
+
+## 3. Signed And Notarized macOS Release
+
+Tracked by GitHub issue #3.
+
+Prerequisites:
+
+- Valid Developer ID Application signing identity on the build host
+- Apple notarization credentials available only through local env vars or CI
+  secrets
+- A signing branch that removes or replaces the current
+  `build.mac.identity: null` unsigned-build override
+
+Use the required CTO branch/worktree flow before changing signing config:
+
+```bash
+git worktree add -b release/cto-signed-mac ../image2tools-signed-mac main
+cd ../image2tools-signed-mac
+```
+
+Set credentials outside logs:
+
+```bash
+export CSC_NAME="Developer ID Application: <Team Name> (<TEAM_ID>)"
+export APPLE_ID="<apple-id-email>"
+export APPLE_APP_SPECIFIC_PASSWORD="<app-specific-password>"
+export APPLE_TEAM_ID="<team-id>"
+```
+
+Then run:
+
+```bash
+pnpm verify:signing-ready
+pnpm package:mac
+pnpm verify:release:mac
+```
+
+After success, update release metadata, `CHECKLIST.md`, `TODO.md`, and
+`COMPLETION_AUDIT.md`, then close issue #3.
+
+## 4. Windows And Linux Native Validation
+
+Tracked by GitHub issue #4.
+
+Run on each native platform:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm verify:mock-api
+pnpm package
+```
+
+Manual platform checks:
+
+- packaged app launches
+- mock API key and base URL can be configured
+- connection test succeeds against `http://127.0.0.1:8787/v1`
+- generation, edit, multi-image edit, and inpaint paths can be exercised through
+  the mock-backed app or equivalent verifier
+- download works
+- open-folder behavior works for that OS
+
+Record OS/version, package artifact paths, launch results, and any
+platform-specific notes in `CHECKLIST.md` and `COMPLETION_AUDIT.md`, then close
+issue #4.
+
+## Final Completion Pass
+
+After all four external blockers are closed:
+
+```bash
+pnpm build
+pnpm verify:mock-api
+pnpm verify:release:mac
+git status --short --branch
+gh pr list --state open
+gh issue list --state open
+```
+
+Completion requires no open project-blocking issues, no open PRs, clean and
+synced `main`, current audit docs, and real evidence for the actual API,
+release, CI, and native-platform gates.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [TODO.md](./TODO.md): 可直接执行的任务清单
 - [CHECKLIST.md](./CHECKLIST.md): 开发与发布检查清单
 - [COMPLETION_AUDIT.md](./COMPLETION_AUDIT.md): 当前交付证据、验证命令和外部待办
+- [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md): 真实 API、签名、公证、跨平台和 CI 外部验收步骤
 
 ## 本地运行
 

--- a/TODO.md
+++ b/TODO.md
@@ -95,6 +95,8 @@
 
 GitHub milestone: https://github.com/Bliveren/image2tools/milestone/1
 
+统一外部验收步骤见 [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md)。
+
 - [x] 配置远程 `origin` 并推送当前 `main`
 - [ ] 用真实 API Key 做一次实际生成、编辑、局部重绘手工验收（GitHub issue #1）
 - [x] 运行 `pnpm package:dir` 和 `pnpm package:mac` 产出本机试用包


### PR DESCRIPTION
## Summary
- add EXTERNAL_ACCEPTANCE.md with the remaining external acceptance gates
- link the runbook from README, TODO, and COMPLETION_AUDIT
- keep completion statuses unchanged; real API, signing, Windows/Linux, and CI billing remain external blockers

## Verification
- git diff --check