### PR TITLE
fix: harden mac release dmg detach cleanup

### DIFF
--- a/scripts/verify-mac-release.mjs
+++ b/scripts/verify-mac-release.mjs
@@ -55,6 +55,12 @@ async function detachDmg(mountPoint) {
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
   }
+  try {
+    await run("hdiutil", ["detach", "-force", mountPoint]);
+    return;
+  } catch (error) {
+    lastError = error;
+  }
   throw lastError;
 }
 
@@ -170,10 +176,10 @@ async function main() {
     await runInstallCycle(mountPoint, tempRoot, 2);
     console.log("macOS release verification passed.");
   } finally {
+    await rm(tempRoot, { recursive: true, force: true });
     if (mountPoint) {
       await detachDmg(mountPoint);
     }
-    await rm(tempRoot, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the temporary copied app before detaching the mounted dmg
- add a force-detach fallback after normal hdiutil detach retries

## Verification
- node --check scripts/verify-mac-release.mjs
- git diff --check
- pnpm package:mac
- pnpm verify:release:mac

## External blockers
- Does not resolve real API acceptance, signing/notarization, Windows/Linux native validation, or GitHub Actions billing (#1, #3, #4, #5).