### PR TITLE
Refresh audit after Linux CI fix

### DIFF
--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,9 +2,9 @@
 
 Date: 2026-05-18
 Branch: `main`
-Runtime/config evidence through: merged `main` at `9d8feac`
+Runtime/config evidence through: merged `main` at `fda838d`
 Release evidence through: merged `main` at `703139d`
-Audit and blocker-tracking evidence through: merged `main` at `9d8feac`
+Audit and blocker-tracking evidence through: merged `main` at `fda838d`
 
 ## Objective Restated
 
@@ -32,7 +32,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Docs updated | `README.md`, `PLAN.md`, `ARCHITECTURE.md`, `TODO.md`, `CHECKLIST.md` updated | Done |
 | External acceptance runbook | `EXTERNAL_ACCEPTANCE.md` consolidates the remaining real API, signing/notarization, Windows/Linux, and CI billing gates with commands and evidence requirements | Done |
 | CTO worktree cleanup | After PR #55, stale worktrees and local/remote feature branches were pruned; `git worktree list` showed only the main worktree before this audit-refresh branch was opened | Done |
-| Clean main worktree | `git status --short --branch` showed clean and synced `main` at `9d8feac` before this audit-refresh branch was opened | Done |
+| Clean main worktree | `git status --short --branch` showed clean and synced `main` at `fda838d` before this audit-refresh branch was opened | Done |
 | Abandoned renderer stash | `stash@{0}` inspected; touched only `src/renderer/App.tsx` and `src/renderer/styles.css`; current `main` has newer renderer behavior including draft recovery and mask alpha validation; archived non-destructively to `origin/archive/abandoned-renderer-stash`; local stash dropped after verifying the archive commit matched | Resolved; tracked in GitHub issue #2 |
 | Remote/PR parity | private GitHub `origin` configured at `https://github.com/Bliveren/image2tools.git`; `main` pushed and tracks `origin/main`; `git ls-remote --heads origin main` matches local pushed history | Done for current `main`; future subtask branches can use PR flow |
 | Official OpenAI docs parity | Current OpenAI Image Generation guide and OpenAPI endpoint metadata confirm `gpt-image-2`, `/images/generations`, `/images/edits`, base64 output, streaming partial images, up to 16 input/reference images for GPT image edit requests, mask-first-image behavior for multi-image masks, mask requirements, size/format/quality/compression/background/moderation parameters, no transparent background for `gpt-image-2`, and omitted `input_fidelity` for `gpt-image-2`; docs also note GPT Image organization verification and extra partial-image token cost | Done |
@@ -225,6 +225,14 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - On current `main` at `9d8feac`, `pnpm verify:real-api` exited before making real API calls because neither `IMAGE2TOOLS_API_KEY` nor `OPENAI_API_KEY` was set, matching issue #1.
 - On current `main` at `9d8feac`, `pnpm verify:signing-ready` failed for the expected external prerequisites: no valid code signing identity and unset `CSC_NAME`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`; no signing or notarization was attempted, matching issue #3.
 - PR #56 run `26038247847` and post-merge main run `26038331901` both failed before any workflow step executed; all four jobs had empty `steps: []`, matching the GitHub Actions billing/spending-limit blocker tracked in issue #5 rather than a repository-code failure.
+- `0240923` includes PR #57, a docs-only merge that recorded final local audit checks in this completion audit.
+- Post-PR #57 main CI run `26038660344` partially started: build, macOS, and Windows jobs still failed before steps, but the Linux package job reached `Install Linux smoke-test dependencies` and failed because Ubuntu 24.04 had no installable `libasound2` package candidate.
+- `fda838d` includes PR #58, which replaced the Linux package gate dependency `libasound2` with Ubuntu 24.04's `libasound2t64` in `.github/workflows/ci.yml`.
+- PR #58 local checks passed: workflow YAML parsed with Ruby and `git diff --check` passed.
+- PR #58 run `26038840030` and post-merge main run `26038929593` both failed before any workflow step executed; all four jobs had empty `steps: []`, so the `libasound2t64` fix is merged but still not remotely exercised because issue #5 blocks CI execution.
+- On current `main` at `fda838d`, `pnpm build` passed with 4 test files and 28 tests, followed by successful renderer and main builds.
+- On current `main` at `fda838d`, `pnpm verify:mock-api` passed.
+- On current `main` at `fda838d`, `git diff --check` passed and workflow YAML parsing passed.
 
 ## Remaining External Work
 


### PR DESCRIPTION
## Summary
- refresh COMPLETION_AUDIT.md through current main at fda838d
- record the post-PR #57 Linux runner dependency failure and PR #58 fix
- record latest local build/mock/YAML checks and CI billing-blocker status

## Verification
- git diff --check
- rg -n "fda838d|PR #58|libasound2t64|26038660344|26038840030|26038929593|workflow YAML" COMPLETION_AUDIT.md