### PR TITLE
Validate job and draft IPC requests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,6 +182,7 @@ src/
 - API Key 只存本地
 - 前端不打印 Key
 - 错误日志脱敏
+- Main process 对配置、任务、草稿、下载、打开目录、删除等 IPC payload 做运行时校验后再访问文件或状态
 - 下载文件由 main process 统一落盘
 - 可选支持系统钥匙串 / Keychain
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -63,6 +63,7 @@
 - [x] shared 参数校验会拒绝运行时非法 Image 2 枚举值
 - [x] shared 参数校验会拒绝畸形参数对象与非整数/非有限数值
 - [x] config 保存、prompt、API Key、Base URL 输入会拒绝或归一化畸形运行时值
+- [x] job run / draft save IPC 请求会拒绝畸形 payload、路径数组和草稿资源对象
 - [x] 状态文件写入有备份与恢复路径
 - [x] 未完成任务重启后会恢复为失败状态
 - [x] 工作区草稿可自动保存并在重启后恢复

--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-18
 Branch: `main`
-Runtime/config evidence through: `fix/cto-config-input-validation` pre-merge
+Runtime/config evidence through: `fix/cto-ipc-request-validation` pre-merge
 Release and external-blocker evidence through: `6a97504`
 
 ## Objective Restated
@@ -21,11 +21,11 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Text-to-image generation | `/images/generations` implementation and tests in `src/main/services/openaiImage.ts` / `.test.ts`, including saving multiple returned images when `n > 1` | Implemented; real API manual run pending |
 | Image edit and inpaint | `/images/edits`, multipart `image[]`, mask support, renderer mode switching, mask editor, mask/source size, format, and alpha validation, plus service tests for advanced edit parameter transmission | Implemented; real API manual run pending |
 | Streaming partial previews | SSE parsing and partial event handling in main + renderer; covered by tests | Done |
-| Local file save and download | Base64 output saved under Electron `userData`; download dialog copies selected generated asset; main-process IPC rejects download/open/delete paths outside the app image store or current history | Done |
+| Local file save and download | Base64 output saved under Electron `userData`; download dialog copies selected generated asset; main-process IPC rejects malformed job/draft payloads before path or asset handling and rejects download/open/delete paths outside the app image store or current history | Done |
 | History and reuse | JSON history, search, reuse, copy prompt, open folder, delete, clear | Done |
 | Recovery | Atomic state writes with `.bak`, interrupted job recovery, workspace draft autosave/restore | Done |
 | Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, SSE events, and a mock request-inspection route; `pnpm verify:mock-api` probes models, JSON generation with Image 2 parameter assertions, streaming generation, multipart edit with Image 2 parameter assertions, multi-image mask edit/inpaint, and streaming edit | Done |
-| Tests | `pnpm build` passed with 4 test files and 27 tests on `fix/cto-config-input-validation` pre-merge | Done |
+| Tests | `pnpm build` passed with 4 test files and 28 tests on `fix/cto-ipc-request-validation` pre-merge | Done |
 | Packaging | `electron-builder` config includes main, preload, shared, and renderer runtime outputs; project icons in `build/`; `pnpm package:dir`; `pnpm package:mac`; local app; dmg-copy launch; two-cycle reinstall smoke tests; `pnpm verify:release:mac` confirms the app process and main window; private GitHub pre-release `v0.1.0-mac-unsigned` | Done for unsigned macOS local/pre-release artifacts |
 | Remote CI | `.github/workflows/ci.yml` runs build + mock API verifier on Ubuntu and macOS, Windows, and Linux package gates for push/PR/manual dispatch; runs are blocked before job steps by GitHub billing/spending limit | Configured; external billing blocker tracked in GitHub issue #5 |
 | Docs updated | `README.md`, `PLAN.md`, `ARCHITECTURE.md`, `TODO.md`, `CHECKLIST.md` updated | Done |
@@ -60,6 +60,8 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for `fix/cto-param-shape-validation` pre-merge; Vitest reported 4 test files and 25 tests passed.
 - `pnpm vitest run src/shared/validation.test.ts`: passed on 2026-05-18 for `fix/cto-config-input-validation` pre-merge; Vitest reported 1 test file and 12 tests passed, including malformed prompt/API key/Base URL inputs and provider config IPC payload validation.
 - `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for `fix/cto-config-input-validation` pre-merge; Vitest reported 4 test files and 27 tests passed.
+- `pnpm vitest run src/shared/validation.test.ts`: passed on 2026-05-18 for `fix/cto-ipc-request-validation` pre-merge; Vitest reported 1 test file and 13 tests passed, including malformed job run and workspace draft IPC payloads.
+- `pnpm build`: typecheck, Vitest, renderer build, and main build passed on 2026-05-18 for `fix/cto-ipc-request-validation` pre-merge; Vitest reported 4 test files and 28 tests passed.
 - `pnpm package:dir`: unsigned macOS app directory regenerated successfully on 2026-05-18 after `9111b90`; command reran build, typecheck, and 15 tests first.
 - `open -n release/mac-arm64/Image2Tools.app`: packaged app launched on 2026-05-18 after `8a69b39`; process was observed, then the smoke-test process was terminated after AppleScript quit was not handled by the app.
 - `pnpm package:mac`: regenerated `release/Image2Tools-0.1.0-mac-arm64.dmg`, `.zip`, and blockmaps successfully on 2026-05-18 after `9111b90`; command reran build, typecheck, and 15 tests first.
@@ -127,11 +129,13 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for `fix/cto-param-enum-validation` pre-merge.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for `fix/cto-param-shape-validation` pre-merge.
 - `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for `fix/cto-config-input-validation` pre-merge.
+- `pnpm verify:mock-api`: automatic mock verification passed on 2026-05-18 for `fix/cto-ipc-request-validation` pre-merge.
 - PR #46 extends the mock OpenAI server with request inspection and updates `pnpm verify:mock-api` to assert key Image 2 parameters on JSON generation and multipart edit requests: size, quality, output format, output compression, background, count, and moderation.
 - PR #47 adds service-level tests that verify all returned generation images are saved for multi-result responses and advanced Image 2 parameters are passed through multipart edit requests.
 - `fix/cto-param-enum-validation` adds shared runtime allow-list validation for `quality`, `outputFormat`, `background`, and `moderation`, so malformed persisted state or direct IPC payloads are rejected before OpenAI request construction.
 - `fix/cto-param-shape-validation` adds shared runtime shape and finite-integer validation for Image 2 params, so malformed persisted state or direct IPC payloads return validation errors instead of throwing or passing invalid numeric values into request construction.
 - `fix/cto-config-input-validation` adds runtime validation for provider config save payloads and hardens prompt, API key, Base URL, and size helpers against malformed non-string inputs.
+- `fix/cto-ipc-request-validation` adds runtime validation for job run and workspace draft save payloads, including mode, prompt, input path arrays, optional mask data, Image 2 params, brush size, and draft asset object metadata before main-process handlers touch paths or persisted state.
 - `pnpm verify:real-api`: without an API key, exits before making real API calls.
 - `pnpm verify:real-api`: on current `971998b`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set.
 - `pnpm verify:real-api`: on current `06394ad`, exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set; issue #1 was updated with this current blocker evidence.

--- a/TODO.md
+++ b/TODO.md
@@ -73,6 +73,7 @@
 - [x] shared 参数校验拒绝运行时非法枚举值（quality / format / background / moderation）
 - [x] shared 参数校验拒绝畸形运行时参数对象与非整数/非有限数值
 - [x] config / prompt / API Key 运行时输入校验拒绝非字符串畸形值
+- [x] job run / draft save IPC 请求会先做运行时 shape 校验
 - [x] 增加手工 QA 用例
 - [x] 增加本地 mock API 回归入口
 - [x] 增加本地 mock API 自动校验脚本

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -32,7 +32,9 @@ import {
   getValidationError,
   normalizeBaseURL,
   validateApiKey,
-  validateProviderConfigInput
+  validateProviderConfigInput,
+  validateRunJobRequest,
+  validateWorkspaceDraftInput
 } from "../shared/validation.js";
 import { buildEndpoint, fetchWithTimeout, runOpenAIImageJob } from "./services/openaiImage.js";
 import { assertKnownOutputPath, assertManagedRegularFile, collectOwnedJobFilePaths } from "./services/assetOwnership.js";
@@ -480,12 +482,14 @@ async function handleClearApiKey(): Promise<ProviderConfig> {
 }
 
 async function handleSaveDraft(_event: IpcMainInvokeEvent, input: WorkspaceDraftInput): Promise<WorkspaceDraft> {
+  const validation = validateWorkspaceDraftInput(input);
+  if (!validation.ok) {
+    throw new Error(validation.message ?? "草稿参数无效。");
+  }
   const state = await readState();
   const draft: WorkspaceDraft = {
     ...input,
-    prompt: input.prompt,
     inputAssets: input.inputAssets.slice(0, 10),
-    maskDataUrl: input.maskDataUrl,
     updatedAt: new Date().toISOString()
   };
   await writeState({ ...state, draft });
@@ -561,6 +565,10 @@ async function handleSelectMask(): Promise<InputAsset | null> {
 }
 
 async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest): Promise<GenerationJob> {
+  const validation = validateRunJobRequest(request);
+  if (!validation.ok) {
+    throw new Error(validation.message ?? "任务请求无效。");
+  }
   const validationError = getValidationError(request.params, request.prompt);
   if (validationError) {
     throw new Error(validationError);

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -16,7 +16,9 @@ import {
   validateImageParams,
   validateMaskMimeType,
   validateMaskSourceFormat,
-  validateProviderConfigInput
+  validateProviderConfigInput,
+  validateRunJobRequest,
+  validateWorkspaceDraftInput
 } from "./validation";
 
 describe("gpt-image-2 validation", () => {
@@ -102,6 +104,61 @@ describe("gpt-image-2 validation", () => {
     expect(validateProviderConfigInput({ ...valid, defaultQuality: "standard" } as never).ok).toBe(false);
     expect(validateProviderConfigInput({ ...valid, timeoutMs: Number.NaN } as never).ok).toBe(false);
     expect(validateProviderConfigInput({ ...valid, apiKey: null } as never).ok).toBe(false);
+  });
+
+  it("validates job and draft IPC request shapes", () => {
+    const job = {
+      mode: "generate",
+      prompt: "Prompt",
+      inputPaths: [],
+      params: DEFAULT_IMAGE_PARAMS
+    };
+    const draft = {
+      mode: "edit",
+      prompt: "Draft prompt",
+      params: DEFAULT_IMAGE_PARAMS,
+      inputAssets: [],
+      brushSize: 72
+    };
+
+    expect(validateRunJobRequest(job).ok).toBe(true);
+    expect(validateWorkspaceDraftInput(draft).ok).toBe(true);
+    expect(validateRunJobRequest(null).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, mode: "compose" } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, prompt: null } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, inputPaths: ["a.png", 1] } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, maskPath: 123 } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, maskDataUrl: 123 } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, params: { ...DEFAULT_IMAGE_PARAMS, n: 1.5 } } as never).ok).toBe(false);
+    expect(validateWorkspaceDraftInput(null).ok).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, mode: "compose" } as never).ok).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, prompt: null } as never).ok).toBe(false);
+    expect(
+      validateWorkspaceDraftInput({
+        ...draft,
+        inputAssets: Array.from({ length: 11 }, (_, index) => ({
+          id: String(index),
+          name: "a.png",
+          path: "/tmp/a.png",
+          mimeType: "image/png",
+          sizeBytes: 1
+        }))
+      }).ok
+    ).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, inputAssets: [1] } as never).ok).toBe(false);
+    const asset = {
+      id: "1",
+      name: "a.png",
+      path: "/tmp/a.png",
+      mimeType: "image/png",
+      sizeBytes: 1
+    };
+    expect(validateWorkspaceDraftInput({ ...draft, inputAssets: [{ ...asset, dataUrl: 123 }] } as never).ok).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, inputAssets: [{ ...asset, width: 0 }] } as never).ok).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, inputAssets: [{ ...asset, height: 1.5 }] } as never).ok).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, maskAsset: { id: 1 } } as never).ok).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, maskDataUrl: 123 } as never).ok).toBe(false);
+    expect(validateWorkspaceDraftInput({ ...draft, brushSize: 0 } as never).ok).toBe(false);
   });
 
   it("maps formats and strips data URL prefixes", () => {

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -1,4 +1,10 @@
-import type { ImageBackground, ImageFormat, ImageParams, ImageQuality, ModerationMode } from "./types.js";
+import type {
+  ImageBackground,
+  ImageFormat,
+  ImageParams,
+  ImageQuality,
+  ModerationMode
+} from "./types.js";
 
 export const GPT_IMAGE_2_MODEL = "gpt-image-2";
 
@@ -105,7 +111,7 @@ export function validateGptImage2Size(size: unknown): ValidationResult {
   return { ok: true };
 }
 
-export function validateImageParams(params: ImageParams): ValidationResult {
+export function validateImageParams(params: unknown): ValidationResult {
   if (!isRecord(params)) {
     return { ok: false, message: "参数格式无效。" };
   }
@@ -184,12 +190,98 @@ export function validateProviderConfigInput(input: unknown): ValidationResult {
   return { ok: true };
 }
 
+export function validateInputAssetShape(asset: unknown): ValidationResult {
+  if (!isRecord(asset)) {
+    return { ok: false, message: "输入资源格式无效。" };
+  }
+  if (typeof asset.id !== "string") {
+    return { ok: false, message: "输入资源 ID 无效。" };
+  }
+  if (typeof asset.name !== "string") {
+    return { ok: false, message: "输入资源名称无效。" };
+  }
+  if (typeof asset.path !== "string") {
+    return { ok: false, message: "输入资源路径无效。" };
+  }
+  if (typeof asset.mimeType !== "string") {
+    return { ok: false, message: "输入资源 MIME 类型无效。" };
+  }
+  if (!isInteger(asset.sizeBytes) || asset.sizeBytes < 0) {
+    return { ok: false, message: "输入资源大小无效。" };
+  }
+  if (asset.dataUrl !== undefined && typeof asset.dataUrl !== "string") {
+    return { ok: false, message: "输入资源数据无效。" };
+  }
+  if (asset.width !== undefined && (!isInteger(asset.width) || asset.width < 1)) {
+    return { ok: false, message: "输入资源宽度无效。" };
+  }
+  if (asset.height !== undefined && (!isInteger(asset.height) || asset.height < 1)) {
+    return { ok: false, message: "输入资源高度无效。" };
+  }
+  return { ok: true };
+}
+
+export function validateRunJobRequest(request: unknown): ValidationResult {
+  if (!isRecord(request)) {
+    return { ok: false, message: "任务请求格式无效。" };
+  }
+  if (request.mode !== "generate" && request.mode !== "edit" && request.mode !== "inpaint") {
+    return { ok: false, message: "任务模式无效。" };
+  }
+  if (typeof request.prompt !== "string") {
+    return { ok: false, message: "Prompt 格式无效。" };
+  }
+  if (!Array.isArray(request.inputPaths) || request.inputPaths.some((item) => typeof item !== "string")) {
+    return { ok: false, message: "输入图片路径无效。" };
+  }
+  if (request.maskPath !== undefined && typeof request.maskPath !== "string") {
+    return { ok: false, message: "Mask 路径无效。" };
+  }
+  if (request.maskDataUrl !== undefined && typeof request.maskDataUrl !== "string") {
+    return { ok: false, message: "Mask 数据无效。" };
+  }
+  return validateImageParams(request.params);
+}
+
+export function validateWorkspaceDraftInput(input: unknown): ValidationResult {
+  if (!isRecord(input)) {
+    return { ok: false, message: "草稿格式无效。" };
+  }
+  if (input.mode !== "generate" && input.mode !== "edit" && input.mode !== "inpaint") {
+    return { ok: false, message: "草稿模式无效。" };
+  }
+  if (typeof input.prompt !== "string") {
+    return { ok: false, message: "草稿 Prompt 无效。" };
+  }
+  if (!Array.isArray(input.inputAssets)) {
+    return { ok: false, message: "草稿输入资源无效。" };
+  }
+  if (input.inputAssets.length > 10) {
+    return { ok: false, message: "草稿输入资源不能超过 10 张。" };
+  }
+  for (const asset of input.inputAssets) {
+    const assetValidation = validateInputAssetShape(asset);
+    if (!assetValidation.ok) return assetValidation;
+  }
+  if (input.maskAsset !== undefined && input.maskAsset !== null) {
+    const maskValidation = validateInputAssetShape(input.maskAsset);
+    if (!maskValidation.ok) return maskValidation;
+  }
+  if (input.maskDataUrl !== undefined && typeof input.maskDataUrl !== "string") {
+    return { ok: false, message: "草稿 Mask 数据无效。" };
+  }
+  if (!isInteger(input.brushSize) || input.brushSize < 1) {
+    return { ok: false, message: "画笔大小无效。" };
+  }
+  return validateImageParams(input.params);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isOneOf<T extends string>(value: string, options: readonly T[]): value is T {
-  return (options as readonly string[]).includes(value);
+function isOneOf<T extends string>(value: unknown, options: readonly T[]): value is T {
+  return typeof value === "string" && (options as readonly string[]).includes(value);
 }
 
 function isInteger(value: unknown): value is number {


### PR DESCRIPTION
## Summary
- add runtime validators for job run requests, workspace draft saves, and draft input asset metadata
- reject malformed job/draft IPC payloads in main-process handlers before path or state handling
- update checklist/audit docs with the new IPC hardening evidence

## Verification
- pnpm vitest run src/shared/validation.test.ts
- pnpm build
- pnpm verify:mock-api
- git diff --check

## Notes
- GitHub Actions may still fail before executing steps due to the known billing/spending-limit blocker tracked in issue #5.