### PR TITLE
Verify mock Image 2 parameters

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -68,6 +68,7 @@
 - [x] 关键路径手动回归通过（无真实 API 调用）
 - [x] 本地 mock OpenAI Image API 可用于无真实 Key 回归
 - [x] 本地 mock API 自动校验脚本通过
+- [x] mock API 自动校验覆盖关键 Image 2 参数传递
 - [x] packaged app 可通过 UI 保存 mock 配置、连接测试并完成一次 mock 生成
 - [x] 无控制台报错
 - [x] 打包配置已添加

--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -24,7 +24,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Local file save and download | Base64 output saved under Electron `userData`; download dialog copies selected generated asset; main-process IPC rejects download/open/delete paths outside the app image store or current history | Done |
 | History and reuse | JSON history, search, reuse, copy prompt, open folder, delete, clear | Done |
 | Recovery | Atomic state writes with `.bak`, interrupted job recovery, workspace draft autosave/restore | Done |
-| Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, and SSE events; `pnpm verify:mock-api` probes models, JSON generation, streaming generation, multipart edit, multi-image mask edit/inpaint, and streaming edit | Done |
+| Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, SSE events, and a mock request-inspection route; `pnpm verify:mock-api` probes models, JSON generation with Image 2 parameter assertions, streaming generation, multipart edit with Image 2 parameter assertions, multi-image mask edit/inpaint, and streaming edit | Done |
 | Tests | `pnpm build` passed with 4 test files and 21 tests on `d701ae8` | Done |
 | Packaging | `electron-builder` config includes main, preload, shared, and renderer runtime outputs; project icons in `build/`; `pnpm package:dir`; `pnpm package:mac`; local app; dmg-copy launch; two-cycle reinstall smoke tests; `pnpm verify:release:mac` confirms the app process and main window; private GitHub pre-release `v0.1.0-mac-unsigned` | Done for unsigned macOS local/pre-release artifacts |
 | Remote CI | `.github/workflows/ci.yml` runs build + mock API verifier on Ubuntu and macOS, Windows, and Linux package gates for push/PR/manual dispatch; runs are blocked before job steps by GitHub billing/spending limit | Configured; external billing blocker tracked in GitHub issue #5 |
@@ -118,6 +118,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `06394ad`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `033e888`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `d701ae8`.
+- PR #46 extends the mock OpenAI server with request inspection and updates `pnpm verify:mock-api` to assert key Image 2 parameters on JSON generation and multipart edit requests: size, quality, output format, output compression, background, count, and moderation.
 - `pnpm verify:real-api`: without an API key, exits before making real API calls.
 - `pnpm verify:real-api`: on current `971998b`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set.
 - `pnpm verify:real-api`: on current `06394ad`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set; issue #1 was updated with this current blocker evidence.

--- a/TODO.md
+++ b/TODO.md
@@ -72,6 +72,7 @@
 - [x] 增加手工 QA 用例
 - [x] 增加本地 mock API 回归入口
 - [x] 增加本地 mock API 自动校验脚本
+- [x] mock API 自动校验覆盖 Image 2 参数传递（size / quality / format / compression / background / moderation）
 - [x] 增加异常恢复
 - [x] 增加崩溃后草稿恢复
 - [x] 增加错误码归类

--- a/scripts/mock-openai-image-api.mjs
+++ b/scripts/mock-openai-image-api.mjs
@@ -4,6 +4,7 @@ import http from "node:http";
 const tinyPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lw1m8QAAAABJRU5ErkJggg==";
 const port = Number(process.env.PORT ?? 8787);
 const host = process.env.HOST ?? "127.0.0.1";
+const recentRequests = [];
 
 function sendJson(response, status, payload) {
   response.writeHead(status, {
@@ -23,6 +24,31 @@ function hasField(bodyText, name) {
   }
 }
 
+function multipartFieldValues(bodyText) {
+  const fields = {};
+  const parts = bodyText.split(/\r?\n--/);
+  for (const part of parts) {
+    const [rawHeaders, ...bodyParts] = part.split(/\r?\n\r?\n/);
+    const name = /name="([^"]+)"/.exec(rawHeaders)?.[1];
+    if (!name) continue;
+    if (!fields[name]) {
+      fields[name] = [];
+    }
+    const value = bodyParts.join("\n\n").replace(/\r?\n$/, "");
+    fields[name].push(value);
+  }
+  return fields;
+}
+
+function parseRequestFields(bodyText) {
+  try {
+    const payload = JSON.parse(bodyText);
+    return Object.fromEntries(Object.entries(payload).map(([key, value]) => [key, [value]]));
+  } catch {
+    return multipartFieldValues(bodyText);
+  }
+}
+
 function validateImageRequest(pathname, bodyText) {
   if (!hasField(bodyText, "model")) {
     return "Missing model field";
@@ -34,6 +60,14 @@ function validateImageRequest(pathname, bodyText) {
     return "Missing edit image field";
   }
   return null;
+}
+
+function recordImageRequest(pathname, bodyText) {
+  recentRequests.push({
+    pathname,
+    fields: parseRequestFields(bodyText)
+  });
+  recentRequests.splice(0, Math.max(0, recentRequests.length - 20));
 }
 
 function sendSse(response, prefix) {
@@ -77,6 +111,11 @@ const server = http.createServer(async (request, response) => {
       return;
     }
 
+    if (request.method === "GET" && url.pathname === "/v1/mock/requests") {
+      sendJson(response, 200, { data: recentRequests });
+      return;
+    }
+
     if (request.method === "POST" && (url.pathname === "/v1/images/generations" || url.pathname === "/v1/images/edits")) {
       const bodyText = await readText(request);
       const validationError = validateImageRequest(url.pathname, bodyText);
@@ -84,6 +123,7 @@ const server = http.createServer(async (request, response) => {
         sendJson(response, 400, { error: { message: validationError } });
         return;
       }
+      recordImageRequest(url.pathname, bodyText);
       const prefix = url.pathname.endsWith("/edits") ? "image_edit" : "image_generation";
       if (wantsStream(request, bodyText)) {
         sendSse(response, prefix);

--- a/scripts/verify-mock-api.mjs
+++ b/scripts/verify-mock-api.mjs
@@ -56,6 +56,23 @@ async function verifyModels() {
   assert(payload.data?.[0]?.id === "gpt-image-2", "models response did not include gpt-image-2");
 }
 
+async function recentMockRequests() {
+  const response = await fetch(`${baseURL}/mock/requests`, {
+    headers: { Authorization: `Bearer ${apiKey}` }
+  });
+  assert(response.ok, `mock requests failed with HTTP ${response.status}`);
+  const payload = await response.json();
+  return payload.data ?? [];
+}
+
+function fieldValue(request, name) {
+  return request?.fields?.[name]?.[0];
+}
+
+function latestRequest(requests, pathname) {
+  return requests.findLast?.((item) => item.pathname === pathname) ?? [...requests].reverse().find((item) => item.pathname === pathname);
+}
+
 async function verifyJsonGeneration() {
   const response = await fetch(`${baseURL}/images/generations`, {
     method: "POST",
@@ -63,11 +80,33 @@ async function verifyJsonGeneration() {
       Authorization: `Bearer ${apiKey}`,
       "content-type": "application/json"
     },
-    body: JSON.stringify({ model: "gpt-image-2", prompt: "mock generation", stream: false })
+    body: JSON.stringify({
+      model: "gpt-image-2",
+      prompt: "mock generation",
+      size: "1536x1024",
+      quality: "medium",
+      output_format: "webp",
+      output_compression: 42,
+      background: "opaque",
+      n: 2,
+      stream: false,
+      moderation: "low"
+    })
   });
   assert(response.ok, `json generation failed with HTTP ${response.status}`);
   const payload = await response.json();
   assert(payload.data?.[0]?.b64_json?.startsWith(tinyPngPrefix), "json generation did not return a PNG b64_json");
+
+  const requests = await recentMockRequests();
+  const request = latestRequest(requests, "/v1/images/generations");
+  assert(fieldValue(request, "model") === "gpt-image-2", "json generation did not send model");
+  assert(fieldValue(request, "size") === "1536x1024", "json generation did not send size");
+  assert(fieldValue(request, "quality") === "medium", "json generation did not send quality");
+  assert(fieldValue(request, "output_format") === "webp", "json generation did not send output_format");
+  assert(fieldValue(request, "output_compression") === 42, "json generation did not send output_compression");
+  assert(fieldValue(request, "background") === "opaque", "json generation did not send background");
+  assert(fieldValue(request, "n") === 2, "json generation did not send n");
+  assert(fieldValue(request, "moderation") === "low", "json generation did not send moderation");
 }
 
 async function verifySseGeneration() {
@@ -91,6 +130,13 @@ async function verifyMultipartEdit() {
   const form = new FormData();
   form.append("model", "gpt-image-2");
   form.append("prompt", "mock edit");
+  form.append("size", "1024x1536");
+  form.append("quality", "high");
+  form.append("output_format", "jpeg");
+  form.append("output_compression", "55");
+  form.append("background", "opaque");
+  form.append("n", "1");
+  form.append("moderation", "low");
   form.append("stream", "false");
   form.append("image[]", new Blob([Buffer.from("mock")], { type: "image/png" }), "source.png");
 
@@ -102,6 +148,18 @@ async function verifyMultipartEdit() {
   assert(response.ok, `multipart edit failed with HTTP ${response.status}`);
   const payload = await response.json();
   assert(payload.data?.[0]?.b64_json?.startsWith(tinyPngPrefix), "multipart edit did not return a PNG b64_json");
+
+  const requests = await recentMockRequests();
+  const request = latestRequest(requests, "/v1/images/edits");
+  assert(fieldValue(request, "model") === "gpt-image-2", "multipart edit did not send model");
+  assert(fieldValue(request, "size") === "1024x1536", "multipart edit did not send size");
+  assert(fieldValue(request, "quality") === "high", "multipart edit did not send quality");
+  assert(fieldValue(request, "output_format") === "jpeg", "multipart edit did not send output_format");
+  assert(fieldValue(request, "output_compression") === "55", "multipart edit did not send output_compression");
+  assert(fieldValue(request, "background") === "opaque", "multipart edit did not send background");
+  assert(fieldValue(request, "n") === "1", "multipart edit did not send n");
+  assert(fieldValue(request, "moderation") === "low", "multipart edit did not send moderation");
+  assert(request?.fields?.["image[]"]?.length === 1, "multipart edit did not send one image[] field");
 }
 
 async function verifyMultipartInpaint() {


### PR DESCRIPTION
## Summary
- add a mock request-inspection route to the local OpenAI Image API mock
- extend `pnpm verify:mock-api` to assert key Image 2 parameters on JSON generation and multipart edit requests
- document the strengthened no-key regression coverage

## Verification
- `node --check scripts/mock-openai-image-api.mjs && node --check scripts/verify-mock-api.mjs`
- `git diff --check`
- `pnpm verify:mock-api`
- `pnpm build`

## Notes
This does not require a real API key and does not close the external real API acceptance issue. It strengthens local coverage for size, quality, output format, compression, background, count, and moderation request fields.
