### PR TITLE
Harden Image 2 parameter shape validation

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -61,6 +61,7 @@
 - [x] OpenAI 请求层有无真实 Key 的可测试路径
 - [x] OpenAI 请求层测试覆盖多结果保存与编辑参数透传
 - [x] shared 参数校验会拒绝运行时非法 Image 2 枚举值
+- [x] shared 参数校验会拒绝畸形参数对象与非整数/非有限数值
 - [x] 状态文件写入有备份与恢复路径
 - [x] 未完成任务重启后会恢复为失败状态
 - [x] 工作区草稿可自动保存并在重启后恢复
@@ -120,5 +121,6 @@
 - [x] 结果按 base64 图像保存
 - [x] `background` 只允许 `auto` / `opaque`
 - [x] `quality`、`output_format`、`background`、`moderation` 运行时枚举值会被校验
+- [x] `n`、`partial_images`、`timeoutMs`、`output_compression` 必须是整数且有限
 - [x] `output_compression` 仅在 `jpeg` / `webp` 时发送
 - [x] `stream` 开启时处理 partial 与 completed 事件

--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,8 +2,8 @@
 
 Date: 2026-05-18
 Branch: `main`
-Runtime/config evidence through: `fix/cto-param-enum-validation` pre-merge
-Release and external-blocker evidence through: `a4f93f2`
+Runtime/config evidence through: `fix/cto-param-shape-validation` pre-merge
+Release and external-blocker evidence through: `59f0b13`
 
 ## Objective Restated
 
@@ -17,7 +17,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | API key entry, local save, and clear | Provider form in `src/renderer/App.tsx`; encrypted storage and `config:clearApiKey` via Electron `safeStorage` in `src/main/main.ts` | Done |
 | Base URL entry and connection test | `baseURL` config in renderer; `/models` connection test via `handleTestConnection` | Done |
 | Simple parameter config | Size, quality, format, compression, count, stream, partial images, moderation, timeout controls in renderer | Done |
-| `gpt-image-2` defaults and limits | `DEFAULT_IMAGE_PARAMS`, size validation, runtime enum validation for quality/format/background/moderation, no transparent or `input_fidelity` in `src/shared/validation.ts` and `src/shared/types.ts` | Done |
+| `gpt-image-2` defaults and limits | `DEFAULT_IMAGE_PARAMS`, size validation, runtime shape validation, enum validation for quality/format/background/moderation, finite integer validation for count-like parameters, no transparent or `input_fidelity` in `src/shared/validation.ts` and `src/shared/types.ts` | Done |
 | Text-to-image generation | `/images/generations` implementation and tests in `src/main/services/openaiImage.ts` / `.test.ts`, including saving multiple returned images when `n > 1` | Implemented; real API manual run pending |
 | Image edit and inpaint | `/images/edits`, multipart `image[]`, mask support, renderer mode switching, mask editor, mask/source size, format, and alpha validation, plus service tests for advanced edit parameter transmission | Implemented; real API manual run pending |
 | Streaming partial previews | SSE parsing and partial event handling in main + renderer; covered by tests | Done |
@@ -25,7 +25,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | History and reuse | JSON history, search, reuse, copy prompt, open folder, delete, clear | Done |
 | Recovery | Atomic state writes with `.bak`, interrupted job recovery, workspace draft autosave/restore | Done |
 | Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, SSE events, and a mock request-inspection route; `pnpm verify:mock-api` probes models, JSON generation with Image 2 parameter assertions, streaming generation, multipart edit with Image 2 parameter assertions, multi-image mask edit/inpaint, and streaming edit | Done |
-| Tests | `pnpm build` passed with 4 test files and 24 tests on `fix/cto-param-enum-validation` pre-merge | Done |
+| Tests | `pnpm build` passed with 4 test files and 25 tests on `fix/cto-param-shape-validation` pre-merge | Done |
 | Packaging | `electron-builder` config includes main, preload, shared, and renderer runtime outputs; project icons in `build/`; `pnpm package:dir`; `pnpm package:mac`; local app; dmg-copy launch; two-cycle reinstall smoke tests; `pnpm verify:release:mac` confirms the app process and main window; private GitHub pre-release `v0.1.0-mac-unsigned` | Done for unsigned macOS local/pre-release artifacts |
 | Remote CI | `.github/workflows/ci.yml` runs build + mock API verifier on Ubuntu and macOS, Windows, and Linux package gates for push/PR/manual dispatch; runs are blocked before job steps by GitHub billing/spending limit | Configured; external billing blocker tracked in GitHub issue #5 |
 | Docs updated | `README.md`, `PLAN.md`, `ARCHITECTURE.md`, `TODO.md`, `CHECKLIST.md` updated | Done |
@@ -56,6 +56,8 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for current `main` at `d701ae8`; Vitest reported 4 test files and 21 tests passed.
 - `pnpm vitest run src/shared/validation.test.ts`: passed on 2026-05-18 for `fix/cto-param-enum-validation` pre-merge; Vitest reported 1 test file and 9 tests passed, including runtime rejection of invalid quality, output format, background, and moderation values.
 - `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for `fix/cto-param-enum-validation` pre-merge; Vitest reported 4 test files and 24 tests passed.
+- `pnpm vitest run src/shared/validation.test.ts`: passed on 2026-05-18 for `fix/cto-param-shape-validation` pre-merge; Vitest reported 1 test file and 10 tests passed, including malformed runtime parameter objects and non-integer or non-finite numeric values.
+- `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for `fix/cto-param-shape-validation` pre-merge; Vitest reported 4 test files and 25 tests passed.
 - `pnpm package:dir`: unsigned macOS app directory regenerated successfully on 2026-05-18 after `9111b90`; command reran build, typecheck, and 15 tests first.
 - `open -n release/mac-arm64/Image2Tools.app`: packaged app launched on 2026-05-18 after `8a69b39`; process was observed, then the smoke-test process was terminated after AppleScript quit was not handled by the app.
 - `pnpm package:mac`: regenerated `release/Image2Tools-0.1.0-mac-arm64.dmg`, `.zip`, and blockmaps successfully on 2026-05-18 after `9111b90`; command reran build, typecheck, and 15 tests first.
@@ -121,9 +123,11 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `033e888`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for current `main` at `d701ae8`.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for `fix/cto-param-enum-validation` pre-merge.
+- `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for `fix/cto-param-shape-validation` pre-merge.
 - PR #46 extends the mock OpenAI server with request inspection and updates `pnpm verify:mock-api` to assert key Image 2 parameters on JSON generation and multipart edit requests: size, quality, output format, output compression, background, count, and moderation.
 - PR #47 adds service-level tests that verify all returned generation images are saved for multi-result responses and advanced Image 2 parameters are passed through multipart edit requests.
 - `fix/cto-param-enum-validation` adds shared runtime allow-list validation for `quality`, `outputFormat`, `background`, and `moderation`, so malformed persisted state or direct IPC payloads are rejected before OpenAI request construction.
+- `fix/cto-param-shape-validation` adds shared runtime shape and finite-integer validation for Image 2 params, so malformed persisted state or direct IPC payloads return validation errors instead of throwing or passing invalid numeric values into request construction.
 - `pnpm verify:real-api`: without an API key, exits before making real API calls.
 - `pnpm verify:real-api`: on current `971998b`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set.
 - `pnpm verify:real-api`: on current `06394ad`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set; issue #1 was updated with this current blocker evidence.

--- a/TODO.md
+++ b/TODO.md
@@ -71,6 +71,7 @@
 - [x] 增加自动化测试
 - [x] OpenAI 请求层单元测试覆盖多结果保存与编辑参数透传
 - [x] shared 参数校验拒绝运行时非法枚举值（quality / format / background / moderation）
+- [x] shared 参数校验拒绝畸形运行时参数对象与非整数/非有限数值
 - [x] 增加手工 QA 用例
 - [x] 增加本地 mock API 回归入口
 - [x] 增加本地 mock API 自动校验脚本

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -46,6 +46,21 @@ describe("gpt-image-2 validation", () => {
     expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, moderation: "strict" } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
   });
 
+  it("rejects malformed runtime params without throwing", () => {
+    expect(validateImageParams(null as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, model: null } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, size: null } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, stream: "true" } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, n: Number.NaN } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, partialImages: Number.POSITIVE_INFINITY } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, timeoutMs: Number.NaN } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, outputCompression: Number.NEGATIVE_INFINITY } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, n: 1.5 } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, partialImages: 1.5 } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, timeoutMs: 30000.5 } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, outputCompression: 50.5 } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+  });
+
   it("normalizes base URLs and compression behavior", () => {
     expect(normalizeBaseURL("https://api.openai.com/v1///")).toBe("https://api.openai.com/v1");
     expect(shouldSendCompression("png")).toBe(false);

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -94,6 +94,18 @@ export function validateGptImage2Size(size: string): ValidationResult {
 }
 
 export function validateImageParams(params: ImageParams): ValidationResult {
+  if (!isRecord(params)) {
+    return { ok: false, message: "参数格式无效。" };
+  }
+  if (typeof params.model !== "string") {
+    return { ok: false, message: "模型参数无效。" };
+  }
+  if (typeof params.size !== "string") {
+    return { ok: false, message: "尺寸参数无效。" };
+  }
+  if (typeof params.stream !== "boolean") {
+    return { ok: false, message: "流式预览参数无效。" };
+  }
   if (params.model.trim() !== GPT_IMAGE_2_MODEL) {
     return { ok: false, message: `MVP 仅支持 ${GPT_IMAGE_2_MODEL}。` };
   }
@@ -111,23 +123,31 @@ export function validateImageParams(params: ImageParams): ValidationResult {
   }
   const size = validateGptImage2Size(params.size);
   if (!size.ok) return size;
-  if (params.n < 1 || params.n > 10) {
+  if (!isInteger(params.n) || params.n < 1 || params.n > 10) {
     return { ok: false, message: "生成数量需在 1 到 10 之间。" };
   }
-  if (params.partialImages < 0 || params.partialImages > 3) {
+  if (!isInteger(params.partialImages) || params.partialImages < 0 || params.partialImages > 3) {
     return { ok: false, message: "partial_images 需在 0 到 3 之间。" };
   }
-  if (params.timeoutMs < 30000 || params.timeoutMs > 600000) {
+  if (!isInteger(params.timeoutMs) || params.timeoutMs < 30000 || params.timeoutMs > 600000) {
     return { ok: false, message: "超时时间需在 30 到 600 秒之间。" };
   }
-  if (params.outputCompression < 0 || params.outputCompression > 100) {
+  if (!isInteger(params.outputCompression) || params.outputCompression < 0 || params.outputCompression > 100) {
     return { ok: false, message: "压缩率需在 0 到 100 之间。" };
   }
   return { ok: true };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function isOneOf<T extends string>(value: string, options: readonly T[]): value is T {
   return (options as readonly string[]).includes(value);
+}
+
+function isInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value);
 }
 
 export function normalizeImageMimeType(mimeType?: string): string {


### PR DESCRIPTION
## Summary
- reject malformed runtime ImageParams payloads before model/size string operations
- require stream to be boolean and count-like numeric params to be finite integers
- add regression coverage for malformed persisted/IPC payloads and update project audit docs

## Verification
- pnpm vitest run src/shared/validation.test.ts
- pnpm build
- pnpm verify:mock-api
- git diff --check

## Notes
- No real API calls were run; issue #1 still requires an external API key and explicit cost approval.
- GitHub Actions may still fail before job steps because of the billing/spending-limit blocker tracked in issue #5.