### PR TITLE
Add multi-model contracts and state migration

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,7 +18,6 @@ import type {
   ConnectionTestResult,
   DownloadRequest,
   GenerationJob,
-  ImageParams,
   InputAsset,
   JobProgressEvent,
   ProviderConfig,
@@ -32,7 +31,6 @@ import type {
   WorkspaceDraftInput
 } from "../shared/types.js";
 import {
-  DEFAULT_BASE_URL,
   DEFAULT_IMAGE_PARAMS,
   dataUrlToBase64,
   getValidationError,
@@ -42,12 +40,13 @@ import {
   validateRunJobRequest,
   validateWorkspaceDraftInput
 } from "../shared/validation.js";
-import { buildEndpoint, fetchWithTimeout, runOpenAIImageJob } from "./services/openaiImage.js";
+import { getModelDisplayName, GPT_IMAGE_2_LAUNCH_ID } from "../shared/modelCatalog.js";
+import { asOpenAIImageJob, buildEndpoint, fetchWithTimeout, runOpenAIImageJob } from "./services/openaiImage.js";
 import { assertKnownOutputPath, assertManagedRegularFile, collectOwnedJobFilePaths, normalizeManagedAssetPath } from "./services/assetOwnership.js";
 import { recoverInterruptedJobs } from "./services/stateRecovery.js";
+import { type AppStateFile, type StoredProviderConfig, STATE_VERSION, getDefaultState, normalizeImageParams, normalizeState } from "./services/stateMigration.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STATE_VERSION = 1;
 const MAX_HISTORY = 100;
 const FALLBACK_KEY_PREFIX = "plain:";
 const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
@@ -64,27 +63,6 @@ protocol.registerSchemesAsPrivileged([
     }
   }
 ]);
-
-interface StoredConfig {
-  id: string;
-  name: string;
-  baseURL: string;
-  enabled: boolean;
-  defaultModel: string;
-  defaultSize: string;
-  defaultQuality: ImageParams["quality"];
-  timeoutMs: number;
-  updatedAt: string;
-  encryptedApiKey?: string;
-  encryption: "safeStorage" | "localFallback" | "none";
-}
-
-interface AppStateFile {
-  version: number;
-  config: StoredConfig;
-  history: GenerationJob[];
-  draft?: WorkspaceDraft;
-}
 
 interface ApiErrorPayload {
   error?: {
@@ -106,19 +84,6 @@ interface PackageMetadata {
     updateManifestUrl?: unknown;
   };
 }
-
-const defaultStoredConfig: StoredConfig = {
-  id: "default",
-  name: "OpenAI",
-  baseURL: DEFAULT_BASE_URL,
-  enabled: true,
-  defaultModel: DEFAULT_IMAGE_PARAMS.model,
-  defaultSize: DEFAULT_IMAGE_PARAMS.size,
-  defaultQuality: DEFAULT_IMAGE_PARAMS.quality,
-  timeoutMs: DEFAULT_IMAGE_PARAMS.timeoutMs,
-  updatedAt: new Date(0).toISOString(),
-  encryption: "none"
-};
 
 let stateCache: AppStateFile | null = null;
 let recoveredInterruptedJobs = false;
@@ -192,17 +157,10 @@ function getImagesDir(): string {
   return path.join(app.getPath("userData"), "images");
 }
 
-function getDefaultState(): AppStateFile {
-  return {
-    version: STATE_VERSION,
-    config: { ...defaultStoredConfig },
-    history: []
-  };
-}
-
-function toPublicConfig(config: StoredConfig): ProviderConfig {
+function toPublicConfig(config: StoredProviderConfig): ProviderConfig {
   return {
     id: config.id,
+    kind: config.kind,
     name: config.name,
     apiKeySaved: Boolean(config.encryptedApiKey),
     apiKeyPreview: getSavedApiKeyPreview(config),
@@ -212,6 +170,11 @@ function toPublicConfig(config: StoredConfig): ProviderConfig {
     defaultSize: config.defaultSize,
     defaultQuality: config.defaultQuality,
     timeoutMs: config.timeoutMs,
+    discoveredModels: config.discoveredModels,
+    lastModelDiscoveryAt: config.lastModelDiscoveryAt,
+    lastModelDiscoveryError: config.lastModelDiscoveryError,
+    activeLaunchId: config.activeLaunchId,
+    activeModelId: config.activeModelId,
     updatedAt: config.updatedAt
   };
 }
@@ -279,22 +242,9 @@ async function writeState(state: AppStateFile, options: WriteStateOptions = {}):
   stateCache = payload;
 }
 
-async function readStateFile(filePath: string): Promise<Partial<AppStateFile>> {
+async function readStateFile(filePath: string): Promise<unknown> {
   const raw = await fs.readFile(filePath, "utf8");
-  return JSON.parse(raw) as Partial<AppStateFile>;
-}
-
-function normalizeState(parsed: Partial<AppStateFile>): AppStateFile {
-  return {
-    version: STATE_VERSION,
-    config: {
-      ...defaultStoredConfig,
-      ...(parsed.config ?? {}),
-      baseURL: normalizeBaseURL(parsed.config?.baseURL ?? DEFAULT_BASE_URL)
-    },
-    history: Array.isArray(parsed.history) ? parsed.history : [],
-    draft: parsed.draft
-  };
+  return JSON.parse(raw) as unknown;
 }
 
 function applyStartupRecovery(state: AppStateFile): AppStateFile {
@@ -303,7 +253,7 @@ function applyStartupRecovery(state: AppStateFile): AppStateFile {
   return result.changed ? { ...state, history: result.history } : state;
 }
 
-function encryptApiKey(apiKey: string): Pick<StoredConfig, "encryptedApiKey" | "encryption"> {
+function encryptApiKey(apiKey: string): Pick<StoredProviderConfig, "encryptedApiKey" | "encryption"> {
   const trimmed = apiKey.trim();
   if (!trimmed) {
     return { encryptedApiKey: undefined, encryption: "none" };
@@ -324,7 +274,7 @@ function encryptApiKey(apiKey: string): Pick<StoredConfig, "encryptedApiKey" | "
   };
 }
 
-function decryptApiKey(config: StoredConfig): string | null {
+function decryptApiKey(config: StoredProviderConfig): string | null {
   if (!config.encryptedApiKey) return null;
 
   if (config.encryption === "safeStorage") {
@@ -341,7 +291,7 @@ function decryptApiKey(config: StoredConfig): string | null {
   return null;
 }
 
-function getSavedApiKeyPreview(config: StoredConfig): string | undefined {
+function getSavedApiKeyPreview(config: StoredProviderConfig): string | undefined {
   if (!config.encryptedApiKey) return undefined;
 
   try {
@@ -607,10 +557,17 @@ async function persistMaskDataUrl(dataUrl: string): Promise<InputAsset> {
   };
 }
 
-function createJob(request: RunJobRequest, inputAssets: InputAsset[], maskAsset?: InputAsset): GenerationJob {
+function createJob(request: RunJobRequest, config: StoredProviderConfig, inputAssets: InputAsset[], maskAsset?: InputAsset): GenerationJob {
   const now = new Date().toISOString();
+  const launchId = request.params.launchId;
+  const modelId = request.params.model;
   return {
     id: `job_${randomUUID()}`,
+    providerKind: request.params.providerKind,
+    providerId: config.id,
+    launchId,
+    modelId,
+    modelDisplayName: getModelDisplayName(launchId, modelId),
     mode: request.mode,
     prompt: request.prompt.trim(),
     inputAssets,
@@ -656,13 +613,18 @@ async function handleSaveConfig(_event: IpcMainInvokeEvent, input: ProviderConfi
     throw new Error(configValidation.message ?? "配置参数无效。");
   }
   const now = new Date().toISOString();
-  const nextConfig: StoredConfig = {
+  const activeLaunchId = input.activeLaunchId ?? state.config.activeLaunchId ?? GPT_IMAGE_2_LAUNCH_ID;
+  const activeModelId = input.activeModelId?.trim() || input.defaultModel.trim() || DEFAULT_IMAGE_PARAMS.model;
+  const nextConfig: StoredProviderConfig = {
     ...state.config,
+    kind: input.kind ?? state.config.kind,
     baseURL: normalizeBaseURL(input.baseURL),
     defaultModel: input.defaultModel.trim() || DEFAULT_IMAGE_PARAMS.model,
     defaultSize: input.defaultSize.trim() || DEFAULT_IMAGE_PARAMS.size,
     defaultQuality: input.defaultQuality,
     timeoutMs: input.timeoutMs,
+    activeLaunchId,
+    activeModelId,
     updatedAt: now
   };
 
@@ -680,7 +642,7 @@ async function handleSaveConfig(_event: IpcMainInvokeEvent, input: ProviderConfi
 
 async function handleClearApiKey(): Promise<ProviderConfig> {
   const state = await readState();
-  const nextConfig: StoredConfig = {
+  const nextConfig: StoredProviderConfig = {
     ...state.config,
     encryptedApiKey: undefined,
     encryption: "none",
@@ -696,8 +658,12 @@ async function handleSaveDraft(_event: IpcMainInvokeEvent, input: WorkspaceDraft
     throw new Error(validation.message ?? "草稿参数无效。");
   }
   const state = await readState();
+  const params = normalizeImageParams(input.params);
   const draft: WorkspaceDraft = {
     ...input,
+    params,
+    activeLaunchId: input.activeLaunchId ?? params.launchId,
+    activeModelId: input.activeModelId?.trim() || params.model,
     updatedAt: new Date().toISOString()
   };
   await writeState({ ...state, draft });
@@ -777,16 +743,20 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
   if (!validation.ok) {
     throw new Error(validation.message ?? "任务请求无效。");
   }
-  const validationError = getValidationError(request.params, request.prompt);
+  const normalizedRequest: RunJobRequest = {
+    ...request,
+    params: normalizeImageParams(request.params)
+  };
+  const validationError = getValidationError(normalizedRequest.params, normalizedRequest.prompt);
   if (validationError) {
     throw new Error(validationError);
   }
 
   const state = await readState();
   const apiKey = await getApiKeyOrThrow();
-  const { inputs, mask } = await resolveRequestInputs(request);
+  const { inputs, mask } = await resolveRequestInputs(normalizedRequest);
   const startedAt = Date.now();
-  let job = createJob(request, inputs, mask);
+  let job = createJob(normalizedRequest, state.config, inputs, mask);
   await upsertJob(job);
 
   job = {
@@ -798,7 +768,7 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
   sendJobEvent({ jobId: job.id, type: "started" });
 
   try {
-    job = await runOpenAIImageJob(job, apiKey, state.config.baseURL, {
+    job = await runOpenAIImageJob(asOpenAIImageJob(job), apiKey, state.config.baseURL, {
       fetch,
       imagesDir: getImagesDir(),
       ensureDir,

--- a/src/main/services/assetOwnership.test.ts
+++ b/src/main/services/assetOwnership.test.ts
@@ -24,6 +24,11 @@ function makeJob(imagesDir: string, outputPath = path.join(imagesDir, "result.pn
   const now = new Date(0).toISOString();
   return {
     id: "job_test",
+    providerKind: "openai",
+    providerId: "default",
+    launchId: "gpt-image-2",
+    modelId: "gpt-image-2",
+    modelDisplayName: "GPT Image 2",
     mode: "generate",
     prompt: "Test",
     inputAssets: [],

--- a/src/main/services/openaiImage.test.ts
+++ b/src/main/services/openaiImage.test.ts
@@ -2,9 +2,9 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { GenerationJob, ImageParams, InputAsset, JobProgressEvent } from "../../shared/types";
+import type { InputAsset, JobProgressEvent, OpenAIImageParams } from "../../shared/types";
 import { DEFAULT_IMAGE_PARAMS } from "../../shared/validation";
-import { baseRequestBody, buildEndpoint, parseSSE, runOpenAIImageJob } from "./openaiImage";
+import { baseRequestBody, buildEndpoint, parseSSE, runOpenAIImageJob, type OpenAIImageJob } from "./openaiImage";
 
 const tinyPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lw1m8QAAAABJRU5ErkJggg==";
 
@@ -17,7 +17,7 @@ afterEach(async () => {
   }
 });
 
-function params(patch: Partial<ImageParams> = {}): ImageParams {
+function params(patch: Partial<OpenAIImageParams> = {}): OpenAIImageParams {
   return {
     ...DEFAULT_IMAGE_PARAMS,
     timeoutMs: 30000,
@@ -25,10 +25,15 @@ function params(patch: Partial<ImageParams> = {}): ImageParams {
   };
 }
 
-function job(patch: Partial<GenerationJob> = {}): GenerationJob {
+function job(patch: Partial<OpenAIImageJob> = {}): OpenAIImageJob {
   const now = new Date(0).toISOString();
   return {
     id: "job_test",
+    providerKind: "openai",
+    providerId: "default",
+    launchId: "gpt-image-2",
+    modelId: "gpt-image-2",
+    modelDisplayName: "GPT Image 2",
     mode: "generate",
     prompt: "Make a clean product render",
     inputAssets: [],

--- a/src/main/services/openaiImage.ts
+++ b/src/main/services/openaiImage.ts
@@ -1,10 +1,11 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import type { GenerationJob, ImageAsset, ImageParams, InputAsset, JobProgressEvent, UsageDetails } from "../../shared/types.js";
+import type { GenerationJob, ImageAsset, InputAsset, JobProgressEvent, OpenAIImageParams, UsageDetails } from "../../shared/types.js";
 import {
   dataUrlToBase64,
   extensionForFormat,
+  isOpenAIImageParams,
   mimeTypeForFormat,
   shouldSendCompression,
   validateMaskMimeType,
@@ -45,11 +46,20 @@ export interface OpenAIImageRuntime {
   sendJobEvent: (event: JobProgressEvent) => void;
 }
 
+export type OpenAIImageJob = GenerationJob & { params: OpenAIImageParams };
+
 export function buildEndpoint(baseURL: string, endpoint: "/images/generations" | "/images/edits" | "/models"): string {
   return `${baseURL.trim().replace(/\/+$/, "")}${endpoint}`;
 }
 
-export function baseRequestBody(params: ImageParams, prompt: string): Record<string, string | number | boolean> {
+export function asOpenAIImageJob(job: GenerationJob): OpenAIImageJob {
+  if (!isOpenAIImageParams(job.params)) {
+    throw new Error("当前版本尚未接入该模型运行时。");
+  }
+  return job as OpenAIImageJob;
+}
+
+export function baseRequestBody(params: OpenAIImageParams, prompt: string): Record<string, string | number | boolean> {
   const body: Record<string, string | number | boolean> = {
     model: params.model,
     prompt,
@@ -100,7 +110,7 @@ export async function fetchWithTimeout(
 }
 
 export async function runOpenAIImageJob(
-  job: GenerationJob,
+  job: OpenAIImageJob,
   apiKey: string,
   baseURL: string,
   runtime: OpenAIImageRuntime
@@ -112,7 +122,7 @@ export async function runOpenAIImageJob(
 }
 
 async function runGeneration(
-  job: GenerationJob,
+  job: OpenAIImageJob,
   apiKey: string,
   baseURL: string,
   runtime: OpenAIImageRuntime
@@ -136,7 +146,7 @@ async function runGeneration(
 }
 
 async function runEdit(
-  job: GenerationJob,
+  job: OpenAIImageJob,
   apiKey: string,
   baseURL: string,
   runtime: OpenAIImageRuntime
@@ -196,7 +206,7 @@ async function assetToBlob(asset: InputAsset): Promise<Blob> {
 
 async function handleImagesResponse(
   response: Response,
-  job: GenerationJob,
+  job: OpenAIImageJob,
   eventPrefix: "image_generation" | "image_edit",
   runtime: OpenAIImageRuntime
 ): Promise<GenerationJob> {
@@ -217,7 +227,7 @@ async function handleImagesResponse(
 
 async function handleJsonImagesResponse(
   response: Response,
-  job: GenerationJob,
+  job: OpenAIImageJob,
   runtime: OpenAIImageRuntime
 ): Promise<GenerationJob> {
   const contentType = response.headers.get("content-type") ?? "";
@@ -279,7 +289,7 @@ function redactLikelySecrets(value: string): string {
 
 async function handleStreamResponse(
   response: Response,
-  job: GenerationJob,
+  job: OpenAIImageJob,
   eventPrefix: "image_generation" | "image_edit",
   runtime: OpenAIImageRuntime
 ): Promise<GenerationJob> {
@@ -358,7 +368,7 @@ export async function parseSSE(body: ReadableStream<Uint8Array>, onEvent: (event
 }
 
 async function saveImageItems(
-  job: GenerationJob,
+  job: OpenAIImageJob,
   items: Array<{ b64_json?: string; url?: string }>,
   sourceType: "result" | "partial",
   runtime: OpenAIImageRuntime,
@@ -417,7 +427,7 @@ async function processSSEBlock(block: string, onEvent: (event: ImageStreamEvent)
 async function saveBase64Image(
   jobId: string,
   b64Json: string,
-  params: ImageParams,
+  params: OpenAIImageParams,
   sourceType: "result" | "partial",
   index: number,
   runtime: OpenAIImageRuntime

--- a/src/main/services/stateMigration.test.ts
+++ b/src/main/services/stateMigration.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_IMAGE_PARAMS } from "../../shared/validation";
+import { STATE_VERSION, normalizeState } from "./stateMigration";
+
+const legacyParams = {
+  model: "gpt-image-2",
+  size: "1024x1024",
+  quality: "high",
+  outputFormat: "webp",
+  outputCompression: 80,
+  background: "opaque",
+  n: 2,
+  stream: false,
+  partialImages: 0,
+  moderation: "low",
+  timeoutMs: 120000
+};
+
+describe("state migration", () => {
+  it("migrates v1 config to an OpenAI provider config", () => {
+    const migrated = normalizeState({
+      version: 1,
+      config: {
+        id: "default",
+        name: "OpenAI",
+        baseURL: "https://api.openai.com/v1///",
+        enabled: true,
+        defaultModel: "gpt-image-2",
+        defaultSize: "1024x1024",
+        defaultQuality: "high",
+        timeoutMs: 120000,
+        encryptedApiKey: "plain:c2stdGVzdA==",
+        encryption: "localFallback",
+        updatedAt: "2026-01-02T03:04:05.000Z"
+      },
+      history: []
+    });
+
+    expect(migrated.version).toBe(STATE_VERSION);
+    expect(migrated.config).toMatchObject({
+      id: "default",
+      kind: "openai",
+      name: "OpenAI",
+      baseURL: "https://api.openai.com/v1",
+      defaultModel: "gpt-image-2",
+      defaultSize: "1024x1024",
+      defaultQuality: "high",
+      timeoutMs: 120000,
+      discoveredModels: [],
+      activeLaunchId: "gpt-image-2",
+      activeModelId: "gpt-image-2",
+      encryptedApiKey: "plain:c2stdGVzdA==",
+      encryption: "localFallback"
+    });
+  });
+
+  it("migrates v1 history jobs with provider and model metadata", () => {
+    const migrated = normalizeState({
+      version: 1,
+      config: {
+        id: "provider_openai",
+        baseURL: "https://api.openai.com/v1",
+        defaultModel: "gpt-image-2",
+        defaultSize: "auto",
+        defaultQuality: "auto",
+        timeoutMs: 240000,
+        updatedAt: "2026-01-02T03:04:05.000Z",
+        encryption: "none"
+      },
+      history: [
+        {
+          id: "job_1",
+          mode: "generate",
+          prompt: "Generate a poster",
+          inputAssets: [],
+          params: legacyParams,
+          status: "succeeded",
+          createdAt: "2026-01-02T03:04:05.000Z",
+          updatedAt: "2026-01-02T03:04:06.000Z",
+          outputs: []
+        }
+      ]
+    });
+
+    expect(migrated.history[0]).toMatchObject({
+      providerKind: "openai",
+      providerId: "provider_openai",
+      launchId: "gpt-image-2",
+      modelId: "gpt-image-2",
+      modelDisplayName: "GPT Image 2",
+      params: {
+        ...legacyParams,
+        providerKind: "openai",
+        launchId: "gpt-image-2"
+      }
+    });
+  });
+
+  it("migrates v1 drafts with active launch and model defaults", () => {
+    const migrated = normalizeState({
+      version: 1,
+      config: {
+        id: "default",
+        baseURL: "https://api.openai.com/v1",
+        defaultModel: "gpt-image-2",
+        defaultSize: "auto",
+        defaultQuality: "auto",
+        timeoutMs: 240000,
+        updatedAt: "2026-01-02T03:04:05.000Z",
+        encryption: "none"
+      },
+      history: [],
+      draft: {
+        mode: "edit",
+        prompt: "Refine the image",
+        params: legacyParams,
+        inputAssets: [],
+        brushSize: 48,
+        updatedAt: "2026-01-02T03:04:07.000Z"
+      }
+    });
+
+    expect(migrated.draft).toMatchObject({
+      activeLaunchId: "gpt-image-2",
+      activeModelId: "gpt-image-2",
+      params: {
+        providerKind: "openai",
+        launchId: "gpt-image-2",
+        model: "gpt-image-2"
+      }
+    });
+  });
+
+  it("uses GPT Image 2 defaults for malformed or missing v1 params", () => {
+    const migrated = normalizeState({
+      version: 1,
+      config: {},
+      history: [
+        {
+          id: "job_1",
+          mode: "generate",
+          prompt: "Generate",
+          inputAssets: [],
+          params: {},
+          status: "succeeded",
+          createdAt: "2026-01-02T03:04:05.000Z",
+          updatedAt: "2026-01-02T03:04:06.000Z",
+          outputs: []
+        }
+      ]
+    });
+
+    expect(migrated.history[0].params).toEqual(DEFAULT_IMAGE_PARAMS);
+    expect(migrated.history[0].modelId).toBe("gpt-image-2");
+    expect(migrated.history[0].modelDisplayName).toBe("GPT Image 2");
+  });
+});

--- a/src/main/services/stateMigration.ts
+++ b/src/main/services/stateMigration.ts
@@ -1,0 +1,267 @@
+import type {
+  DiscoveredModel,
+  FocusedLaunchId,
+  GenerationJob,
+  ImageParams,
+  ImageQuality,
+  OpenAIImageParams,
+  ProviderKind,
+  WorkspaceDraft
+} from "../../shared/types.js";
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_GEMINI_BASE_URL,
+  DEFAULT_GENERAL_IMAGE_PARAMS,
+  DEFAULT_GEMINI_IMAGE_PARAMS,
+  DEFAULT_IMAGE_PARAMS,
+  IMAGE_BACKGROUND_OPTIONS,
+  IMAGE_FORMAT_OPTIONS,
+  IMAGE_QUALITY_OPTIONS,
+  MODERATION_MODE_OPTIONS,
+  normalizeBaseURL
+} from "../../shared/validation.js";
+import {
+  GENERAL_LAUNCH_ID,
+  GPT_IMAGE_2_LAUNCH_ID,
+  GPT_IMAGE_2_MODEL_ID,
+  NANO_BANANA_3_LAUNCH_ID,
+  getModelDisplayName
+} from "../../shared/modelCatalog.js";
+
+export const STATE_VERSION = 2;
+export const DEFAULT_OPENAI_PROVIDER_ID = "default";
+
+export interface StoredProviderConfig {
+  id: string;
+  kind: ProviderKind;
+  name: string;
+  baseURL: string;
+  enabled: boolean;
+  defaultModel: string;
+  defaultSize: string;
+  defaultQuality: ImageQuality;
+  timeoutMs: number;
+  discoveredModels: DiscoveredModel[];
+  lastModelDiscoveryAt?: string;
+  lastModelDiscoveryError?: string;
+  activeLaunchId: FocusedLaunchId;
+  activeModelId: string;
+  updatedAt: string;
+  encryptedApiKey?: string;
+  encryption: "safeStorage" | "localFallback" | "none";
+}
+
+export interface AppStateFile {
+  version: number;
+  config: StoredProviderConfig;
+  history: GenerationJob[];
+  draft?: WorkspaceDraft;
+}
+
+export const defaultStoredConfig: StoredProviderConfig = {
+  id: DEFAULT_OPENAI_PROVIDER_ID,
+  kind: "openai",
+  name: "OpenAI",
+  baseURL: DEFAULT_BASE_URL,
+  enabled: true,
+  defaultModel: DEFAULT_IMAGE_PARAMS.model,
+  defaultSize: DEFAULT_IMAGE_PARAMS.size,
+  defaultQuality: DEFAULT_IMAGE_PARAMS.quality,
+  timeoutMs: DEFAULT_IMAGE_PARAMS.timeoutMs,
+  discoveredModels: [],
+  activeLaunchId: GPT_IMAGE_2_LAUNCH_ID,
+  activeModelId: DEFAULT_IMAGE_PARAMS.model,
+  updatedAt: new Date(0).toISOString(),
+  encryption: "none"
+};
+
+export function getDefaultState(): AppStateFile {
+  return {
+    version: STATE_VERSION,
+    config: { ...defaultStoredConfig, discoveredModels: [...defaultStoredConfig.discoveredModels] },
+    history: []
+  };
+}
+
+export function normalizeState(parsed: unknown): AppStateFile {
+  if (!isRecord(parsed)) return getDefaultState();
+
+  const config = normalizeStoredConfig(parsed.config);
+  return {
+    version: STATE_VERSION,
+    config,
+    history: Array.isArray(parsed.history) ? parsed.history.map((job) => normalizeGenerationJob(job, config.id)) : [],
+    draft: normalizeWorkspaceDraft(parsed.draft)
+  };
+}
+
+function normalizeStoredConfig(value: unknown): StoredProviderConfig {
+  const input = isRecord(value) ? value : {};
+  const kind = normalizeProviderKind(input.kind, "openai");
+  const defaultModel = nonEmptyString(input.defaultModel, DEFAULT_IMAGE_PARAMS.model);
+  const defaultSize = nonEmptyString(input.defaultSize, DEFAULT_IMAGE_PARAMS.size);
+  const activeLaunchId = normalizeFocusedLaunchId(input.activeLaunchId, GPT_IMAGE_2_LAUNCH_ID);
+  const defaultBaseURL = kind === "gemini" ? DEFAULT_GEMINI_BASE_URL : DEFAULT_BASE_URL;
+  const baseURL = typeof input.baseURL === "string" && input.baseURL.trim() ? input.baseURL : defaultBaseURL;
+
+  return {
+    id: nonEmptyString(input.id, DEFAULT_OPENAI_PROVIDER_ID),
+    kind,
+    name: nonEmptyString(input.name, kind === "gemini" ? "Gemini" : kind === "custom" ? "Custom" : "OpenAI"),
+    baseURL: normalizeBaseURL(baseURL),
+    enabled: typeof input.enabled === "boolean" ? input.enabled : true,
+    defaultModel,
+    defaultSize,
+    defaultQuality: oneOf(input.defaultQuality, IMAGE_QUALITY_OPTIONS, DEFAULT_IMAGE_PARAMS.quality),
+    timeoutMs: boundedInteger(input.timeoutMs, 30000, 600000, DEFAULT_IMAGE_PARAMS.timeoutMs),
+    discoveredModels: normalizeDiscoveredModels(input.discoveredModels, kind),
+    lastModelDiscoveryAt: optionalString(input.lastModelDiscoveryAt),
+    lastModelDiscoveryError: optionalString(input.lastModelDiscoveryError),
+    activeLaunchId,
+    activeModelId: nonEmptyString(input.activeModelId, activeLaunchId === GPT_IMAGE_2_LAUNCH_ID ? defaultModel : getDefaultModelForLaunch(activeLaunchId)),
+    updatedAt: nonEmptyString(input.updatedAt, new Date(0).toISOString()),
+    encryptedApiKey: optionalString(input.encryptedApiKey),
+    encryption: normalizeEncryption(input.encryption)
+  };
+}
+
+function normalizeDiscoveredModels(value: unknown, fallbackKind: ProviderKind): DiscoveredModel[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item) || typeof item.id !== "string" || !item.id.trim()) return [];
+    return [
+      {
+        id: item.id.trim(),
+        providerKind: normalizeProviderKind(item.providerKind, fallbackKind),
+        displayName: optionalString(item.displayName),
+        description: optionalString(item.description),
+        raw: item.raw
+      }
+    ];
+  });
+}
+
+function normalizeGenerationJob(value: unknown, fallbackProviderId: string): GenerationJob {
+  const input = isRecord(value) ? value : {};
+  const params = normalizeImageParams(input.params);
+  const providerKind = normalizeProviderKind(input.providerKind, params.providerKind);
+  const launchId = normalizeFocusedLaunchId(input.launchId, params.launchId);
+  const modelId = nonEmptyString(input.modelId, params.model);
+
+  return {
+    ...(input as unknown as GenerationJob),
+    providerKind,
+    providerId: nonEmptyString(input.providerId, fallbackProviderId),
+    launchId,
+    modelId,
+    modelDisplayName: nonEmptyString(input.modelDisplayName, getModelDisplayName(launchId, modelId)),
+    params
+  };
+}
+
+function normalizeWorkspaceDraft(value: unknown): WorkspaceDraft | undefined {
+  if (!isRecord(value)) return undefined;
+  const params = normalizeImageParams(value.params);
+  return {
+    ...(value as unknown as WorkspaceDraft),
+    activeLaunchId: normalizeFocusedLaunchId(value.activeLaunchId, params.launchId),
+    activeModelId: nonEmptyString(value.activeModelId, params.model),
+    params
+  };
+}
+
+export function normalizeImageParams(value: unknown): ImageParams {
+  const input = isRecord(value) ? value : {};
+  const launchId = normalizeFocusedLaunchId(input.launchId, GPT_IMAGE_2_LAUNCH_ID);
+  const providerKind = normalizeProviderKind(input.providerKind, launchId === NANO_BANANA_3_LAUNCH_ID ? "gemini" : "openai");
+
+  if (launchId === GENERAL_LAUNCH_ID) {
+    const defaults = DEFAULT_GENERAL_IMAGE_PARAMS;
+    return {
+      ...defaults,
+      providerKind,
+      launchId: GENERAL_LAUNCH_ID,
+      model: nonEmptyString(input.model, defaults.model),
+      outputCount: boundedInteger(input.outputCount, 1, 1, defaults.outputCount),
+      timeoutMs: boundedInteger(input.timeoutMs, 30000, 600000, defaults.timeoutMs)
+    };
+  }
+
+  if (providerKind === "gemini" || launchId === NANO_BANANA_3_LAUNCH_ID) {
+    const defaults = DEFAULT_GEMINI_IMAGE_PARAMS;
+    return {
+      ...defaults,
+      providerKind: "gemini",
+      launchId: NANO_BANANA_3_LAUNCH_ID,
+      model: nonEmptyString(input.model, defaults.model),
+      aspectRatio: oneOf(input.aspectRatio, ["1:1", "3:4", "4:3", "9:16", "16:9", "21:9"] as const, defaults.aspectRatio),
+      resolution: oneOf(input.resolution, ["0.5K", "1K", "2K", "4K"] as const, defaults.resolution),
+      outputCount: boundedInteger(input.outputCount, 1, 1, defaults.outputCount),
+      thinking: typeof input.thinking === "boolean" ? input.thinking : defaults.thinking,
+      searchGrounding: typeof input.searchGrounding === "boolean" ? input.searchGrounding : defaults.searchGrounding,
+      timeoutMs: boundedInteger(input.timeoutMs, 30000, 600000, defaults.timeoutMs)
+    };
+  }
+
+  return normalizeOpenAIImageParams(input);
+}
+
+function normalizeOpenAIImageParams(input: Record<string, unknown>): OpenAIImageParams {
+  return {
+    ...DEFAULT_IMAGE_PARAMS,
+    providerKind: "openai",
+    launchId: GPT_IMAGE_2_LAUNCH_ID,
+    model: nonEmptyString(input.model, GPT_IMAGE_2_MODEL_ID),
+    size: nonEmptyString(input.size, DEFAULT_IMAGE_PARAMS.size),
+    quality: oneOf(input.quality, IMAGE_QUALITY_OPTIONS, DEFAULT_IMAGE_PARAMS.quality),
+    outputFormat: oneOf(input.outputFormat, IMAGE_FORMAT_OPTIONS, DEFAULT_IMAGE_PARAMS.outputFormat),
+    outputCompression: boundedInteger(input.outputCompression, 0, 100, DEFAULT_IMAGE_PARAMS.outputCompression),
+    background: oneOf(input.background, IMAGE_BACKGROUND_OPTIONS, DEFAULT_IMAGE_PARAMS.background),
+    n: boundedInteger(input.n, 1, 10, DEFAULT_IMAGE_PARAMS.n),
+    stream: typeof input.stream === "boolean" ? input.stream : DEFAULT_IMAGE_PARAMS.stream,
+    partialImages: boundedInteger(input.partialImages, 0, 3, DEFAULT_IMAGE_PARAMS.partialImages),
+    moderation: oneOf(input.moderation, MODERATION_MODE_OPTIONS, DEFAULT_IMAGE_PARAMS.moderation),
+    timeoutMs: boundedInteger(input.timeoutMs, 30000, 600000, DEFAULT_IMAGE_PARAMS.timeoutMs)
+  };
+}
+
+function getDefaultModelForLaunch(launchId: FocusedLaunchId): string {
+  if (launchId === NANO_BANANA_3_LAUNCH_ID) return DEFAULT_GEMINI_IMAGE_PARAMS.model;
+  if (launchId === GENERAL_LAUNCH_ID) return DEFAULT_GENERAL_IMAGE_PARAMS.model;
+  return GPT_IMAGE_2_MODEL_ID;
+}
+
+function normalizeProviderKind(value: unknown, fallback: ProviderKind): ProviderKind {
+  if (value === "openai" || value === "gemini" || value === "custom") return value;
+  return fallback;
+}
+
+function normalizeFocusedLaunchId(value: unknown, fallback: FocusedLaunchId): FocusedLaunchId {
+  if (value === GPT_IMAGE_2_LAUNCH_ID || value === NANO_BANANA_3_LAUNCH_ID || value === GENERAL_LAUNCH_ID) return value;
+  return fallback;
+}
+
+function normalizeEncryption(value: unknown): StoredProviderConfig["encryption"] {
+  if (value === "safeStorage" || value === "localFallback" || value === "none") return value;
+  return "none";
+}
+
+function oneOf<T extends string>(value: unknown, options: readonly T[], fallback: T): T {
+  return typeof value === "string" && (options as readonly string[]).includes(value) ? (value as T) : fallback;
+}
+
+function nonEmptyString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function boundedInteger(value: unknown, min: number, max: number, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= min && value <= max ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/main/services/stateRecovery.test.ts
+++ b/src/main/services/stateRecovery.test.ts
@@ -6,6 +6,11 @@ import { INTERRUPTED_JOB_MESSAGE, recoverInterruptedJobs } from "./stateRecovery
 function job(status: GenerationJob["status"]): GenerationJob {
   return {
     id: `job_${status}`,
+    providerKind: "openai",
+    providerId: "default",
+    launchId: "gpt-image-2",
+    modelId: "gpt-image-2",
+    modelDisplayName: "GPT Image 2",
     mode: "generate",
     prompt: "Recover this job",
     inputAssets: [],

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -32,6 +32,7 @@ import {
   validateMaskMimeType,
   validateMaskSourceFormat,
   getValidationError,
+  isOpenAIImageParams,
   validateGptImage2Size
 } from "../shared/validation";
 import type {
@@ -40,10 +41,10 @@ import type {
   ImageAsset,
   ImageBackground,
   ImageFormat,
-  ImageParams,
   ImageQuality,
   InputAsset,
   ModerationMode,
+  OpenAIImageParams,
   ProviderConfig,
   WorkMode,
   UpdateCheckResult,
@@ -82,6 +83,7 @@ const RESIZER_WIDTH = 12;
 
 const fallbackConfig: ProviderConfig = {
   id: "default",
+  kind: "openai",
   name: "OpenAI",
   apiKeySaved: false,
   apiKeyPreview: undefined,
@@ -91,6 +93,9 @@ const fallbackConfig: ProviderConfig = {
   defaultSize: DEFAULT_IMAGE_PARAMS.size,
   defaultQuality: DEFAULT_IMAGE_PARAMS.quality,
   timeoutMs: DEFAULT_IMAGE_PARAMS.timeoutMs,
+  discoveredModels: [],
+  activeLaunchId: DEFAULT_IMAGE_PARAMS.launchId,
+  activeModelId: DEFAULT_IMAGE_PARAMS.model,
   updatedAt: new Date(0).toISOString()
 };
 
@@ -230,7 +235,7 @@ export function App() {
   const [snapshot, setSnapshot] = useState<AppSnapshot>(fallbackSnapshot);
   const [mode, setMode] = useState<WorkMode>("generate");
   const [prompt, setPrompt] = useState("A clean product photo of a matte black travel mug on a brushed steel counter");
-  const [params, setParams] = useState<ImageParams>(DEFAULT_IMAGE_PARAMS);
+  const [params, setParams] = useState<OpenAIImageParams>(DEFAULT_IMAGE_PARAMS);
   const [apiKey, setApiKey] = useState("");
   const [baseURL, setBaseURL] = useState(DEFAULT_BASE_URL);
   const [customSize, setCustomSize] = useState("2048x1152");
@@ -459,7 +464,7 @@ export function App() {
     if (!draft) return;
     setMode(draft.mode);
     setPrompt(draft.prompt);
-    setParams(draft.params);
+    setParams(isOpenAIImageParams(draft.params) ? draft.params : DEFAULT_IMAGE_PARAMS);
     setInputAssets(draft.inputAssets);
     setMaskAsset(draft.maskAsset ?? null);
     setMaskDataUrl(draft.maskDataUrl ?? null);
@@ -480,7 +485,7 @@ export function App() {
     }
   }
 
-  function updateParams(patch: Partial<ImageParams>) {
+  function updateParams(patch: Partial<OpenAIImageParams>) {
     markDraftChanged();
     setParams((current) => ({ ...current, ...patch }));
   }
@@ -731,7 +736,7 @@ export function App() {
     flashButton(`reuse:${job.id}`);
     setMode(job.mode);
     setPrompt(job.prompt);
-    setParams(job.params);
+    setParams(isOpenAIImageParams(job.params) ? job.params : DEFAULT_IMAGE_PARAMS);
     setInputAssets(job.inputAssets);
     setMaskAsset(job.maskAsset ?? null);
     setMaskDataUrl(null);
@@ -1407,6 +1412,7 @@ export function App() {
             filteredHistory.map((job) => {
               const result = getBestResult(job);
               const jobError = getJobError(job);
+              const paramsSummary = isOpenAIImageParams(job.params) ? `${job.params.size} · ${job.params.quality}` : job.modelDisplayName;
               return (
                 <article key={job.id} className={activeJob?.id === job.id ? "history-item active" : "history-item"}>
                   <button
@@ -1425,7 +1431,7 @@ export function App() {
                     </div>
                     <p>{job.prompt}</p>
                     <small>
-                      {job.status} · {job.params.size} · {job.params.quality} · {formatDuration(job.durationMs)}
+                      {job.status} · {paramsSummary} · {formatDuration(job.durationMs)}
                     </small>
                     {jobError && <p className="history-error">{jobError}</p>}
                   </div>

--- a/src/shared/modelCatalog.test.ts
+++ b/src/shared/modelCatalog.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  FOCUSED_MODEL_CATALOG,
+  GENERAL_LAUNCH_ID,
+  GPT_IMAGE_2_LAUNCH_ID,
+  NANO_BANANA_3_LAUNCH_ID,
+  NANO_BANANA_3_MODEL_ID,
+  getFocusedModelDefinition,
+  getFocusedModelsForProvider,
+  getModelDisplayName
+} from "./modelCatalog";
+
+describe("focused model catalog", () => {
+  it("defines the phase 1 focused launches", () => {
+    expect(FOCUSED_MODEL_CATALOG.map((definition) => definition.launchId)).toEqual([
+      GPT_IMAGE_2_LAUNCH_ID,
+      NANO_BANANA_3_LAUNCH_ID,
+      GENERAL_LAUNCH_ID
+    ]);
+    expect(getFocusedModelDefinition(GPT_IMAGE_2_LAUNCH_ID)).toMatchObject({
+      displayName: "GPT Image 2",
+      providerKind: "openai",
+      defaultModelId: "gpt-image-2",
+      capabilities: {
+        inpaint: "exact-mask",
+        streamingPartials: true,
+        configurableResolution: "openai-size"
+      }
+    });
+  });
+
+  it("maps Nano Banana 3 to the selected Gemini model and guided-region editing", () => {
+    expect(getFocusedModelDefinition(NANO_BANANA_3_LAUNCH_ID)).toMatchObject({
+      displayName: "Nano Banana 3",
+      providerKind: "gemini",
+      defaultModelId: NANO_BANANA_3_MODEL_ID,
+      capabilities: {
+        inpaint: "guided-region",
+        outputText: true,
+        configurableResolution: "gemini-resolution-aspect",
+        supportsThinking: true,
+        supportsSearchGrounding: true
+      }
+    });
+  });
+
+  it("includes General as a provider fallback without advanced capabilities", () => {
+    expect(getFocusedModelDefinition(GENERAL_LAUNCH_ID)).toMatchObject({
+      displayName: "General",
+      capabilities: {
+        generate: true,
+        edit: false,
+        inpaint: false,
+        streamingPartials: false,
+        configurableResolution: "none"
+      }
+    });
+    expect(getFocusedModelsForProvider("openai").map((definition) => definition.launchId)).toEqual([
+      GPT_IMAGE_2_LAUNCH_ID,
+      GENERAL_LAUNCH_ID
+    ]);
+    expect(getModelDisplayName(GENERAL_LAUNCH_ID, "image-model-x")).toBe("image-model-x");
+  });
+});

--- a/src/shared/modelCatalog.ts
+++ b/src/shared/modelCatalog.ts
@@ -1,0 +1,90 @@
+import type { FocusedLaunchId, FocusedModelDefinition, ProviderKind } from "./types.js";
+
+export const GPT_IMAGE_2_LAUNCH_ID = "gpt-image-2" as const;
+export const GPT_IMAGE_2_MODEL_ID = "gpt-image-2" as const;
+export const NANO_BANANA_3_LAUNCH_ID = "nano-banana-3" as const;
+export const NANO_BANANA_3_MODEL_ID = "gemini-3.1-flash-image" as const;
+export const GENERAL_LAUNCH_ID = "general" as const;
+export const GENERAL_MODEL_ID = "general" as const;
+
+export const FOCUSED_MODEL_CATALOG = [
+  {
+    launchId: GPT_IMAGE_2_LAUNCH_ID,
+    displayName: "GPT Image 2",
+    providerKind: "openai",
+    modelIds: [GPT_IMAGE_2_MODEL_ID],
+    defaultModelId: GPT_IMAGE_2_MODEL_ID,
+    capabilities: {
+      generate: true,
+      edit: true,
+      inpaint: "exact-mask",
+      referenceImages: true,
+      multiTurn: false,
+      streamingPartials: true,
+      outputText: false,
+      configurableOutputFormat: true,
+      configurableResolution: "openai-size",
+      supportsThinking: false,
+      supportsSearchGrounding: false
+    }
+  },
+  {
+    launchId: NANO_BANANA_3_LAUNCH_ID,
+    displayName: "Nano Banana 3",
+    providerKind: "gemini",
+    modelIds: [NANO_BANANA_3_MODEL_ID],
+    defaultModelId: NANO_BANANA_3_MODEL_ID,
+    capabilities: {
+      generate: true,
+      edit: true,
+      inpaint: "guided-region",
+      referenceImages: true,
+      multiTurn: true,
+      streamingPartials: false,
+      outputText: true,
+      configurableOutputFormat: false,
+      configurableResolution: "gemini-resolution-aspect",
+      supportsThinking: true,
+      supportsSearchGrounding: true
+    }
+  },
+  {
+    launchId: GENERAL_LAUNCH_ID,
+    displayName: "General",
+    providerKind: "custom",
+    modelIds: [GENERAL_MODEL_ID],
+    defaultModelId: GENERAL_MODEL_ID,
+    capabilities: {
+      generate: true,
+      edit: false,
+      inpaint: false,
+      referenceImages: true,
+      multiTurn: false,
+      streamingPartials: false,
+      outputText: false,
+      configurableOutputFormat: false,
+      configurableResolution: "none",
+      supportsThinking: false,
+      supportsSearchGrounding: false
+    }
+  }
+] as const satisfies readonly FocusedModelDefinition[];
+
+export function getFocusedModelDefinition(launchId: FocusedLaunchId): FocusedModelDefinition | undefined {
+  return FOCUSED_MODEL_CATALOG.find((definition) => definition.launchId === launchId);
+}
+
+export function getFocusedModelsForProvider(providerKind: ProviderKind): FocusedModelDefinition[] {
+  if (providerKind === "custom") {
+    return FOCUSED_MODEL_CATALOG.filter((definition) => definition.launchId === GENERAL_LAUNCH_ID);
+  }
+  return FOCUSED_MODEL_CATALOG.filter(
+    (definition) => definition.providerKind === providerKind || definition.launchId === GENERAL_LAUNCH_ID
+  );
+}
+
+export function getModelDisplayName(launchId: FocusedLaunchId, modelId: string): string {
+  const definition = getFocusedModelDefinition(launchId);
+  if (!definition) return modelId;
+  return definition.launchId === GENERAL_LAUNCH_ID ? modelId || definition.displayName : definition.displayName;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,9 @@
 export type WorkMode = "generate" | "edit" | "inpaint";
 
+export type ProviderKind = "openai" | "gemini" | "custom";
+
+export type FocusedLaunchId = "gpt-image-2" | "nano-banana-3" | "general";
+
 export type ImageQuality = "auto" | "low" | "medium" | "high";
 
 export type ImageFormat = "png" | "jpeg" | "webp";
@@ -10,8 +14,40 @@ export type ModerationMode = "auto" | "low";
 
 export type JobStatus = "queued" | "running" | "succeeded" | "failed";
 
+export interface ImageModelCapabilities {
+  generate: boolean;
+  edit: boolean;
+  inpaint: "exact-mask" | "guided-region" | false;
+  referenceImages: boolean;
+  multiTurn: boolean;
+  streamingPartials: boolean;
+  outputText: boolean;
+  configurableOutputFormat: boolean;
+  configurableResolution: "openai-size" | "gemini-resolution-aspect" | "none";
+  supportsThinking: boolean;
+  supportsSearchGrounding: boolean;
+}
+
+export interface FocusedModelDefinition {
+  launchId: FocusedLaunchId;
+  displayName: string;
+  providerKind: ProviderKind;
+  modelIds: string[];
+  defaultModelId: string;
+  capabilities: ImageModelCapabilities;
+}
+
+export interface DiscoveredModel {
+  id: string;
+  providerKind: ProviderKind;
+  displayName?: string;
+  description?: string;
+  raw?: unknown;
+}
+
 export interface ProviderConfig {
   id: string;
+  kind: ProviderKind;
   name: string;
   apiKeySaved: boolean;
   apiKeyPreview?: string;
@@ -21,19 +57,29 @@ export interface ProviderConfig {
   defaultSize: string;
   defaultQuality: ImageQuality;
   timeoutMs: number;
+  discoveredModels: DiscoveredModel[];
+  lastModelDiscoveryAt?: string;
+  lastModelDiscoveryError?: string;
+  activeLaunchId: FocusedLaunchId;
+  activeModelId: string;
   updatedAt: string;
 }
 
 export interface ProviderConfigInput {
+  kind?: ProviderKind;
   apiKey?: string;
   baseURL: string;
   defaultModel: string;
   defaultSize: string;
   defaultQuality: ImageQuality;
   timeoutMs: number;
+  activeLaunchId?: FocusedLaunchId;
+  activeModelId?: string;
 }
 
-export interface ImageParams {
+export interface OpenAIImageParams {
+  providerKind: "openai";
+  launchId: "gpt-image-2";
   model: string;
   size: string;
   quality: ImageQuality;
@@ -46,6 +92,32 @@ export interface ImageParams {
   moderation: ModerationMode;
   timeoutMs: number;
 }
+
+export type GeminiAspectRatio = "1:1" | "3:4" | "4:3" | "9:16" | "16:9" | "21:9";
+
+export type GeminiResolution = "0.5K" | "1K" | "2K" | "4K";
+
+export interface GeminiImageParams {
+  providerKind: "gemini";
+  launchId: "nano-banana-3";
+  model: string;
+  aspectRatio: GeminiAspectRatio;
+  resolution: GeminiResolution;
+  outputCount: number;
+  thinking: boolean;
+  searchGrounding: boolean;
+  timeoutMs: number;
+}
+
+export interface GeneralImageParams {
+  providerKind: ProviderKind;
+  launchId: "general";
+  model: string;
+  outputCount: number;
+  timeoutMs: number;
+}
+
+export type ImageParams = OpenAIImageParams | GeminiImageParams | GeneralImageParams;
 
 export interface InputAsset {
   id: string;
@@ -82,6 +154,11 @@ export interface UsageDetails {
 
 export interface GenerationJob {
   id: string;
+  providerKind: ProviderKind;
+  providerId: string;
+  launchId: FocusedLaunchId;
+  modelId: string;
+  modelDisplayName: string;
   mode: WorkMode;
   prompt: string;
   inputAssets: InputAsset[];
@@ -133,6 +210,8 @@ export interface DownloadRequest {
 }
 
 export interface WorkspaceDraftInput {
+  activeLaunchId?: FocusedLaunchId;
+  activeModelId?: string;
   mode: WorkMode;
   prompt: string;
   params: ImageParams;
@@ -143,6 +222,8 @@ export interface WorkspaceDraftInput {
 }
 
 export interface WorkspaceDraft extends WorkspaceDraftInput {
+  activeLaunchId: FocusedLaunchId;
+  activeModelId: string;
   updatedAt: string;
 }
 

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_IMAGE_PARAMS,
+  DEFAULT_GEMINI_IMAGE_PARAMS,
+  DEFAULT_GENERAL_IMAGE_PARAMS,
   MAX_GPT_IMAGE_INPUTS,
   dataUrlToBase64,
   extensionForFormat,
@@ -48,6 +50,15 @@ describe("gpt-image-2 validation", () => {
     expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, outputFormat: "gif" } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
     expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, background: "transparent" } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
     expect(validateImageParams({ ...DEFAULT_IMAGE_PARAMS, moderation: "strict" } as unknown as typeof DEFAULT_IMAGE_PARAMS).ok).toBe(false);
+  });
+
+  it("validates provider-specific image param union members", () => {
+    expect(validateImageParams(DEFAULT_IMAGE_PARAMS).ok).toBe(true);
+    expect(validateImageParams(DEFAULT_GEMINI_IMAGE_PARAMS).ok).toBe(true);
+    expect(validateImageParams(DEFAULT_GENERAL_IMAGE_PARAMS).ok).toBe(true);
+    expect(validateImageParams({ ...DEFAULT_GEMINI_IMAGE_PARAMS, aspectRatio: "2:1" }).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_GEMINI_IMAGE_PARAMS, outputCount: 2 }).ok).toBe(false);
+    expect(validateImageParams({ ...DEFAULT_GENERAL_IMAGE_PARAMS, outputCount: 2 }).ok).toBe(false);
   });
 
   it("rejects malformed runtime params without throwing", () => {
@@ -99,7 +110,9 @@ describe("gpt-image-2 validation", () => {
     };
 
     expect(validateProviderConfigInput(valid).ok).toBe(true);
+    expect(validateProviderConfigInput({ ...valid, kind: "openai", activeLaunchId: "gpt-image-2", activeModelId: "gpt-image-2" }).ok).toBe(true);
     expect(validateProviderConfigInput(null as never).ok).toBe(false);
+    expect(validateProviderConfigInput({ ...valid, kind: "anthropic" } as never).ok).toBe(false);
     expect(validateProviderConfigInput({ ...valid, baseURL: null } as never).ok).toBe(false);
     expect(validateProviderConfigInput({ ...valid, defaultModel: "gpt-image-1.5" } as never).ok).toBe(false);
     expect(validateProviderConfigInput({ ...valid, defaultSize: "512x512" } as never).ok).toBe(false);
@@ -144,6 +157,7 @@ describe("gpt-image-2 validation", () => {
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "data:image/png;base64,abc" } as never).ok).toBe(true);
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "data:image/jpeg;base64,abc" } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "not-a-data-url" } as never).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, params: DEFAULT_GEMINI_IMAGE_PARAMS }).ok).toBe(false);
     expect(
       validateRunJobRequest({
         ...job,

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -1,17 +1,28 @@
 import type {
+  FocusedLaunchId,
+  GeneralImageParams,
+  GeminiAspectRatio,
+  GeminiImageParams,
+  GeminiResolution,
   ImageBackground,
   ImageFormat,
   ImageParams,
   ImageQuality,
-  ModerationMode
+  ModerationMode,
+  OpenAIImageParams,
+  ProviderKind
 } from "./types.js";
+import { GENERAL_LAUNCH_ID, GPT_IMAGE_2_LAUNCH_ID, GPT_IMAGE_2_MODEL_ID, NANO_BANANA_3_LAUNCH_ID, NANO_BANANA_3_MODEL_ID } from "./modelCatalog.js";
 
-export const GPT_IMAGE_2_MODEL = "gpt-image-2";
+export const GPT_IMAGE_2_MODEL = GPT_IMAGE_2_MODEL_ID;
 
 export const DEFAULT_BASE_URL = "https://api.openai.com/v1";
+export const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 export const MAX_GPT_IMAGE_INPUTS = 16;
 
-export const DEFAULT_IMAGE_PARAMS: ImageParams = {
+export const DEFAULT_IMAGE_PARAMS: OpenAIImageParams = {
+  providerKind: "openai",
+  launchId: GPT_IMAGE_2_LAUNCH_ID,
   model: GPT_IMAGE_2_MODEL,
   size: "auto",
   quality: "auto",
@@ -25,10 +36,34 @@ export const DEFAULT_IMAGE_PARAMS: ImageParams = {
   timeoutMs: 240000
 };
 
+export const DEFAULT_GEMINI_IMAGE_PARAMS: GeminiImageParams = {
+  providerKind: "gemini",
+  launchId: NANO_BANANA_3_LAUNCH_ID,
+  model: NANO_BANANA_3_MODEL_ID,
+  aspectRatio: "1:1",
+  resolution: "1K",
+  outputCount: 1,
+  thinking: true,
+  searchGrounding: false,
+  timeoutMs: 240000
+};
+
+export const DEFAULT_GENERAL_IMAGE_PARAMS: GeneralImageParams = {
+  providerKind: "custom",
+  launchId: GENERAL_LAUNCH_ID,
+  model: "",
+  outputCount: 1,
+  timeoutMs: 240000
+};
+
 export const IMAGE_QUALITY_OPTIONS = ["auto", "low", "medium", "high"] as const satisfies readonly ImageQuality[];
 export const IMAGE_FORMAT_OPTIONS = ["png", "jpeg", "webp"] as const satisfies readonly ImageFormat[];
 export const IMAGE_BACKGROUND_OPTIONS = ["auto", "opaque"] as const satisfies readonly ImageBackground[];
 export const MODERATION_MODE_OPTIONS = ["auto", "low"] as const satisfies readonly ModerationMode[];
+export const PROVIDER_KIND_OPTIONS = ["openai", "gemini", "custom"] as const satisfies readonly ProviderKind[];
+export const FOCUSED_LAUNCH_OPTIONS = [GPT_IMAGE_2_LAUNCH_ID, NANO_BANANA_3_LAUNCH_ID, GENERAL_LAUNCH_ID] as const satisfies readonly FocusedLaunchId[];
+export const GEMINI_ASPECT_RATIO_OPTIONS = ["1:1", "3:4", "4:3", "9:16", "16:9", "21:9"] as const satisfies readonly GeminiAspectRatio[];
+export const GEMINI_RESOLUTION_OPTIONS = ["0.5K", "1K", "2K", "4K"] as const satisfies readonly GeminiResolution[];
 const IMAGE_PATH_PATTERN = /\.(png|jpe?g|webp)$/i;
 
 export interface ValidationResult {
@@ -123,9 +158,34 @@ export function validateGptImage2Size(size: unknown): ValidationResult {
   return { ok: true };
 }
 
-export function validateImageParams(params: unknown): ValidationResult {
+export function isOpenAIImageParams(params: unknown): params is OpenAIImageParams {
+  return (
+    isRecord(params) &&
+    params.providerKind === "openai" &&
+    params.launchId === GPT_IMAGE_2_LAUNCH_ID &&
+    typeof params.model === "string" &&
+    typeof params.size === "string" &&
+    typeof params.stream === "boolean"
+  );
+}
+
+function paramsProviderKind(params: Record<string, unknown>): ProviderKind | undefined {
+  return isOneOf(params.providerKind, PROVIDER_KIND_OPTIONS) ? params.providerKind : undefined;
+}
+
+function paramsLaunchId(params: Record<string, unknown>): FocusedLaunchId | undefined {
+  return isOneOf(params.launchId, FOCUSED_LAUNCH_OPTIONS) ? params.launchId : undefined;
+}
+
+export function validateOpenAIImageParams(params: unknown): ValidationResult {
   if (!isRecord(params)) {
     return { ok: false, message: "参数格式无效。" };
+  }
+  if (params.providerKind !== undefined && params.providerKind !== "openai") {
+    return { ok: false, message: "OpenAI 图片参数的 providerKind 必须为 openai。" };
+  }
+  if (params.launchId !== undefined && params.launchId !== GPT_IMAGE_2_LAUNCH_ID) {
+    return { ok: false, message: `OpenAI 图片参数的 launchId 必须为 ${GPT_IMAGE_2_LAUNCH_ID}。` };
   }
   if (typeof params.model !== "string") {
     return { ok: false, message: "模型参数无效。" };
@@ -168,9 +228,85 @@ export function validateImageParams(params: unknown): ValidationResult {
   return { ok: true };
 }
 
+export function validateGeminiImageParams(params: unknown): ValidationResult {
+  if (!isRecord(params)) {
+    return { ok: false, message: "参数格式无效。" };
+  }
+  if (params.providerKind !== "gemini") {
+    return { ok: false, message: "Gemini 图片参数的 providerKind 必须为 gemini。" };
+  }
+  if (params.launchId !== NANO_BANANA_3_LAUNCH_ID) {
+    return { ok: false, message: `Gemini 图片参数的 launchId 必须为 ${NANO_BANANA_3_LAUNCH_ID}。` };
+  }
+  if (typeof params.model !== "string" || !params.model.trim()) {
+    return { ok: false, message: "模型参数无效。" };
+  }
+  if (!isOneOf(params.aspectRatio, GEMINI_ASPECT_RATIO_OPTIONS)) {
+    return { ok: false, message: "Gemini 图片比例参数无效。" };
+  }
+  if (!isOneOf(params.resolution, GEMINI_RESOLUTION_OPTIONS)) {
+    return { ok: false, message: "Gemini 图片分辨率参数无效。" };
+  }
+  if (!isInteger(params.outputCount) || params.outputCount < 1 || params.outputCount > 1) {
+    return { ok: false, message: "Gemini 首期输出数量固定为 1。" };
+  }
+  if (typeof params.thinking !== "boolean") {
+    return { ok: false, message: "Gemini Thinking 参数无效。" };
+  }
+  if (typeof params.searchGrounding !== "boolean") {
+    return { ok: false, message: "Gemini Search grounding 参数无效。" };
+  }
+  if (!isInteger(params.timeoutMs) || params.timeoutMs < 30000 || params.timeoutMs > 600000) {
+    return { ok: false, message: "超时时间需在 30 到 600 秒之间。" };
+  }
+  return { ok: true };
+}
+
+export function validateGeneralImageParams(params: unknown): ValidationResult {
+  if (!isRecord(params)) {
+    return { ok: false, message: "参数格式无效。" };
+  }
+  if (!isOneOf(params.providerKind, PROVIDER_KIND_OPTIONS)) {
+    return { ok: false, message: "General 图片参数的 providerKind 无效。" };
+  }
+  if (params.launchId !== GENERAL_LAUNCH_ID) {
+    return { ok: false, message: `General 图片参数的 launchId 必须为 ${GENERAL_LAUNCH_ID}。` };
+  }
+  if (typeof params.model !== "string") {
+    return { ok: false, message: "模型参数无效。" };
+  }
+  if (!isInteger(params.outputCount) || params.outputCount < 1 || params.outputCount > 1) {
+    return { ok: false, message: "General 首期输出数量固定为 1。" };
+  }
+  if (!isInteger(params.timeoutMs) || params.timeoutMs < 30000 || params.timeoutMs > 600000) {
+    return { ok: false, message: "超时时间需在 30 到 600 秒之间。" };
+  }
+  return { ok: true };
+}
+
+export function validateImageParams(params: unknown): ValidationResult {
+  if (!isRecord(params)) {
+    return { ok: false, message: "参数格式无效。" };
+  }
+
+  const providerKind = paramsProviderKind(params);
+  const launchId = paramsLaunchId(params);
+
+  if (providerKind === "gemini" || launchId === NANO_BANANA_3_LAUNCH_ID) {
+    return validateGeminiImageParams(params);
+  }
+  if (launchId === GENERAL_LAUNCH_ID) {
+    return validateGeneralImageParams(params);
+  }
+  return validateOpenAIImageParams(params);
+}
+
 export function validateProviderConfigInput(input: unknown): ValidationResult {
   if (!isRecord(input)) {
     return { ok: false, message: "配置参数格式无效。" };
+  }
+  if (input.kind !== undefined && !isOneOf(input.kind, PROVIDER_KIND_OPTIONS)) {
+    return { ok: false, message: "Provider 类型无效。" };
   }
   if (typeof input.baseURL !== "string") {
     return { ok: false, message: "Base URL 格式无效。" };
@@ -198,6 +334,12 @@ export function validateProviderConfigInput(input: unknown): ValidationResult {
   }
   if (input.apiKey !== undefined && typeof input.apiKey !== "string") {
     return { ok: false, message: "API Key 格式无效。" };
+  }
+  if (input.activeLaunchId !== undefined && !isOneOf(input.activeLaunchId, FOCUSED_LAUNCH_OPTIONS)) {
+    return { ok: false, message: "启动模型无效。" };
+  }
+  if (input.activeModelId !== undefined && typeof input.activeModelId !== "string") {
+    return { ok: false, message: "活动模型 ID 无效。" };
   }
   return { ok: true };
 }
@@ -233,7 +375,14 @@ export function validateInputAssetShape(asset: unknown): ValidationResult {
   return { ok: true };
 }
 
-export function validateRunJobRequest(request: unknown): ValidationResult {
+function hasOpenAIParamsShape(params: unknown): boolean {
+  if (!isRecord(params)) return false;
+  const providerKind = paramsProviderKind(params);
+  const launchId = paramsLaunchId(params);
+  return (providerKind === undefined || providerKind === "openai") && (launchId === undefined || launchId === GPT_IMAGE_2_LAUNCH_ID);
+}
+
+function validateRunJobRequestBase(request: unknown): ValidationResult {
   if (!isRecord(request)) {
     return { ok: false, message: "任务请求格式无效。" };
   }
@@ -249,13 +398,23 @@ export function validateRunJobRequest(request: unknown): ValidationResult {
   if (request.inputPaths.some((item) => !IMAGE_PATH_PATTERN.test(item))) {
     return { ok: false, message: "输入图片必须是 PNG、JPEG 或 WebP。" };
   }
-  if (request.inputPaths.length > MAX_GPT_IMAGE_INPUTS) {
+  return { ok: true };
+}
+
+export function validateOpenAIRunJobRequest(request: unknown): ValidationResult {
+  const base = validateRunJobRequestBase(request);
+  if (!base.ok) return base;
+  if (!isRecord(request)) {
+    return { ok: false, message: "任务请求格式无效。" };
+  }
+  const inputPaths = request.inputPaths as string[];
+  if (inputPaths.length > MAX_GPT_IMAGE_INPUTS) {
     return { ok: false, message: `GPT Image 2 输入图片不能超过 ${MAX_GPT_IMAGE_INPUTS} 张。` };
   }
-  if (request.mode === "generate" && request.inputPaths.length > 0) {
+  if (request.mode === "generate" && inputPaths.length > 0) {
     return { ok: false, message: "文生图不应携带输入图片。" };
   }
-  if ((request.mode === "edit" || request.mode === "inpaint") && request.inputPaths.length === 0) {
+  if ((request.mode === "edit" || request.mode === "inpaint") && inputPaths.length === 0) {
     return { ok: false, message: request.mode === "inpaint" ? "局部重绘至少需要一张源图。" : "图像编辑至少需要一张源图。" };
   }
   if (request.maskPath !== undefined && typeof request.maskPath !== "string") {
@@ -282,7 +441,23 @@ export function validateRunJobRequest(request: unknown): ValidationResult {
   if (request.mode === "inpaint" && !hasMask) {
     return { ok: false, message: "局部重绘需要提供 mask。" };
   }
-  return validateImageParams(request.params);
+  return validateOpenAIImageParams(request.params);
+}
+
+export function validateRunJobRequest(request: unknown): ValidationResult {
+  const base = validateRunJobRequestBase(request);
+  if (!base.ok) return base;
+  if (!isRecord(request)) {
+    return { ok: false, message: "任务请求格式无效。" };
+  }
+
+  const params = validateImageParams(request.params);
+  if (!params.ok) return params;
+
+  if (!hasOpenAIParamsShape(request.params)) {
+    return { ok: false, message: "当前版本尚未接入该模型运行时。" };
+  }
+  return validateOpenAIRunJobRequest(request);
 }
 
 export function validateWorkspaceDraftInput(input: unknown): ValidationResult {
@@ -298,7 +473,7 @@ export function validateWorkspaceDraftInput(input: unknown): ValidationResult {
   if (!Array.isArray(input.inputAssets)) {
     return { ok: false, message: "草稿输入资源无效。" };
   }
-  if (input.inputAssets.length > MAX_GPT_IMAGE_INPUTS) {
+  if (hasOpenAIParamsShape(input.params) && input.inputAssets.length > MAX_GPT_IMAGE_INPUTS) {
     return { ok: false, message: `草稿输入资源不能超过 ${MAX_GPT_IMAGE_INPUTS} 张。` };
   }
   for (const asset of input.inputAssets) {


### PR DESCRIPTION
## Summary
- add shared provider/model contracts, model catalog, and provider-specific image param validation
- add state v2 normalization/migration for v1 OpenAI config, history, and drafts
- stamp new OpenAI jobs/drafts with provider/model metadata while keeping Gemini runtime and discovery out of scope

## Validation
- pnpm test
- pnpm typecheck