### PR TITLE
Align Image 2 input image limit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,6 +103,7 @@ flowchart LR
 - `background`: `auto` / `opaque`；不暴露 `transparent`
 - `partial_images`: `0..3`
 - `partial_images`: 开启流式局部图会产生额外 image output token 成本
+- 编辑输入/参考图最多 16 张；使用 mask 时 mask 只应用到第一张输入图
 - `input_fidelity`: 不对 `gpt-image-2` 暴露，模型自动高保真处理输入图
 
 ## 7. 数据模型

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -39,6 +39,7 @@
 - [x] mask 与首张源图格式一致性校验生效
 - [x] mask alpha 通道校验生效
 - [x] 编辑结果可下载
+- [x] 参考图数量限制为 GPT Image 2 支持的最多 16 张
 - [x] 多图编辑时 mask 只应用到第一张图的提示清晰
 
 ## 5. 体验检查
@@ -124,5 +125,6 @@
 - [x] `background` 只允许 `auto` / `opaque`
 - [x] `quality`、`output_format`、`background`、`moderation` 运行时枚举值会被校验
 - [x] `n`、`partial_images`、`timeoutMs`、`output_compression` 必须是整数且有限
+- [x] 编辑输入/参考图数量最多 16 张
 - [x] `output_compression` 仅在 `jpeg` / `webp` 时发送
 - [x] `stream` 开启时处理 partial 与 completed 事件

--- a/PLAN.md
+++ b/PLAN.md
@@ -197,6 +197,7 @@
 - `gpt-image-2` 支持 `stream: true` 和 `partial_images: 0..3`
 - 流式 `partial_images` 会产生额外 image output token 成本
 - `gpt-image-2` 支持灵活尺寸，宽高必须为 16 的倍数、比例不超过 3:1、最长边不超过 3840、总像素在 655360 到 8294400 之间
+- `gpt-image-2` 编辑请求最多支持 16 张输入/参考图；使用 mask 时 mask 只应用到第一张输入图
 - mask 编辑要求源图和 mask 格式、尺寸一致且小于 50MB，mask 必须包含 alpha 通道
 - 真实 API 验收前需要确认 OpenAI 组织已完成 GPT Image 所需的组织验证
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -489,7 +489,6 @@ async function handleSaveDraft(_event: IpcMainInvokeEvent, input: WorkspaceDraft
   const state = await readState();
   const draft: WorkspaceDraft = {
     ...input,
-    inputAssets: input.inputAssets.slice(0, 10),
     updatedAt: new Date().toISOString()
   };
   await writeState({ ...state, draft });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,6 +23,7 @@ import {
 import {
   DEFAULT_BASE_URL,
   DEFAULT_IMAGE_PARAMS,
+  MAX_GPT_IMAGE_INPUTS,
   maskMimeTypeForSource,
   mimeTypeFromDataUrl,
   validateMaskMimeType,
@@ -261,6 +262,9 @@ export function App() {
   const modeError = useMemo(() => {
     if (mode === "edit" && inputAssets.length === 0) return "Add at least one reference image.";
     if (mode === "inpaint" && inputAssets.length === 0) return "Add a source image before inpainting.";
+    if (mode !== "generate" && inputAssets.length > MAX_GPT_IMAGE_INPUTS) {
+      return `GPT Image 2 supports up to ${MAX_GPT_IMAGE_INPUTS} input images.`;
+    }
     if (mode === "inpaint" && !maskPreview) return "Paint or upload a mask before inpainting.";
     if (mode === "inpaint" && maskCheck && !maskCheck.ok) return maskCheck.message;
     return null;
@@ -466,9 +470,17 @@ export function App() {
     const assets = await bridge.selectImages();
     if (assets.length > 0) {
       markDraftChanged();
-      setInputAssets((current) => dedupeAssets([...current, ...assets]));
+      const next = dedupeAssets([...inputAssets, ...assets]);
+      const cappedNext = next.slice(0, MAX_GPT_IMAGE_INPUTS);
+      const addedCount = Math.max(0, cappedNext.length - inputAssets.length);
+      const capped = next.length > MAX_GPT_IMAGE_INPUTS;
+      setInputAssets(cappedNext);
       if (mode === "generate") setMode("edit");
-      setNotice({ kind: "success", text: `${assets.length} image${assets.length === 1 ? "" : "s"} added.` });
+      const cappedNote = capped ? ` GPT Image 2 accepts up to ${MAX_GPT_IMAGE_INPUTS} input images.` : "";
+      setNotice({
+        kind: capped ? "info" : "success",
+        text: `${addedCount} image${addedCount === 1 ? "" : "s"} added, ${cappedNext.length} selected.${cappedNote}`
+      });
     }
   }
 

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_IMAGE_PARAMS,
+  MAX_GPT_IMAGE_INPUTS,
   dataUrlToBase64,
   extensionForFormat,
   getValidationError,
@@ -130,13 +131,37 @@ describe("gpt-image-2 validation", () => {
     expect(validateRunJobRequest({ ...job, maskPath: 123 } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, maskDataUrl: 123 } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, params: { ...DEFAULT_IMAGE_PARAMS, n: 1.5 } } as never).ok).toBe(false);
+    expect(
+      validateRunJobRequest({
+        ...job,
+        inputPaths: Array.from({ length: MAX_GPT_IMAGE_INPUTS }, (_, index) => `/tmp/${index}.png`)
+      }).ok
+    ).toBe(true);
+    expect(
+      validateRunJobRequest({
+        ...job,
+        inputPaths: Array.from({ length: MAX_GPT_IMAGE_INPUTS + 1 }, (_, index) => `/tmp/${index}.png`)
+      }).ok
+    ).toBe(false);
     expect(validateWorkspaceDraftInput(null).ok).toBe(false);
     expect(validateWorkspaceDraftInput({ ...draft, mode: "compose" } as never).ok).toBe(false);
     expect(validateWorkspaceDraftInput({ ...draft, prompt: null } as never).ok).toBe(false);
     expect(
       validateWorkspaceDraftInput({
         ...draft,
-        inputAssets: Array.from({ length: 11 }, (_, index) => ({
+        inputAssets: Array.from({ length: MAX_GPT_IMAGE_INPUTS }, (_, index) => ({
+          id: String(index),
+          name: "a.png",
+          path: "/tmp/a.png",
+          mimeType: "image/png",
+          sizeBytes: 1
+        }))
+      }).ok
+    ).toBe(true);
+    expect(
+      validateWorkspaceDraftInput({
+        ...draft,
+        inputAssets: Array.from({ length: MAX_GPT_IMAGE_INPUTS + 1 }, (_, index) => ({
           id: String(index),
           name: "a.png",
           path: "/tmp/a.png",

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -9,6 +9,7 @@ import type {
 export const GPT_IMAGE_2_MODEL = "gpt-image-2";
 
 export const DEFAULT_BASE_URL = "https://api.openai.com/v1";
+export const MAX_GPT_IMAGE_INPUTS = 16;
 
 export const DEFAULT_IMAGE_PARAMS: ImageParams = {
   model: GPT_IMAGE_2_MODEL,
@@ -234,6 +235,9 @@ export function validateRunJobRequest(request: unknown): ValidationResult {
   if (!Array.isArray(request.inputPaths) || request.inputPaths.some((item) => typeof item !== "string")) {
     return { ok: false, message: "输入图片路径无效。" };
   }
+  if (request.inputPaths.length > MAX_GPT_IMAGE_INPUTS) {
+    return { ok: false, message: `GPT Image 2 输入图片不能超过 ${MAX_GPT_IMAGE_INPUTS} 张。` };
+  }
   if (request.maskPath !== undefined && typeof request.maskPath !== "string") {
     return { ok: false, message: "Mask 路径无效。" };
   }
@@ -256,8 +260,8 @@ export function validateWorkspaceDraftInput(input: unknown): ValidationResult {
   if (!Array.isArray(input.inputAssets)) {
     return { ok: false, message: "草稿输入资源无效。" };
   }
-  if (input.inputAssets.length > 10) {
-    return { ok: false, message: "草稿输入资源不能超过 10 张。" };
+  if (input.inputAssets.length > MAX_GPT_IMAGE_INPUTS) {
+    return { ok: false, message: `草稿输入资源不能超过 ${MAX_GPT_IMAGE_INPUTS} 张。` };
   }
   for (const asset of input.inputAssets) {
     const assetValidation = validateInputAssetShape(asset);


### PR DESCRIPTION
## Summary
- align GPT Image 2 edit input/reference image handling to the current 16-image API limit
- cap renderer selections at the shared limit and remove the stale 10-image draft truncation
- update planning, architecture, and checklist docs with the same constraint

## Verification
- pnpm vitest run src/shared/validation.test.ts
- pnpm build
- pnpm verify:mock-api
- git diff --check