### PR TITLE
Reject invalid run request mask sources

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -66,6 +66,7 @@
 - [x] config 保存、prompt、API Key、Base URL 输入会拒绝或归一化畸形运行时值
 - [x] job run / draft save IPC 请求会拒绝畸形 payload、路径数组和草稿资源对象
 - [x] job run IPC 请求会在创建历史任务前拒绝文生图携带输入、编辑缺少输入、非局部重绘携带 mask、局部重绘缺少 mask
+- [x] job run IPC 请求会在写入 mask 文件前拒绝非图片输入路径、非 PNG/WebP mask 路径和畸形 mask data URL
 - [x] 状态文件写入有备份与恢复路径
 - [x] 未完成任务重启后会恢复为失败状态
 - [x] 工作区草稿可自动保存并在重启后恢复

--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -2,9 +2,9 @@
 
 Date: 2026-05-18
 Branch: `main`
-Runtime/config evidence through: latest runtime-affecting `main` at `ae38e13`
+Runtime/config evidence through: latest runtime-affecting `main` at `7e33313`
 Release evidence through: refreshed private macOS preview assets documented on merged `main` at `1d8e215`
-Audit and blocker-tracking evidence through: merged `main` at `ae38e13`
+Audit and blocker-tracking evidence through: merged `main` at `7e33313`
 Note: docs-only audit merges may advance `main` without changing runtime,
 release artifacts, or external blocker status; the evidence rows below call out
 that distinction explicitly.
@@ -25,7 +25,7 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 | Text-to-image generation | `/images/generations` implementation and tests in `src/main/services/openaiImage.ts` / `.test.ts`, including saving multiple returned images when `n > 1` | Implemented; real API manual run pending |
 | Image edit and inpaint | `/images/edits`, multipart `image[]`, mask support, renderer mode switching, 16-image reference cap, mask editor, mask/source size, format, and alpha validation, plus service tests for advanced edit parameter transmission | Implemented; real API manual run pending |
 | Streaming partial previews | SSE parsing and partial event handling in main + renderer; covered by tests | Done |
-| Local file save and download | Base64 output saved under Electron `userData`; download dialog copies selected generated asset; main-process IPC rejects malformed job/draft payloads and mode/input/mask mismatches before path, job, or asset handling, and rejects download/open/delete paths outside the app image store or current history | Done |
+| Local file save and download | Base64 output saved under Electron `userData`; download dialog copies selected generated asset; main-process IPC rejects malformed job/draft payloads, mode/input/mask mismatches, non-image input paths, non-PNG/WebP mask paths, and malformed mask data URLs before path, mask persistence, job, or asset handling, and rejects download/open/delete paths outside the app image store or current history | Done |
 | History and reuse | JSON history, search, reuse, copy prompt, open folder, delete, clear | Done |
 | Recovery | Atomic state writes with `.bak`, interrupted job recovery, workspace draft autosave/restore | Done |
 | Local no-key integration path | `pnpm mock:openai` serves `/models`, `/images/generations`, `/images/edits`, JSON results, SSE events, and a mock request-inspection route; `pnpm verify:mock-api` probes models, JSON generation with Image 2 parameter assertions, streaming generation, multipart edit with Image 2 parameter assertions, multi-image mask edit/inpaint with `image[]` and `mask` field assertions, and streaming edit | Done |
@@ -258,6 +258,8 @@ Deliver a simple Electron desktop tool for `gpt-image-2` that lets the user save
 - On merged `main` at `6d4def9`, `pnpm verify:mock-api`, `pnpm build`, and `git diff --check` passed locally; the post-merge GitHub Actions run `26043216928` still failed before workflow steps executed with all jobs reporting empty `steps: []`, matching issue #5.
 - `fix/cto-run-request-mode-validation` hardens shared job-run IPC validation so direct payloads are rejected before job creation when generate carries input images, edit has no input images, non-inpaint requests carry mask data, or inpaint has no mask.
 - `pnpm vitest run src/shared/validation.test.ts`, `pnpm verify:mock-api`, `pnpm build`, and `git diff --check` passed on the run-request mode validation branch before PR review.
+- `fix/cto-run-request-mask-source-validation` hardens shared job-run IPC validation so direct payloads with non-image input paths, non-PNG/WebP mask paths, JPEG mask data URLs, or malformed mask data URLs are rejected before main persists mask files or creates jobs.
+- `pnpm vitest run src/shared/validation.test.ts`, `pnpm verify:mock-api`, `pnpm build`, and `git diff --check` passed on the run-request mask/source validation branch before PR review.
 
 ## Remaining External Work
 

--- a/TODO.md
+++ b/TODO.md
@@ -76,6 +76,7 @@
 - [x] config / prompt / API Key 运行时输入校验拒绝非字符串畸形值
 - [x] job run / draft save IPC 请求会先做运行时 shape 校验
 - [x] job run IPC 请求会拒绝 mode 与输入图片 / mask 不匹配的无效组合
+- [x] job run IPC 请求会拒绝非图片输入路径、非 PNG/WebP mask 路径和畸形 mask data URL
 - [x] 增加手工 QA 用例
 - [x] 增加本地 mock API 回归入口
 - [x] 增加本地 mock API 自动校验脚本

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -135,10 +135,14 @@ describe("gpt-image-2 validation", () => {
     expect(validateRunJobRequest({ ...job, maskPath: "/tmp/mask.png" } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, mode: "edit", inputPaths: [] } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, mode: "edit", inputPaths: ["/tmp/a.png"] } as never).ok).toBe(true);
+    expect(validateRunJobRequest({ ...job, mode: "edit", inputPaths: ["/tmp/a.txt"] } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, mode: "edit", inputPaths: ["/tmp/a.png"], maskPath: "/tmp/mask.png" } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"] } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskPath: "/tmp/mask.jpg" } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskPath: "/tmp/mask.png" } as never).ok).toBe(true);
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "data:image/png;base64,abc" } as never).ok).toBe(true);
+    expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "data:image/jpeg;base64,abc" } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "not-a-data-url" } as never).ok).toBe(false);
     expect(
       validateRunJobRequest({
         ...job,

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -29,6 +29,7 @@ export const IMAGE_QUALITY_OPTIONS = ["auto", "low", "medium", "high"] as const 
 export const IMAGE_FORMAT_OPTIONS = ["png", "jpeg", "webp"] as const satisfies readonly ImageFormat[];
 export const IMAGE_BACKGROUND_OPTIONS = ["auto", "opaque"] as const satisfies readonly ImageBackground[];
 export const MODERATION_MODE_OPTIONS = ["auto", "low"] as const satisfies readonly ModerationMode[];
+const IMAGE_PATH_PATTERN = /\.(png|jpe?g|webp)$/i;
 
 export interface ValidationResult {
   ok: boolean;
@@ -235,6 +236,9 @@ export function validateRunJobRequest(request: unknown): ValidationResult {
   if (!Array.isArray(request.inputPaths) || request.inputPaths.some((item) => typeof item !== "string")) {
     return { ok: false, message: "输入图片路径无效。" };
   }
+  if (request.inputPaths.some((item) => !IMAGE_PATH_PATTERN.test(item))) {
+    return { ok: false, message: "输入图片必须是 PNG、JPEG 或 WebP。" };
+  }
   if (request.inputPaths.length > MAX_GPT_IMAGE_INPUTS) {
     return { ok: false, message: `GPT Image 2 输入图片不能超过 ${MAX_GPT_IMAGE_INPUTS} 张。` };
   }
@@ -247,8 +251,19 @@ export function validateRunJobRequest(request: unknown): ValidationResult {
   if (request.maskPath !== undefined && typeof request.maskPath !== "string") {
     return { ok: false, message: "Mask 路径无效。" };
   }
+  if (typeof request.maskPath === "string" && request.maskPath && !/\.(png|webp)$/i.test(request.maskPath)) {
+    return { ok: false, message: "Mask 必须是 PNG 或 WebP。" };
+  }
   if (request.maskDataUrl !== undefined && typeof request.maskDataUrl !== "string") {
     return { ok: false, message: "Mask 数据无效。" };
+  }
+  if (typeof request.maskDataUrl === "string" && request.maskDataUrl) {
+    const maskMimeType = mimeTypeFromDataUrl(request.maskDataUrl);
+    if (!maskMimeType) {
+      return { ok: false, message: "Mask 数据必须是 PNG 或 WebP data URL。" };
+    }
+    const maskType = validateMaskMimeType(maskMimeType);
+    if (!maskType.ok) return maskType;
   }
   const hasMask = Boolean(request.maskPath || request.maskDataUrl);
   if (request.mode !== "inpaint" && hasMask) {


### PR DESCRIPTION
## Summary
- reject direct job-run payloads with non-image input paths before job creation
- reject non-PNG/WebP mask paths and malformed or JPEG mask data URLs before mask persistence
- update TODO/checklist/audit evidence for the new IPC validation gate

## Verification
- pnpm vitest run src/shared/validation.test.ts
- pnpm verify:mock-api
- pnpm build
- git diff --check main..HEAD

## CI note
GitHub Actions is still externally blocked by the account payment/spending-limit issue tracked in issue #5; local gates above passed.