### PR TITLE
docs: record linux container validation evidence

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -80,6 +80,9 @@
 - [x] macOS dmg 安装 smoke test 可通过 `pnpm verify:release:mac` 自动复跑
 - [x] macOS dmg smoke test 会确认主窗口实际出现
 - [x] GitHub Actions 已配置 build、mock API verifier、macOS / Windows / Linux package gates
+- [x] Linux ARM64 容器环境可 build、通过 mock verifier、生成 AppImage、解包并在 Xvfb 下启动
+- [ ] Windows 原生安装与启动验证完成
+- [ ] Linux 原生桌面 AppImage 直接运行、下载、打开文件夹行为验证完成
 - [x] 真实 API 验收脚本默认受成本确认保护
 - [x] 真实 streaming 验收需要额外成本确认
 - [x] 签名/公证 readiness 脚本不会暴露 secret 且不会尝试签名

--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,8 +2,8 @@
 
 Date: 2026-05-18
 Branch: `main`
-Runtime/config evidence through: `033e888`
-Release and external-blocker evidence through: `033e888`
+Runtime/config evidence through: `d701ae8`
+Release and external-blocker evidence through: `d701ae8`
 
 ## Objective Restated
 
@@ -25,7 +25,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | History and reuse | JSON history, search, reuse, copy prompt, open folder, delete, clear | Done |
 | Recovery | Atomic state writes with `.bak`, interrupted job recovery, workspace draft autosave/restore | Done |
 | Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, and SSE events; `pnpm verify:mock-api` probes models, JSON generation, streaming generation, multipart edit, multi-image mask edit/inpaint, and streaming edit | Done |
-| Tests | `pnpm build` passed with 4 test files and 21 tests on `033e888` | Done |
+| Tests | `pnpm build` passed with 4 test files and 21 tests on `d701ae8` | Done |
 | Packaging | `electron-builder` config includes main, preload, shared, and renderer runtime outputs; project icons in `build/`; `pnpm package:dir`; `pnpm package:mac`; local app; dmg-copy launch; two-cycle reinstall smoke tests; `pnpm verify:release:mac` confirms the app process and main window; private GitHub pre-release `v0.1.0-mac-unsigned` | Done for unsigned macOS local/pre-release artifacts |
 | Remote CI | `.github/workflows/ci.yml` runs build + mock API verifier on Ubuntu and macOS, Windows, and Linux package gates for push/PR/manual dispatch; runs are blocked before job steps by GitHub billing/spending limit | Configured; external billing blocker tracked in GitHub issue #5 |
 | Docs updated | `README.md`, `PLAN.md`, `ARCHITECTURE.md`, `TODO.md`, `CHECKLIST.md` updated | Done |
@@ -37,7 +37,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Official OpenAI docs parity | Current OpenAI Image Generation guide and OpenAPI endpoint metadata confirm `gpt-image-2`, `/images/generations`, `/images/edits`, base64 output, streaming partial images, mask requirements, size/format/quality/compression/background/moderation parameters, no transparent background for `gpt-image-2`, and omitted `input_fidelity` for `gpt-image-2`; docs also note GPT Image organization verification and extra partial-image token cost | Done |
 | Real API generation/edit/inpaint | `pnpm verify:real-api` provides a cost-confirmed real API acceptance path for generation, single-image edit, multi-image edit, and inpaint; an extra opt-in cost flag adds real streaming generation and edit coverage; no real API key was provided or used; tracked in GitHub issue #1 | External/manual pending |
 | Signed installable distribution | Unsigned macOS dmg/zip generated; `pnpm verify:signing-ready` checks code signing identity, notarization env vars, and signed packaging override without exposing secrets; `pnpm package:mac:signed` is available for the future Developer ID/notarization path; no certificate/notarization available; tracked in GitHub issue #3 | External/manual pending |
-| Cross-platform install validation | Windows and Linux package gates are configured in GitHub Actions; native install/launch validation still needs corresponding environments; tracked in GitHub issue #4 | External/manual pending |
+| Cross-platform install validation | Windows and Linux package gates are configured in GitHub Actions; Ubuntu 24.04 ARM64 Docker validation on the macOS host passed build, mock API verification, Linux AppImage packaging, AppImage extraction, and extracted-app launch under Xvfb. Direct AppImage execution is still blocked in Docker by missing FUSE device support, and native Windows plus native Linux desktop shell checks are still pending; tracked in GitHub issue #4 | Partially verified; external/manual pending |
 
 ## Verification Commands Run
 
@@ -53,6 +53,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for current `main` at `780af4d`; Vitest reported 4 test files and 21 tests passed.
 - `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for current `main` at `06394ad`; Vitest reported 4 test files and 21 tests passed.
 - `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for current `main` at `033e888`; Vitest reported 4 test files and 21 tests passed.
+- `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for current `main` at `d701ae8`; Vitest reported 4 test files and 21 tests passed.
 - `pnpm package:dir`: unsigned macOS app directory regenerated successfully on 2026-05-18 after `9111b90`; command reran build, typecheck, and 15 tests first.
 - `open -n release/mac-arm64/Image2Tools.app`: packaged app launched on 2026-05-18 after `8a69b39`; process was observed, then the smoke-test process was terminated after AppleScript quit was not handled by the app.
 - `pnpm package:mac`: regenerated `release/Image2Tools-0.1.0-mac-arm64.dmg`, `.zip`, and blockmaps successfully on 2026-05-18 after `9111b90`; command reran build, typecheck, and 15 tests first.
@@ -89,6 +90,12 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `shasum -a 256 release/Image2Tools-0.1.0-mac-arm64.dmg release/Image2Tools-0.1.0-mac-arm64.zip`: refreshed local SHA256 values match GitHub asset digests (`194efb3e19c28d72ee32a9e386a4f74e89e4fa81de7420ddc751c1f0b264b96a` for dmg, `f8b14515a7b92b755dc3d9f1d6b8cbf374ff7f8f47299a22cdfe3141300451a7` for zip).
 - `pnpm verify:release:mac`: passed on current `main` at `06394ad`; it completed two copy/launch/window/remove cycles and confirmed a main window in both cycles.
 - `shasum -a 256 release/Image2Tools-0.1.0-mac-arm64.dmg release/Image2Tools-0.1.0-mac-arm64.zip`: current local unsigned release files still match the documented GitHub release asset digests (`194efb3e19c28d72ee32a9e386a4f74e89e4fa81de7420ddc751c1f0b264b96a` for dmg, `f8b14515a7b92b755dc3d9f1d6b8cbf374ff7f8f47299a22cdfe3141300451a7` for zip).
+- `docker pull --platform linux/arm64 node:25-bookworm`: after one transient TLS copy error, downloaded the Node 25 Debian Bookworm ARM64 image for Linux container validation.
+- `docker run --platform linux/arm64 ... node:25-bookworm ... pnpm build && pnpm verify:mock-api && pnpm package`: in an Ubuntu/Debian Bookworm ARM64 container, `pnpm build` passed with 4 test files and 21 tests, `pnpm verify:mock-api` passed, and `pnpm package` produced `release/Image2Tools-0.1.0-linux-arm64.AppImage` plus `release/linux-arm64-unpacked/image2tools`.
+- `file release/Image2Tools-0.1.0-linux-arm64.AppImage release/linux-arm64-unpacked/image2tools`: confirmed both Linux artifacts are ARM aarch64 ELF executables.
+- `xvfb-run -a release/linux-arm64-unpacked/image2tools --no-sandbox`: unpacked Linux app stayed running for the smoke window interval in the Ubuntu ARM64 container; only expected container DBus/GPU initialization warnings were logged before the process was terminated.
+- `release/Image2Tools-0.1.0-linux-arm64.AppImage --appimage-extract` followed by `xvfb-run -a squashfs-root/image2tools --no-sandbox`: AppImage extraction succeeded and the extracted app stayed running for the smoke window interval in the Ubuntu ARM64 container.
+- Direct `xvfb-run -a release/Image2Tools-0.1.0-linux-arm64.AppImage --no-sandbox`: failed in the Docker container because FUSE device support is unavailable (`fuse: device not found, try 'modprobe fuse' first`); this is an environment limitation of the container, so native Linux AppImage execution remains pending under issue #4.
 - `pnpm mock:openai`: local mock API server starts at `http://127.0.0.1:8787/v1`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the `947450a` tree.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for the `7b3b9bc` tree.
@@ -103,10 +110,12 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `780af4d`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `06394ad`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `033e888`.
+- `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `d701ae8`.
 - `pnpm verify:real-api`: without an API key, exits before making real API calls.
 - `pnpm verify:real-api`: on current `971998b`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set.
 - `pnpm verify:real-api`: on current `06394ad`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set; issue #1 was updated with this current blocker evidence.
 - `pnpm verify:real-api`: on current `033e888`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set.
+- `pnpm verify:real-api`: on current `d701ae8`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set.
 - `IMAGE2TOOLS_API_KEY=sk-test-no-call pnpm verify:real-api`: exits before making real API calls unless `IMAGE2TOOLS_REAL_API_ACCEPT_COST=1` is explicitly set.
 - `IMAGE2TOOLS_API_KEY=sk-mock-image2tools IMAGE2TOOLS_BASE_URL=http://127.0.0.1:8788/v1 IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 pnpm verify:real-api`: passed against the local mock API, covering the script's generation, single-edit, multi-edit, and inpaint request paths; temporary artifacts and mock process were cleaned up.
 - `IMAGE2TOOLS_API_KEY=sk-mock-image2tools IMAGE2TOOLS_BASE_URL=http://127.0.0.1:8788/v1 IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 IMAGE2TOOLS_REAL_API_ACCEPT_STREAM_COST=1 pnpm verify:real-api`: passed against the local mock API after adding the opt-in streaming generation and edit checks; temporary artifacts and mock process were cleaned up.
@@ -119,6 +128,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm package:mac`: passed on the signing opt-in branch and still generated an unsigned macOS dmg/zip using explicit `mac.identity=null` and `mac.notarize=false` overrides.
 - `pnpm verify:release:mac`: passed on the signing opt-in branch after the unsigned package rebuild; it completed two copy/launch/window/remove cycles and confirmed a main window in both cycles.
 - `pnpm verify:signing-ready`: on current `033e888`, still failed for the expected external reasons (no code signing identity and Apple notarization env vars unset) while confirming `package:mac:signed` can override `mac.identity` and enable notarization; issue #3 was updated with this current blocker evidence.
+- `pnpm verify:signing-ready`: on current `d701ae8`, still failed for the expected external reasons (no code signing identity and Apple notarization env vars unset) while confirming `package:mac:signed` can override `mac.identity` and enable notarization.
 - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`: GitHub Actions workflow YAML parsed locally after adding Windows/Linux package jobs and manual dispatch.
 - `gh run view 26011616452 --repo Bliveren/image2tools`: CI was triggered but both jobs were blocked before starting because GitHub reported account payment/spending-limit restrictions.
 - `gh run list --repo Bliveren/image2tools --branch main --limit 5 --json databaseId,displayTitle,status,conclusion,event,headSha,url,createdAt,updatedAt`: repeated `main` CI runs still conclude `failure` before executing workflow steps, including `26018882123` for `cdc73f6` and `26019519641` for `8ac18c6`.
@@ -130,6 +140,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `gh run view 26025852856 --repo Bliveren/image2tools --json jobs,status,conclusion,event,url,headSha`: latest observed `main` CI run for `780af4d` still concluded `failure` before workflow steps ran; Build and mock API verifier, macOS package, Windows package, and Linux package jobs all had empty `steps` arrays.
 - `gh run view 26026330595 --repo Bliveren/image2tools --json jobs,status,conclusion,event,url,headSha`: latest observed `main` CI run for `06394ad` still concluded `failure` before workflow steps ran; Build and mock API verifier, macOS package, Windows package, and Linux package jobs all had empty `steps` arrays; issues #4 and #5 record this as current blocker evidence.
 - `gh run view 26027165476 --repo Bliveren/image2tools --json jobs,status,conclusion,event,url,headSha`: latest observed `main` CI run for `033e888` still concluded `failure` before workflow steps ran; Build and mock API verifier, macOS package, Windows package, and Linux package jobs all had empty `steps` arrays; issues #4 and #5 record this as current blocker evidence.
+- `gh run view 26027440740 --repo Bliveren/image2tools --json jobs,status,conclusion,event,url,headSha`: latest observed `main` CI run for `d701ae8` still concluded `failure` before workflow steps ran; Build and mock API verifier, macOS package, Windows package, and Linux package jobs all had empty `steps` arrays; issue #5 records this as current blocker evidence.
 - `gh issue list --repo Bliveren/image2tools --state open --json number,title,labels,url,updatedAt`: remaining open issues are external blockers #1, #3, #4, and #5.
 - `gh release view v0.1.0-mac-unsigned --repo Bliveren/image2tools --json tagName,name,isPrerelease,isDraft,url,assets,publishedAt,targetCommitish`: private pre-release `v0.1.0-mac-unsigned` is published, not draft, marked as pre-release, and has the dmg/zip assets uploaded with SHA256 digests matching the local release files.
 - `EXTERNAL_ACCEPTANCE.md`: added in PR #29 and linked from `README.md`, `TODO.md`, and this audit so the remaining external gates have a single repo-level runbook.
@@ -152,6 +163,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `780af4d` includes PR #35 IPC asset path hardening and PR #36 macOS release verifier cleanup/detach hardening; local `pnpm build`, `pnpm verify:mock-api`, `pnpm package:mac`, and `pnpm verify:release:mac` passed before refreshing the unsigned private pre-release assets.
 - `06394ad` is a docs-only merge after the `780af4d` release refresh; current local `pnpm build`, `pnpm verify:mock-api`, `pnpm verify:release:mac`, and release SHA256 verification passed, while the remaining real API, signing, Windows/Linux, and CI gates remain external blockers.
 - `033e888` includes PR #39 signing package path improvements; current local `pnpm build` and `pnpm verify:mock-api` passed, `pnpm verify:real-api` refused to call without a key, and `pnpm verify:signing-ready` confirmed the signed packaging override while remaining blocked on external signing materials.
+- `d701ae8` is a docs-only merge after PR #40. Current local `pnpm build` and `pnpm verify:mock-api` pass; `pnpm verify:real-api` still refuses to call without a key; `pnpm verify:signing-ready` still confirms the signed packaging override while remaining blocked on external signing materials; latest CI still fails before steps due to issue #5; Linux ARM64 container packaging/extracted-launch evidence is now captured, while native Windows/Linux desktop validation remains open under issue #4.
 
 ## Remaining External Work
 
@@ -162,5 +174,5 @@ Runbook: [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md)
 - Use a real Image 2 API key to manually verify text generation, single-image edit, multi-image edit, and inpainting: GitHub issue #1.
 - Confirm the OpenAI organization behind the real API key has GPT Image organization verification before manual acceptance: GitHub issue #1.
 - Add signing identity, notarization, and formal release metadata: GitHub issue #3.
-- Validate non-macOS target platforms: GitHub issue #4.
+- Validate non-macOS target platforms: GitHub issue #4. Linux ARM64 container packaging and extracted launch evidence exists, but native Windows validation and native Linux desktop shell behavior are still pending.
 - Resolve GitHub Actions billing/spending limit so CI can execute: GitHub issue #5.

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -125,6 +125,15 @@ After success, update release metadata, `CHECKLIST.md`, `TODO.md`, and
 
 Tracked by GitHub issue #4.
 
+Current partial evidence:
+
+- Ubuntu/Debian Bookworm ARM64 Docker validation on the macOS host passed
+  `pnpm build`, `pnpm verify:mock-api`, Linux AppImage packaging, AppImage
+  extraction, and extracted-app launch under Xvfb.
+- Direct AppImage execution in Docker remains blocked by missing FUSE device
+  support, so this is not a substitute for native Linux desktop validation.
+- Windows native validation has not been performed.
+
 Run on each native platform:
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -107,9 +107,10 @@ GitHub milestone: https://github.com/Bliveren/image2tools/milestone/1
 - [x] 增加受额外成本确认保护的真实 streaming 生成/编辑验收路径
 - [x] 增加 macOS 签名/公证 readiness 检查脚本
 - [x] 增加显式 signed macOS 打包命令，默认 unsigned 试用包不受影响
+- [x] 在 Ubuntu ARM64 Docker 环境补充 Linux build、mock verifier、AppImage 打包、AppImage 解包与 Xvfb 启动烟测证据
 - [ ] 解除 GitHub Actions billing/spending limit 阻塞并取得绿色 CI（GitHub issue #5）
 - [ ] 补充签名、公证与正式分发元数据（GitHub issue #3）
-- [ ] 非 macOS 平台安装验证（GitHub issue #4）
+- [ ] 非 macOS 平台安装验证（GitHub issue #4；Windows 与原生 Linux 桌面 shell 行为仍待验证）
 - [x] 已评估 `stash@{0}` 中未合并的 renderer 实验；当前 `main` 已覆盖其核心能力并包含更新的草稿恢复、mask 校验和打包配置
 - [x] 已将 `stash@{0}` 非破坏性归档到 `origin/archive/abandoned-renderer-stash`
 - [x] 本地 `stash@{0}` 已在确认远程归档后删除（GitHub issue #2）


### PR DESCRIPTION
## Summary
- record current d701ae8 build/mock/signing/CI audit evidence
- add Ubuntu ARM64 Docker Linux package and extracted launch evidence
- keep issue #4 open for native Windows and native Linux desktop shell validation

## Verification
- pnpm build
- pnpm verify:mock-api
- pnpm verify:real-api exits before calls because no key is configured
- pnpm verify:signing-ready fails for expected external signing credentials
- Docker linux/arm64 build/mock/package/extracted-launch smoke
- git diff --check