### PR TITLE
Add expandable model-aware history panel

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
   Brush,
+  ChevronDown,
+  ChevronUp,
   CheckCircle2,
   Clipboard,
   Download,
@@ -80,6 +82,16 @@ const MIN_HISTORY_WIDTH = 280;
 const MAX_HISTORY_WIDTH = 460;
 const MIN_WORKSPACE_WIDTH = 620;
 const RESIZER_WIDTH = 12;
+const HISTORY_COLLAPSED_LIMIT = 6;
+const DEFAULT_HISTORY_MODEL_DISPLAY = "GPT Image 2";
+
+interface HistoryModelDetails {
+  modelDisplayName: string;
+  modelTitle: string;
+  providerDisplayName?: string;
+  providerTitle?: string;
+  searchText: string;
+}
 
 const fallbackConfig: ProviderConfig = {
   id: "default",
@@ -150,6 +162,59 @@ function formatDate(value: string): string {
     hour: "2-digit",
     minute: "2-digit"
   }).format(new Date(value));
+}
+
+function stringFromRuntime(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function runtimeRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function modelLabelFromId(value: string): string {
+  if (value === "gpt-image-2") return DEFAULT_HISTORY_MODEL_DISPLAY;
+  return value;
+}
+
+function providerLabelFromKind(value: string): string {
+  if (value === "openai") return "OpenAI";
+  if (value === "gemini") return "Gemini";
+  if (value === "custom") return "Custom";
+  return value;
+}
+
+function getHistoryModelDetails(job: GenerationJob): HistoryModelDetails {
+  const jobRecord = runtimeRecord(job);
+  const paramsRecord = runtimeRecord(job.params);
+  const modelDisplayName = stringFromRuntime(jobRecord.modelDisplayName);
+  const paramsModel = stringFromRuntime(paramsRecord.model);
+  const modelId = stringFromRuntime(jobRecord.modelId);
+  const launchId = stringFromRuntime(jobRecord.launchId) ?? stringFromRuntime(jobRecord.activeLaunchId) ?? stringFromRuntime(paramsRecord.launchId);
+  const providerKind = stringFromRuntime(jobRecord.providerKind) ?? stringFromRuntime(paramsRecord.providerKind);
+  const rawModelDisplay = modelDisplayName ?? paramsModel ?? DEFAULT_HISTORY_MODEL_DISPLAY;
+  const displayModel = modelLabelFromId(rawModelDisplay);
+  const providerDisplayName = providerKind ? providerLabelFromKind(providerKind) : undefined;
+  const searchText = [
+    displayModel,
+    rawModelDisplay,
+    modelDisplayName,
+    paramsModel,
+    modelId,
+    launchId,
+    providerKind,
+    providerDisplayName
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    modelDisplayName: displayModel,
+    modelTitle: modelId && modelId !== rawModelDisplay ? `${displayModel} (${modelId})` : displayModel,
+    providerDisplayName,
+    providerTitle: providerKind && providerDisplayName !== providerKind ? `${providerDisplayName} (${providerKind})` : providerDisplayName,
+    searchText
+  };
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -256,6 +321,7 @@ export function App() {
   const [isRunning, setIsRunning] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [historySearch, setHistorySearch] = useState("");
+  const [isHistoryExpanded, setIsHistoryExpanded] = useState(false);
   const [brushSize, setBrushSize] = useState(72);
   const [isPainting, setIsPainting] = useState(false);
   const [draftUpdatedAt, setDraftUpdatedAt] = useState<string | null>(null);
@@ -290,10 +356,14 @@ export function App() {
     const query = historySearch.trim().toLowerCase();
     if (!query) return snapshot.history;
     return snapshot.history.filter((job) => {
-      const haystack = `${job.prompt} ${job.mode} ${job.status} ${job.error ?? ""} ${job.createdAt}`.toLowerCase();
+      const modelDetails = getHistoryModelDetails(job);
+      const haystack = `${job.prompt} ${job.mode} ${job.status} ${job.error ?? ""} ${job.createdAt} ${modelDetails.searchText}`.toLowerCase();
       return haystack.includes(query);
     });
   }, [historySearch, snapshot.history]);
+  const hasHistoryOverflow = filteredHistory.length > HISTORY_COLLAPSED_LIMIT;
+  const visibleHistory = isHistoryExpanded ? filteredHistory : filteredHistory.slice(0, HISTORY_COLLAPSED_LIMIT);
+  const isSearchingHistory = historySearch.trim().length > 0;
 
   const modeError = useMemo(() => {
     if (mode === "edit" && inputAssets.length === 0) return copy.validation.addReference;
@@ -1405,14 +1475,27 @@ export function App() {
           <input value={historySearch} onChange={(event) => setHistorySearch(event.target.value)} placeholder={copy.searchPrompt} />
         </label>
 
+        {(isSearchingHistory || hasHistoryOverflow) && (
+          <div className="history-list-status">
+            {isSearchingHistory && <span>{copy.historyMatchCount(filteredHistory.length)}</span>}
+            {hasHistoryOverflow && (
+              <button type="button" className="history-expand-button ghost" onClick={() => setIsHistoryExpanded((current) => !current)}>
+                {isHistoryExpanded ? <ChevronUp size={15} /> : <ChevronDown size={15} />}
+                <span>{isHistoryExpanded ? copy.collapseHistory : copy.showAllHistory(filteredHistory.length)}</span>
+              </button>
+            )}
+          </div>
+        )}
+
         <div className="history-list">
           {filteredHistory.length === 0 ? (
             <div className="history-empty">{copy.noJobsYet}</div>
           ) : (
-            filteredHistory.map((job) => {
+            visibleHistory.map((job) => {
               const result = getBestResult(job);
               const jobError = getJobError(job);
-              const paramsSummary = isOpenAIImageParams(job.params) ? `${job.params.size} · ${job.params.quality}` : job.modelDisplayName;
+              const modelDetails = getHistoryModelDetails(job);
+              const paramsSummary = isOpenAIImageParams(job.params) ? `${job.params.size} · ${job.params.quality}` : modelDetails.modelDisplayName;
               return (
                 <article key={job.id} className={activeJob?.id === job.id ? "history-item active" : "history-item"}>
                   <button
@@ -1428,6 +1511,16 @@ export function App() {
                     <div className="history-meta">
                       <strong>{modeLabels[job.mode].title}</strong>
                       <span>{formatDate(job.createdAt)}</span>
+                    </div>
+                    <div className="history-chip-row" aria-label={copy.model}>
+                      <span className="history-chip model-chip" title={modelDetails.modelTitle}>
+                        {modelDetails.modelDisplayName}
+                      </span>
+                      {modelDetails.providerDisplayName && (
+                        <span className="history-chip provider-chip" title={modelDetails.providerTitle ?? modelDetails.providerDisplayName}>
+                          {modelDetails.providerDisplayName}
+                        </span>
+                      )}
                     </div>
                     <p>{job.prompt}</p>
                     <small>

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -120,10 +120,14 @@ export interface UiCopy {
   sourceForMask: string;
   addSourceForMask: string;
   checkingMask: string;
+  model: string;
   history: string;
   recentJobs: string;
   clearHistory: string;
   searchPrompt: string;
+  historyMatchCount: (count: number) => string;
+  showAllHistory: (count: number) => string;
+  collapseHistory: string;
   noJobsYet: string;
   openJob: string;
   historyResult: string;
@@ -212,10 +216,14 @@ export const translations: Record<Language, UiCopy> = {
     sourceForMask: "Source for mask",
     addSourceForMask: "Add a source image to paint a mask.",
     checkingMask: "Checking mask...",
+    model: "Model",
     history: "History",
     recentJobs: "Recent jobs",
     clearHistory: "Clear history",
     searchPrompt: "Search prompt",
+    historyMatchCount: (count: number) => `${count} match${count === 1 ? "" : "es"}`,
+    showAllHistory: (count: number) => `Show all ${count}`,
+    collapseHistory: "Show fewer",
     noJobsYet: "No jobs yet.",
     openJob: "Open job",
     historyResult: "History result",
@@ -355,10 +363,14 @@ export const translations: Record<Language, UiCopy> = {
     sourceForMask: "蒙版源图",
     addSourceForMask: "添加源图后可绘制蒙版。",
     checkingMask: "正在检查蒙版...",
+    model: "模型",
     history: "历史",
     recentJobs: "最近任务",
     clearHistory: "清空历史",
     searchPrompt: "搜索提示词",
+    historyMatchCount: (count: number) => `${count} 条匹配`,
+    showAllHistory: (count: number) => `显示全部 ${count} 条`,
+    collapseHistory: "收起",
     noJobsYet: "暂无任务。",
     openJob: "打开任务",
     historyResult: "历史结果",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -101,7 +101,9 @@ h3 {
 .app-shell {
   display: grid;
   grid-template-columns: var(--sidebar-width, 310px) 12px minmax(560px, 1fr) 12px var(--history-width, 330px);
+  height: 100vh;
   min-height: 100vh;
+  overflow: hidden;
 }
 
 .sidebar,
@@ -115,10 +117,16 @@ h3 {
   overflow-y: auto;
 }
 
+.history {
+  overflow-y: hidden;
+}
+
 .workspace {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
   padding: 22px;
 }
 
@@ -813,8 +821,41 @@ label {
   padding-left: 32px;
 }
 
+.history-list-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  color: #786e62;
+  font-size: 12px;
+}
+
+.history-list-status > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-expand-button {
+  flex: 0 1 auto;
+  min-width: 0;
+  min-height: 30px;
+  padding: 0 9px;
+  gap: 5px;
+  font-size: 12px;
+}
+
+.history-expand-button span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .history-list {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: 10px;
   min-height: 0;
@@ -870,6 +911,46 @@ label {
 .history-meta span,
 .history-copy small {
   color: #786e62;
+}
+
+.history-meta strong,
+.history-meta span,
+.history-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-width: 0;
+}
+
+.history-chip {
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #d9d1c2;
+  border-radius: 999px;
+  padding: 2px 7px;
+  background: #f5efe4;
+  color: #4d453d;
+  font-size: 11px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-chip {
+  border-color: rgba(31, 111, 97, 0.25);
+  background: #e7f2ee;
+  color: #1f6f61;
+}
+
+.provider-chip {
+  color: #6f655a;
 }
 
 .history-copy p {


### PR DESCRIPTION
## Summary
- Limit filtered history to 6 items by default with expand/collapse controls.
- Add model/provider chips with runtime-safe fallbacks and include them in history search.
- Keep expanded history scrolling inside the right panel and preserve future runtime launch/model fields when reusing jobs.

## Validation
- pnpm typecheck
- pnpm test
- Vite web preview smoke check with Playwright mock history: collapsed 6/8 items, expanded all 8, search matched model/provider text, page height stayed fixed while history list scrolled internally.