### PR TITLE
Refresh audit tracker evidence

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -3,7 +3,8 @@
 Date: 2026-05-18
 Branch: `main`
 Runtime/config evidence through: merged `main` at `703139d`
-Release and external-blocker evidence through: merged `main` at `703139d`
+Release evidence through: merged `main` at `703139d`
+Audit and blocker-tracking evidence through: merged `main` at `465dc9b`
 
 ## Objective Restated
 
@@ -25,13 +26,13 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | History and reuse | JSON history, search, reuse, copy prompt, open folder, delete, clear | Done |
 | Recovery | Atomic state writes with `.bak`, interrupted job recovery, workspace draft autosave/restore | Done |
 | Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, SSE events, and a mock request-inspection route; `pnpm verify:mock-api` probes models, JSON generation with Image 2 parameter assertions, streaming generation, multipart edit with Image 2 parameter assertions, multi-image mask edit/inpaint, and streaming edit | Done |
-| Tests | `pnpm build` passed with 4 test files and 28 tests on merged `main` at `703139d` | Done |
+| Tests | `pnpm build` passed with 4 test files and 28 tests on merged `main` at `703139d`; later merge `465dc9b` was audit-only | Done |
 | Packaging | `electron-builder` config includes main, preload, shared, and renderer runtime outputs; project icons in `build/`; `pnpm package:dir`; `pnpm package:mac`; local app; dmg-copy launch; two-cycle reinstall smoke tests; `pnpm verify:release:mac` uses `ditto` for app bundle copying, verifies copied app signatures, and confirms the app process and main window through CoreGraphics window enumeration; private GitHub pre-release `v0.1.0-mac-unsigned` | Done for ad-hoc signed, unnotarized macOS local/pre-release artifacts |
 | Remote CI | `.github/workflows/ci.yml` runs build + mock API verifier on Ubuntu and macOS, Windows, and Linux package gates for push/PR/manual dispatch; runs are blocked before job steps by GitHub billing/spending limit | Configured; external billing blocker tracked in GitHub issue #5 |
 | Docs updated | `README.md`, `PLAN.md`, `ARCHITECTURE.md`, `TODO.md`, `CHECKLIST.md` updated | Done |
 | External acceptance runbook | `EXTERNAL_ACCEPTANCE.md` consolidates the remaining real API, signing/notarization, Windows/Linux, and CI billing gates with commands and evidence requirements | Done |
-| CTO worktree cleanup | After PR #52, stale worktree and branch were pruned; `git worktree list` showed only the main worktree before this audit-refresh branch was opened | Done |
-| Clean main worktree | `git status --short --branch` showed clean `main` at `703139d` before this audit-refresh branch was opened | Done |
+| CTO worktree cleanup | After PR #53 and issue body maintenance, stale worktrees and branches were pruned; `git worktree list` showed only the main worktree before this audit-refresh branch was opened | Done |
+| Clean main worktree | `git status --short --branch` showed clean `main` at `465dc9b` before this audit-refresh branch was opened | Done |
 | Abandoned renderer stash | `stash@{0}` inspected; touched only `src/renderer/App.tsx` and `src/renderer/styles.css`; current `main` has newer renderer behavior including draft recovery and mask alpha validation; archived non-destructively to `origin/archive/abandoned-renderer-stash`; local stash dropped after verifying the archive commit matched | Resolved; tracked in GitHub issue #2 |
 | Remote/PR parity | private GitHub `origin` configured at `https://github.com/Bliveren/image2tools.git`; `main` pushed and tracks `origin/main`; `git ls-remote --heads origin main` matches local pushed history | Done for current `main`; future subtask branches can use PR flow |
 | Official OpenAI docs parity | Current OpenAI Image Generation guide and OpenAPI endpoint metadata confirm `gpt-image-2`, `/images/generations`, `/images/edits`, base64 output, streaming partial images, mask requirements, size/format/quality/compression/background/moderation parameters, no transparent background for `gpt-image-2`, and omitted `input_fidelity` for `gpt-image-2`; docs also note GPT Image organization verification and extra partial-image token cost | Done |
@@ -112,6 +113,8 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `pnpm verify:signing-ready`: on merged `main` at `703139d`, still failed for the expected external reasons (no Developer ID code signing identity and Apple notarization env vars unset) while confirming the default local preview path uses ad-hoc signing and `package:mac:signed` can override `mac.identity` and enable notarization.
 - `gh release view v0.1.0-mac-unsigned --repo Bliveren/image2tools --json assets,url`: private pre-release assets still report GitHub SHA256 digests matching the refreshed ad-hoc signed preview build (`d6bab3af7b318f12025c350aa3b7c1e7e50362a138ee5d23cec0539cde0d3a90` for dmg and `ade24acf2d467abb74094a9e47738b3eb1c142c3ca6719ed0641fdca528d0b25` for zip).
 - `shasum -a 256 release/Image2Tools-0.1.0-mac-arm64.dmg release/Image2Tools-0.1.0-mac-arm64.zip`: in the fresh audit-refresh worktree, the command failed because release artifacts are ignored build outputs and are not present in a new worktree; this does not change the earlier local/GitHub digest match from the release-refresh worktree.
+- PR #53 merged a docs-only completion audit refresh into `main` as `465dc9bfdc0f0f9eeaaa3cf5aeed73a21c825483`; before and after cleanup, `git status --short --branch` was clean, `git worktree list` had only the main worktree, and `gh pr list --state open` returned no open PRs.
+- The four remaining blocker issue bodies were refreshed after PR #53 so their top-level acceptance text matches current commands and state: #1 real API acceptance, #3 Developer ID signed/notarized macOS release, #4 native Windows/Linux validation, and #5 GitHub Actions billing/spending-limit.
 - `docker pull --platform linux/arm64 node:25-bookworm`: after one transient TLS copy error, downloaded the Node 25 Debian Bookworm ARM64 image for Linux container validation.
 - `docker run --platform linux/arm64 ... node:25-bookworm ... pnpm build && pnpm verify:mock-api && pnpm package`: in an Ubuntu/Debian Bookworm ARM64 container, `pnpm build` passed with 4 test files and 21 tests, `pnpm verify:mock-api` passed, and `pnpm package` produced `release/Image2Tools-0.1.0-linux-arm64.AppImage` plus `release/linux-arm64-unpacked/image2tools`.
 - `file release/Image2Tools-0.1.0-linux-arm64.AppImage release/linux-arm64-unpacked/image2tools`: confirmed both Linux artifacts are ARM aarch64 ELF executables.
@@ -207,6 +210,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - `033e888` includes PR #39 signing package path improvements; current local `pnpm build` and `pnpm verify:mock-api` passed, `pnpm verify:real-api` refused to call without a key, and `pnpm verify:signing-ready` confirmed the signed packaging override while remaining blocked on external signing materials.
 - `d701ae8` is a docs-only merge after PR #40. Current local `pnpm build` and `pnpm verify:mock-api` pass; `pnpm verify:real-api` still refuses to call without a key; `pnpm verify:signing-ready` still confirms the signed packaging override while remaining blocked on external signing materials; latest CI still fails before steps due to issue #5; Linux ARM64 container packaging/extracted-launch evidence is now captured, while native Windows/Linux desktop validation remains open under issue #4.
 - `703139d` includes PR #52, which refreshed the private macOS preview release assets from current `main`, switched the local preview package to ad-hoc signing, hardened the macOS release verifier around bundle copy/signature/window checks, and updated docs. Current local `pnpm build` and `pnpm verify:mock-api` pass; `pnpm verify:real-api` still refuses to call without a key; `pnpm verify:signing-ready` still confirms the signed packaging override while remaining blocked on external signing materials; latest CI still fails before steps due to issue #5; real API, signed/notarized distribution, and native Windows/Linux desktop validation remain open external gates.
+- `465dc9b` includes PR #53, a docs-only merge that refreshed this completion audit after PR #52. It does not change runtime, packaging, or release artifacts; the latest local repo state is clean and synced, and the remaining open GitHub issues are still the same external blockers #1, #3, #4, and #5.
 
 ## Remaining External Work
 


### PR DESCRIPTION
## Summary
- distinguish runtime/release evidence from docs-only audit evidence in COMPLETION_AUDIT.md
- record PR #53 as the latest docs-only merge and note that blocker issue bodies were refreshed
- keep the remaining external blockers explicit without changing runtime claims

## Verification
- pnpm verify:mock-api
- pnpm verify:real-api (expected no-key guard; no calls made; fresh worktree has no node_modules)
- pnpm verify:signing-ready (expected external signing-material blocker; fresh worktree has no node_modules)
- gh issue list --repo Bliveren/image2tools --state open --json number,title,labels,url --limit 20
- git diff --check