### PR TITLE
Document multi-model v0.2 plan

### DIFF
--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -1,0 +1,176 @@
+# Multi-Model Checklist
+
+Target release: `v0.2.0`
+
+## 0. 版本目标检查
+
+- [x] 多生图模型支持被确认为 `v0.2.0` 核心版本目标
+- [ ] `v0.2.0` release notes 覆盖 GPT Image 2、Nano Banana 3、General 支持
+- [ ] `v0.2.0` 发布前完成多模型 mock 验证
+- [ ] `v0.2.0` 发布前完成至少一轮真实 OpenAI / Gemini API 外部验收
+
+## 1. 产品检查
+
+- [ ] 服务配置区支持选择 provider
+- [ ] OpenAI provider 默认 Base URL 正确
+- [ ] Gemini provider 默认 Base URL 正确
+- [ ] API Key 保存后可自动发现模型
+- [ ] 模型发现失败有明确提示
+- [ ] 模型发现成功后显示可用模型数量或状态
+- [ ] 启动模型区位于服务配置区下方
+- [ ] `GPT Image 2` 启动按钮可按需启用/置灰
+- [ ] `Nano Banana 3` 启动按钮可按需启用/置灰
+- [ ] `General` 启动按钮可按需启用/置灰
+- [ ] 不可用按钮有用户能理解的原因
+- [ ] 点击启动模型后主工作区切换到对应模型界面
+- [ ] 当前启动模型在 UI 中有清晰状态
+
+## 2. Provider 与模型探测检查
+
+- [ ] OpenAI `/models` 探测成功时能识别 `gpt-image-2`
+- [ ] OpenAI `/models` 不含 `gpt-image-2` 时按钮置灰
+- [ ] Gemini `/models` 探测成功时能识别 `gemini-3.1-flash-image`
+- [ ] Gemini `/models` 不含目标模型时按钮置灰
+- [ ] General 能识别非重点但可用的图片模型
+- [ ] 探测请求不会把 API Key 写入日志
+- [ ] 探测错误会脱敏
+- [ ] 切换 provider 不会误用另一个 provider 的 Key
+- [ ] 清除 Key 后清空对应 provider 的可用模型状态
+
+## 3. 数据迁移检查
+
+- [ ] v1 state 可以读取
+- [ ] v1 config 迁移为 OpenAI provider
+- [ ] v1 encrypted API Key 仍可解密
+- [ ] v1 history 补齐 `providerKind`
+- [ ] v1 history 补齐 `launchId`
+- [ ] v1 history 补齐 `modelId`
+- [ ] v1 history 补齐 `modelDisplayName`
+- [ ] v1 draft 迁移后可恢复
+- [ ] 迁移失败时仍可 fallback 到 backup
+- [ ] state 写入仍保留备份机制
+
+## 4. GPT Image 2 回归检查
+
+- [ ] 文生图仍调用 `/v1/images/generations`
+- [ ] 编辑仍调用 `/v1/images/edits`
+- [ ] 局部重绘仍发送 OpenAI mask 参数
+- [ ] 多图编辑仍使用正确 multipart 字段
+- [ ] stream 开启时仍处理 partial image
+- [ ] `partial_images` 仍限制 0..3
+- [ ] 自定义尺寸仍符合 `gpt-image-2` 约束
+- [ ] `background` 不显示 transparent
+- [ ] `input_fidelity` 不暴露给 `gpt-image-2`
+- [ ] 下载、打开目录、删除历史仍安全
+- [ ] mock OpenAI verifier 通过
+
+## 5. Nano Banana 3 检查
+
+- [ ] 启动按钮映射到 `gemini-3.1-flash-image`
+- [ ] UI 显示 Nano Banana 3 专属参数
+- [ ] UI 不显示 OpenAI-only 参数
+- [ ] 文生图请求使用 Gemini `generateContent`
+- [ ] 参考图编辑请求包含 image `inlineData`
+- [ ] 响应 image parts 能保存到本地
+- [ ] 响应 text parts 能保存为 job metadata
+- [ ] 生成结果能显示在中间画布
+- [ ] 生成结果能下载
+- [ ] 失败错误提示清晰且脱敏
+- [ ] Thinking 开关只在模型支持时显示
+- [ ] Search grounding 开关只在模型支持时显示
+- [ ] Resolution 控件符合 Nano Banana 3 能力
+- [ ] Aspect ratio 控件符合 Nano Banana 3 能力
+- [ ] 局部引导编辑文案不承诺 exact mask
+- [ ] mock Gemini verifier 通过
+
+## 6. General 模式检查
+
+- [ ] General 只在存在可尝试图片模型时启用
+- [ ] General UI 不显示未确认高级能力
+- [ ] General 运行失败时提示模型未适配或 provider 不兼容
+- [ ] General 历史任务记录真实 model id
+- [ ] General 不影响重点模型按钮状态
+
+## 7. 历史任务检查
+
+- [ ] 每条历史显示模型 chip
+- [ ] 模型 chip 显示 `GPT Image 2`
+- [ ] 模型 chip 显示 `Nano Banana 3`
+- [ ] General 历史显示真实 model id 或 `General`
+- [ ] 默认只展示 6 条历史
+- [ ] 超过 6 条出现展开入口
+- [ ] 展开后出现收起入口
+- [ ] 展开后右侧历史区域内部滚动
+- [ ] 展开历史不会拉长窗口整体高度
+- [ ] 搜索历史时模型字段可参与搜索
+- [ ] 复用历史任务能恢复对应模型参数
+- [ ] 删除单条历史仍只删除该 job owned files
+- [ ] 清空历史仍清理 owned generated files
+
+## 8. UI 与交互检查
+
+- [ ] 服务配置、启动模型、参数面板层级清晰
+- [ ] 同层级标题字号统一
+- [ ] 按钮文字不会溢出
+- [ ] 左右栏拖拽仍可用
+- [ ] 切换模型不会重置不相关 provider config
+- [ ] 切换模型时 prompt 草稿保留或有明确恢复规则
+- [ ] 切换模型时不兼容参数会被安全重置
+- [ ] 无 Electron bridge 的 Web 预览仍给出清晰提示
+- [ ] Electron bridge 下配置、探测、运行功能可用
+
+## 9. 安全检查
+
+- [ ] OpenAI API Key 不进入 renderer 明文状态以外的日志
+- [ ] Gemini API Key 不进入 renderer 明文状态以外的日志
+- [ ] 已保存 Key 只显示脱敏预览
+- [ ] 错误信息脱敏 `sk-...`
+- [ ] 错误信息脱敏 Google API key 样式
+- [ ] 本地 state 不提交到仓库
+- [ ] 资源协议仍只允许 managed image dir
+- [ ] 下载仍只允许当前历史中的 output asset
+- [ ] 删除历史不会删除用户上传的外部源图
+- [ ] Gemini uploaded image 权利提醒文案可见
+
+## 10. 自动化检查
+
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] `pnpm build`
+- [ ] `pnpm verify:mock-api`
+- [ ] `pnpm verify:mock-gemini-api`
+- [ ] state migration tests
+- [ ] provider discovery tests
+- [ ] model catalog tests
+- [ ] OpenAI adapter tests
+- [ ] Gemini adapter tests
+- [ ] renderer i18n tests
+- [ ] package config tests
+
+## 11. 真实 API 验收
+
+- [ ] OpenAI Key 可发现 `gpt-image-2`
+- [ ] OpenAI Key 可完成一次文生图
+- [ ] OpenAI Key 可完成一次参考图编辑
+- [ ] OpenAI Key 可完成一次 mask 局部重绘
+- [ ] Gemini Key 可发现 `gemini-3.1-flash-image`
+- [ ] Gemini Key 可完成一次 Nano Banana 3 文生图
+- [ ] Gemini Key 可完成一次 Nano Banana 3 参考图编辑
+- [ ] Gemini Key 可完成一次 Nano Banana 3 局部引导编辑
+- [ ] 历史中能区分 OpenAI 与 Gemini 任务
+- [ ] 真实 API 验收仍受成本确认环境变量保护
+
+## 12. 发布前检查
+
+- [ ] README 更新多模型定位
+- [ ] ARCHITECTURE 更新 provider adapter 架构
+- [ ] TODO 更新多模型阶段状态
+- [ ] CHECKLIST 更新多模型验收项
+- [ ] SECURITY 更新 Gemini Key 说明
+- [ ] EXTERNAL_ACCEPTANCE 更新 Gemini 真实 API 验收
+- [ ] OPEN_SOURCE_AUDIT 更新多 provider 风险
+- [ ] secret scan 无真实 OpenAI Key
+- [ ] secret scan 无真实 Gemini Key
+- [ ] macOS package smoke test 不回退
+- [ ] Windows package smoke test 不回退
+- [ ] Linux package smoke test 不回退

--- a/MULTI_MODEL_PLAN.md
+++ b/MULTI_MODEL_PLAN.md
@@ -1,0 +1,396 @@
+# Image2Tools 多生图模型支持计划
+
+Last updated: 2026-06-09
+
+Target release: `v0.2.0`
+
+## 1. 目标
+
+将 Image2Tools 从当前的 `gpt-image-2` 单模型工作台升级为多生图模型工作台，作为 `v0.2.0` 的核心版本目标。
+
+最终用户体验：
+
+1. 用户在服务配置区保存模型 API Key。
+2. 系统自动读取该 Key 可访问的生图模型。
+3. 服务配置区下方展示重点支持模型的启动按钮：
+   - `GPT Image 2`
+   - `Nano Banana 3`
+   - `General`
+4. Key 支持的模型按钮可点击，不支持的模型按钮置灰并显示不可用原因。
+5. 点击启动模型后，主工作区进入该模型专属的生成、编辑、局部处理和参数配置界面。
+6. 右侧历史任务显示每张图使用的模型，并默认折叠 6 条后的历史内容。
+
+## 2. 当前基线
+
+当前 main 分支已经实现：
+
+- Electron + React + Vite 桌面应用
+- OpenAI `gpt-image-2` 生成、编辑、局部重绘
+- OpenAI Image API streaming partial previews
+- 本地历史、下载、草稿恢复
+- API Key 本地保存与脱敏预览
+- 左右栏可拖拽布局
+- mock OpenAI Image API 验证脚本
+- 跨平台打包配置和 release verifier
+
+当前关键约束：
+
+- `ImageParams`、`validateImageParams`、`openaiImage.ts` 强绑定 `gpt-image-2`
+- `ProviderConfig` 默认假设 OpenAI-like provider
+- 历史任务未把 provider/model 作为一等字段展示
+- mask 编辑语义目前是 OpenAI Image API 的精确 mask 参数语义
+
+## 3. 官方能力判断
+
+### GPT Image 2
+
+参考：OpenAI Image Generation guide
+
+`gpt-image-2` 继续使用 OpenAI Image API：
+
+- 文生图：`/v1/images/generations`
+- 编辑/局部重绘：`/v1/images/edits`
+- 支持 streaming partial images
+- 支持 `size`、`quality`、`output_format`、`output_compression`、`background`、`n`、`moderation`
+- 支持 mask 参数；多图输入时 mask 应用于第一张图
+- `gpt-image-2` 不支持 transparent background，不暴露 `input_fidelity`
+
+### Nano Banana 3
+
+参考：Google AI Gemini image generation docs。
+
+Google 官方把 Nano Banana 定义为 Gemini 的 native image generation capabilities，并列出多条模型线：
+
+- `gemini-2.5-flash-image`：Nano Banana
+- `gemini-3.1-flash-image`：Nano Banana 2
+- `gemini-3-pro-image`：Nano Banana Pro
+
+本项目按用户确认采用建议映射：
+
+- 产品按钮：`Nano Banana 3`
+- 首期模型 ID：`gemini-3.1-flash-image`
+- 后续可在 Nano Banana 面板内增加 Pro/Flash variant selector
+
+Gemini 图片能力侧重点：
+
+- 使用 Gemini `generateContent`
+- 输入可以是文本和图片；`gemini-3.1-flash-image` 还支持 PDF 输入
+- 输出可以包含 image 和 text parts
+- 支持文本生成图片、文本+图片编辑、多轮会话式编辑
+- 生成图片带 SynthID watermark
+- `gemini-3.1-flash-image` 支持 image search grounding、thinking、更多输出分辨率和宽高比
+
+重要边界：
+
+- Gemini image generation docs 没有与 OpenAI Image API 等价的独立 `mask` multipart 参数。
+- 首期不应把 Nano Banana 的局部处理描述为“精确 mask inpaint”。
+- 可以实现“局部引导编辑”：用户涂抹区域后，将源图和 mask/overlay 作为输入参考，并在 prompt 中说明只修改涂抹区域，但 UI 文案必须说明这是引导式区域编辑。
+
+### General
+
+`General` 是兜底模式，用于 Key 可访问但系统尚未重点适配的图片模型。
+
+首期定位：
+
+- 最小可用生成界面
+- 支持输入 prompt
+- 支持基础参考图上传，前提是 provider adapter 可处理
+- 不承诺高级参数、mask、streaming、批量生成
+
+## 4. 核心设计
+
+### 4.0 Phase 0 决策冻结
+
+Provider selector 文案与默认顺序：
+
+- 默认顺序：`OpenAI`、`Gemini`、`Custom`
+- 英文 UI 文案：`Provider`
+- 中文 UI 文案：`服务商`
+- OpenAI 默认 Base URL：`https://api.openai.com/v1`
+- Gemini 默认 Base URL：`https://generativelanguage.googleapis.com/v1beta`
+- Custom 仅作为后续兼容入口，首期不作为重点启动模型的默认入口
+
+General 模式首期范围：
+
+- 仅作为可尝试的兜底生成模式
+- 只展示 prompt、基础参考图输入、运行按钮和“不承诺高级能力”的提示
+- 不显示 mask、streaming、output format、compression、moderation、thinking、search grounding 等未适配能力
+- 不承诺编辑、精确局部重绘、多轮会话或批量生成
+- 运行失败时必须提示当前 provider/model 未适配或不兼容
+- 历史任务必须记录真实 provider/model 信息
+
+### 4.1 Provider Adapter
+
+新增 provider adapter 层，隔离不同 API 的请求、模型探测、参数校验和结果解析。
+
+建议接口：
+
+```ts
+export interface ImageProviderAdapter {
+  kind: ProviderKind;
+  discoverModels(config: StoredProviderConfig): Promise<DiscoveredModel[]>;
+  testConnection(config: StoredProviderConfig): Promise<ConnectionTestResult>;
+  validateJob(request: RunJobRequest): ValidationResult;
+  runJob(job: GenerationJob, runtime: ImageJobRuntime): Promise<GenerationJob>;
+}
+```
+
+Provider kind：
+
+- `openai`
+- `gemini`
+- `custom`
+
+首期 adapters：
+
+- `openaiImageAdapter`
+- `geminiImageAdapter`
+- `generalImageAdapter`，可先包一层能力有限的 provider-specific fallback
+
+### 4.2 Model Capability Catalog
+
+新增本地能力表，区分“远端 Key 能访问模型”和“本应用知道如何操作模型”。
+
+建议字段：
+
+```ts
+export interface FocusedModelDefinition {
+  launchId: "gpt-image-2" | "nano-banana-3" | "general";
+  displayName: string;
+  providerKind: ProviderKind;
+  modelIds: string[];
+  defaultModelId: string;
+  capabilities: ImageModelCapabilities;
+}
+
+export interface ImageModelCapabilities {
+  generate: boolean;
+  edit: boolean;
+  inpaint: "exact-mask" | "guided-region" | false;
+  referenceImages: boolean;
+  multiTurn: boolean;
+  streamingPartials: boolean;
+  outputText: boolean;
+  configurableOutputFormat: boolean;
+  configurableResolution: "openai-size" | "gemini-resolution-aspect" | "none";
+  supportsThinking: boolean;
+  supportsSearchGrounding: boolean;
+}
+```
+
+模型启动按钮状态来自：
+
+1. Provider 是否配置并能连接。
+2. 远端模型列表是否包含 catalog 中的目标 model id。
+3. 本地 adapter 是否支持该 launch id。
+
+### 4.3 数据模型迁移
+
+将 state 从 v1 迁移到 v2。
+
+Provider 配置：
+
+```ts
+interface StoredProviderConfig {
+  id: string;
+  kind: ProviderKind;
+  name: string;
+  baseURL: string;
+  enabled: boolean;
+  encryptedApiKey?: string;
+  encryption: "safeStorage" | "localFallback" | "none";
+  discoveredModels: DiscoveredModel[];
+  lastModelDiscoveryAt?: string;
+  activeLaunchId?: FocusedLaunchId;
+  activeModelId?: string;
+  updatedAt: string;
+}
+```
+
+历史任务：
+
+```ts
+interface GenerationJob {
+  id: string;
+  providerKind: ProviderKind;
+  providerId: string;
+  launchId: FocusedLaunchId;
+  modelId: string;
+  modelDisplayName: string;
+  mode: WorkMode;
+  prompt: string;
+  params: ImageParamsUnion;
+  status: JobStatus;
+  outputs: ImageAsset[];
+}
+```
+
+参数 union：
+
+- `OpenAIImageParams`
+- `GeminiImageParams`
+- `GeneralImageParams`
+
+迁移规则：
+
+- v1 state config 迁移为一个 `openai` provider。
+- v1 历史任务补：
+  - `providerKind: "openai"`
+  - `launchId: "gpt-image-2"`
+  - `modelId: job.params.model || "gpt-image-2"`
+  - `modelDisplayName: "GPT Image 2"`
+
+### 4.4 UI 信息架构
+
+左侧：
+
+1. 服务配置
+   - Provider selector
+   - API Key
+   - Base URL
+   - 保存、测试、清除 Key
+   - 模型探测状态
+2. 启动模型
+   - `GPT Image 2`
+   - `Nano Banana 3`
+   - `General`
+   - 不可用按钮显示 reason tooltip / inline text
+3. 当前启动模型的参数面板
+
+中间：
+
+- 模式 tabs 根据模型能力变化：
+  - GPT Image 2：生成、编辑、局部重绘
+  - Nano Banana 3：生成、参考图编辑、局部引导编辑/继续编辑
+  - General：生成；必要时仅显示 prompt 和基础输入
+- 结果画布保持一致
+- Prompt 区保持一致
+- 上传图片入口根据能力显示
+
+右侧：
+
+- 历史条目显示 model chip
+- 默认只显示 6 条
+- 第 7 条以后折叠
+- 显示 `展开全部` / `收起`
+- 展开后 `.history-list` 内部滚动，不拉长页面整体高度
+
+### 4.5 Nano Banana 3 参数面板
+
+首期建议参数：
+
+- Model variant：默认 `gemini-3.1-flash-image`
+- Aspect ratio：预设常用比例，包含 Gemini 3.1 文档提到的新比例能力
+- Resolution：`0.5K`、`1K`、`2K`、`4K`，默认 `1K`
+- Thinking：仅在支持模型上显示
+- Search grounding：仅在支持模型上显示
+- Output count：首期可限制为 1，避免 Gemini response parts 与历史保存复杂化
+- Timeout seconds
+
+Nano Banana 3 不显示：
+
+- OpenAI `output_format`
+- OpenAI `output_compression`
+- OpenAI `moderation`
+- OpenAI `partial_images`
+- OpenAI exact mask 参数
+
+### 4.6 Gemini 请求策略
+
+Endpoint：
+
+```text
+POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={GEMINI_API_KEY}
+```
+
+请求结构：
+
+- `contents[].parts[].text` 放 prompt
+- `contents[].parts[].inlineData` 放上传图片 base64
+- `generationConfig.responseModalities` 请求 image output
+- model-specific config 放 Gemini adapter 内部转换
+
+响应解析：
+
+- 遍历 `candidates[].content.parts`
+- 保存 `inlineData` / image parts 为本地 `ImageAsset`
+- text parts 可保存为 job metadata，后续可在 UI 显示 reasoning/notes
+
+### 4.7 历史折叠规则
+
+建议状态：
+
+```ts
+const HISTORY_COLLAPSED_COUNT = 6;
+const [historyExpanded, setHistoryExpanded] = useState(false);
+const visibleHistory = historyExpanded ? filteredHistory : filteredHistory.slice(0, HISTORY_COLLAPSED_COUNT);
+```
+
+展示规则：
+
+- 搜索为空：默认显示最近 6 条
+- 搜索有内容：仍默认显示匹配结果前 6 条，并提示匹配总数
+- 展开后历史面板内部滚动
+- 历史条目顶部显示：
+  - model chip
+  - mode
+  - status
+  - time
+
+## 5. 阶段计划
+
+| 阶段 | 目标 | 主要产出 | 完成标准 |
+| --- | --- | --- | --- |
+| Phase 0 | `v0.2.0` 设计冻结 | 本计划、TODO、Checklist | 团队确认 `Nano Banana 3 -> gemini-3.1-flash-image` |
+| Phase 1 | `v0.2.0` 契约与迁移 | Provider/model 类型、catalog、state v2 迁移 | 旧历史与配置无损读取 |
+| Phase 2 | `v0.2.0` 模型探测与启动区 | OpenAI/Gemini discovery、启动模型按钮 | 按钮状态能随 Key 和模型列表变化 |
+| Phase 3 | `v0.2.0` GPT Image 2 adapter 化 | 保留当前全部 OpenAI 能力 | 现有测试、mock verifier、真实验收路径不回退 |
+| Phase 4 | `v0.2.0` Nano Banana 3 adapter | Gemini generateContent、图片输入编辑、参数面板 | 可用 Gemini Key 生成和编辑图片 |
+| Phase 5 | `v0.2.0` General 与历史体验 | General 模式、历史 model chip、6 条折叠 | 历史不拉长窗口且模型可追溯 |
+| Phase 6 | `v0.2.0` 文档、测试、发布验收 | README、mock Gemini API、release 验证 | `pnpm build` 与 mock 验证通过 |
+
+## 6. Ownership 建议
+
+如果并行开发，建议按模块拆分：
+
+1. Agent A：shared contracts
+   - `src/shared/types.ts`
+   - `src/shared/modelCatalog.ts`
+   - validation union
+   - state migration tests
+2. Agent B：main process adapters
+   - `src/main/services/modelDiscovery.ts`
+   - `src/main/services/openaiImage.ts`
+   - `src/main/services/geminiImage.ts`
+   - IPC handlers
+3. Agent C：renderer UI
+   - `src/renderer/App.tsx`
+   - `src/renderer/i18n.ts`
+   - `src/renderer/styles.css`
+4. Agent D：tests, mocks, docs
+   - `scripts/mock-openai-image-api.mjs`
+   - `scripts/mock-gemini-image-api.mjs`
+   - verify scripts
+   - README / acceptance docs
+
+每个 agent 必须从最新 `origin/main` 创建独立 worktree 和 `codex/` 分支，不复用旧 worktree。
+
+## 7. 风险与边界
+
+| 风险 | 影响 | 应对 |
+| --- | --- | --- |
+| 远端模型列表不能表达完整能力 | 按钮状态误判 | 远端模型可见性 + 本地 capability catalog 双重判断 |
+| Nano Banana mask 语义与 OpenAI 不同 | 用户误解局部编辑精度 | UI 命名为“局部引导编辑”，不承诺精确 mask |
+| state v2 迁移破坏旧历史 | 用户历史丢失 | 写迁移测试，保留 v1 读取路径和备份 |
+| 参数 union 增加复杂度 | 类型和 UI 分支混乱 | adapter 层拥有 provider-specific validation |
+| General 过度承诺 | 体验不稳定 | 首期只做 minimal generation |
+| Gemini 输出 text+image 混合 | 历史和结果解析复杂 | image parts 保存为 outputs，text parts 保存为 metadata |
+| API Key 多 provider 管理 | 配置区复杂 | 首期一次只激活一个 provider，后续再做多 provider 列表 |
+
+## 8. 官方参考
+
+- OpenAI Image Generation: https://platform.openai.com/docs/guides/image-generation
+- Gemini Nano Banana Image Generation: https://ai.google.dev/gemini-api/docs/image-generation
+- Gemini Models API: https://ai.google.dev/api/models
+- Gemini 2.5 Flash Image: https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-image
+- Gemini 3.1 Flash Image: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-image

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -1,0 +1,157 @@
+# Multi-Model TODO
+
+Target release: `v0.2.0`
+
+## Phase 0 - `v0.2.0` 设计冻结
+
+- [x] 确认多模型工作台目标
+- [x] 确认重点启动模型：`GPT Image 2`、`Nano Banana 3`、`General`
+- [x] 确认 `Nano Banana 3` 首期映射到 `gemini-3.1-flash-image`
+- [x] 确认 Nano Banana 局部编辑首期为“局部引导编辑”，不是 OpenAI 等价 exact mask
+- [x] 产出多模型 plan / todo / checklist 文档
+- [x] 确认多模型支持作为 `v0.2.0` 版本目标
+- [x] 团队确认 provider selector 文案和默认 provider 顺序
+- [x] 团队确认 General 模式首期功能范围
+
+## Phase 1 - `v0.2.0` 类型契约与数据迁移
+
+- [ ] 新增 `ProviderKind`
+- [ ] 新增 `FocusedLaunchId`
+- [ ] 新增 `FocusedModelDefinition`
+- [ ] 新增 `ImageModelCapabilities`
+- [ ] 新增 `DiscoveredModel`
+- [ ] 将 `ProviderConfig` 扩展为支持 provider kind、discovered models、active launch/model
+- [ ] 将 `ImageParams` 改造为 `OpenAIImageParams | GeminiImageParams | GeneralImageParams`
+- [ ] 将 `GenerationJob` 增加 provider/model 字段
+- [ ] 将 `WorkspaceDraft` 增加 active launch/model 字段
+- [ ] 新增 `src/shared/modelCatalog.ts`
+- [ ] 将 `gpt-image-2` 常量从通用 validation 中迁移到 OpenAI-specific validation
+- [ ] 新增 state v2 结构
+- [ ] 实现 v1 -> v2 state migration
+- [ ] 为 v1 config migration 写测试
+- [ ] 为 v1 history migration 写测试
+- [ ] 确认旧 state backup 逻辑仍正常
+
+## Phase 2 - `v0.2.0` 模型探测与启动模型区
+
+- [ ] 新增 `src/main/services/modelDiscovery.ts`
+- [ ] 实现 OpenAI `GET /models` 探测
+- [ ] 实现 Gemini `GET /models?key=...` 探测
+- [ ] 将模型探测结果存入 provider config
+- [ ] 新增 `config:discoverModels` IPC
+- [ ] 保存 API Key 后自动触发 discovery
+- [ ] 连接测试时同步刷新 discovery
+- [ ] 服务配置区增加 provider selector
+- [ ] 服务配置区根据 provider 切换默认 Base URL
+- [ ] 服务配置区显示最近模型探测时间
+- [ ] 服务配置区显示模型探测失败原因
+- [ ] 新增启动模型按钮区
+- [ ] `GPT Image 2` 按钮根据 OpenAI discovery 启用
+- [ ] `Nano Banana 3` 按钮根据 Gemini discovery 启用
+- [ ] `General` 按钮根据任意可用图片模型启用
+- [ ] 点击启动模型更新 active launch/model
+- [ ] 不可用按钮显示不可用原因
+- [ ] i18n 补齐中英文文案
+
+## Phase 3 - `v0.2.0` GPT Image 2 adapter 化
+
+- [ ] 新增 `ImageProviderAdapter` 接口
+- [ ] 将当前 OpenAI 请求逻辑迁入 `openaiImageAdapter`
+- [ ] 保留 `/images/generations` 文生图请求行为
+- [ ] 保留 `/images/edits` 编辑请求行为
+- [ ] 保留 mask 参数与校验行为
+- [ ] 保留 streaming partial images 行为
+- [ ] 保留 partial/result output 保存行为
+- [ ] 保留 API error 脱敏行为
+- [ ] 更新 `validateRunJobRequest` 支持 OpenAI params union
+- [ ] 更新 `getValidationError` 分发到 OpenAI validation
+- [ ] 更新 OpenAI service tests
+- [ ] 更新 mock OpenAI verify script
+- [ ] 确保 `pnpm verify:mock-api` 仍通过
+- [ ] 确保 GPT Image 2 UI 与当前体验基本一致
+
+## Phase 4 - `v0.2.0` Nano Banana 3 adapter 与 UI
+
+- [ ] 新增 `src/main/services/geminiImage.ts`
+- [ ] 实现 Gemini endpoint builder
+- [ ] 实现 Gemini request body builder
+- [ ] 实现 text-to-image `generateContent`
+- [ ] 实现 text-and-image-to-image `generateContent`
+- [ ] 支持上传图片转 `inlineData`
+- [ ] 解析 Gemini response image parts
+- [ ] 保存 Gemini image parts 为 `ImageAsset`
+- [ ] 保存 Gemini text parts 为 job metadata
+- [ ] 实现 Gemini timeout 和错误归类
+- [ ] 实现 Gemini API Key 错误脱敏
+- [ ] 实现 `GeminiImageParams` validation
+- [ ] Nano Banana UI 增加 aspect ratio 控件
+- [ ] Nano Banana UI 增加 resolution 控件
+- [ ] Nano Banana UI 增加 Thinking 开关
+- [ ] Nano Banana UI 增加 Search grounding 开关
+- [ ] Nano Banana UI 隐藏 OpenAI-only 参数
+- [ ] Nano Banana 模式支持生成
+- [ ] Nano Banana 模式支持参考图编辑
+- [ ] Nano Banana 模式支持局部引导编辑
+- [ ] 局部引导编辑文案说明非 exact mask
+- [ ] 为 Gemini request builder 写单元测试
+- [ ] 为 Gemini response parser 写单元测试
+- [ ] 新增 mock Gemini Image API
+- [ ] 新增 Gemini mock verifier
+
+## Phase 5 - `v0.2.0` General 模式
+
+- [ ] 定义 General launch 的最小能力
+- [ ] General UI 只显示 prompt、基础输入和运行按钮
+- [ ] General 模式显示“高级能力未适配”的提示
+- [ ] General 模式接入 provider-specific fallback
+- [ ] General 模式失败时给出清晰模型不兼容提示
+- [ ] General 历史任务正常记录 provider/model
+- [ ] General 不显示 mask、streaming、format 等未确认能力
+
+## Phase 6 - `v0.2.0` 历史任务体验
+
+- [ ] 历史任务条目增加 model chip
+- [ ] 历史任务条目显示 provider kind
+- [ ] 历史任务条目保留 mode/status/time
+- [ ] 默认只显示 6 条历史
+- [ ] 超过 6 条时显示展开按钮
+- [ ] 展开后显示收起按钮
+- [ ] 展开后历史列表内部滚动
+- [ ] 搜索历史时显示匹配数量
+- [ ] 搜索历史时仍支持 6 条折叠规则
+- [ ] 复用历史任务时恢复对应 provider/model/params
+- [ ] 删除历史任务继续只删除 owned output files
+- [ ] 清空历史仍清理所有 owned outputs
+
+## Phase 7 - `v0.2.0` 测试与验收
+
+- [ ] `pnpm typecheck` 通过
+- [ ] `pnpm test` 通过
+- [ ] `pnpm build` 通过
+- [ ] `pnpm verify:mock-api` 通过
+- [ ] 新增 `pnpm verify:mock-gemini-api`
+- [ ] OpenAI mock 生成通过
+- [ ] OpenAI mock 编辑通过
+- [ ] OpenAI mock inpaint 通过
+- [ ] Gemini mock 生成通过
+- [ ] Gemini mock 参考图编辑通过
+- [ ] 模型 discovery mock 通过
+- [ ] state v1 -> v2 migration tests 通过
+- [ ] renderer i18n shape tests 通过
+- [ ] 手工确认无 Key 时启动模型按钮置灰
+- [ ] 手工确认 OpenAI Key 仅启用 GPT Image 2
+- [ ] 手工确认 Gemini Key 仅启用 Nano Banana 3
+- [ ] 手工确认历史折叠不会拉长窗口
+
+## Phase 8 - `v0.2.0` 文档与发布
+
+- [ ] 更新 README 项目定位，从单 `gpt-image-2` 改为多模型工作台
+- [ ] 更新 ARCHITECTURE.md provider adapter 架构
+- [ ] 更新 TODO.md 当前阶段
+- [ ] 更新 CHECKLIST.md 多模型验收项
+- [ ] 更新 EXTERNAL_ACCEPTANCE.md 增加 Gemini 真实 API 验收
+- [ ] 更新 SECURITY.md 增加 Gemini Key 处理说明
+- [ ] 更新 mock API 文档
+- [ ] 更新 release verifier 说明
+- [ ] 重新跑开源 secret scan
+- [ ] 确认文档没有写死未验证的 Nano Banana 能力

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ The mark combines an image canvas, edit wand, and streaming/output lines to matc
 ## Documentation
 
 - [PLAN.md](./PLAN.md): roadmap, scope, and phase goals
+- [MULTI_MODEL_PLAN.md](./MULTI_MODEL_PLAN.md): multi image-model architecture and rollout plan
+- [MULTI_MODEL_TODO.md](./MULTI_MODEL_TODO.md): executable task list for GPT Image 2, Nano Banana 3, and General support
+- [MULTI_MODEL_CHECKLIST.md](./MULTI_MODEL_CHECKLIST.md): acceptance checklist for multi-model support
 - [ARCHITECTURE.md](./ARCHITECTURE.md): architecture, data flow, and module split
 - [TODO.md](./TODO.md): executable task list
 - [CHECKLIST.md](./CHECKLIST.md): development and release checklist
@@ -356,6 +359,9 @@ IMAGE2TOOLS_REAL_API_ACCEPT_STREAM_COST=1
 ## 文档索引
 
 - [PLAN.md](./PLAN.md): 总体开发计划、阶段目标、范围边界
+- [MULTI_MODEL_PLAN.md](./MULTI_MODEL_PLAN.md): 多生图模型架构与阶段推进计划
+- [MULTI_MODEL_TODO.md](./MULTI_MODEL_TODO.md): GPT Image 2、Nano Banana 3、General 支持的可执行任务清单
+- [MULTI_MODEL_CHECKLIST.md](./MULTI_MODEL_CHECKLIST.md): 多模型支持验收检查清单
 - [ARCHITECTURE.md](./ARCHITECTURE.md): 技术架构、数据流、模块拆分
 - [TODO.md](./TODO.md): 可直接执行的任务清单
 - [CHECKLIST.md](./CHECKLIST.md): 开发与发布检查清单


### PR DESCRIPTION
## Summary
- add the multi-model v0.2 plan, todo, and acceptance checklist
- record Phase 0 decisions for provider selector wording/order and General mode scope
- link the new planning docs from README

## Validation
- documentation-only change