### PR TITLE
Add model discovery UI slice

### DIFF
--- a/src/main/main.test.ts
+++ b/src/main/main.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_IMAGE_PARAMS } from "../shared/validation";
+import type { ProviderConfigInput } from "../shared/types";
+import { buildProviderConfigForSave } from "./services/providerConfigSave";
+import { defaultStoredConfig, type StoredProviderConfig } from "./services/stateMigration";
+
+function savedConfig(patch: Partial<StoredProviderConfig> = {}): StoredProviderConfig {
+  return {
+    ...defaultStoredConfig,
+    encryptedApiKey: "plain:c2stdZXN0LW9wZW5haS1rZXk=",
+    encryption: "localFallback",
+    discoveredModels: [{ id: "gpt-image-2", providerKind: "openai" }],
+    lastModelDiscoveryAt: "2026-06-09T01:02:03.000Z",
+    lastModelDiscoveryError: "old discovery error",
+    updatedAt: "2026-06-09T01:02:03.000Z",
+    ...patch
+  };
+}
+
+function input(patch: Partial<ProviderConfigInput> = {}): ProviderConfigInput {
+  return {
+    kind: "openai",
+    baseURL: "https://api.openai.com/v1",
+    defaultModel: DEFAULT_IMAGE_PARAMS.model,
+    defaultSize: DEFAULT_IMAGE_PARAMS.size,
+    defaultQuality: DEFAULT_IMAGE_PARAMS.quality,
+    timeoutMs: DEFAULT_IMAGE_PARAMS.timeoutMs,
+    activeLaunchId: "gpt-image-2",
+    activeModelId: DEFAULT_IMAGE_PARAMS.model,
+    ...patch
+  };
+}
+
+describe("main config save builder", () => {
+  it("preserves an existing key on same-provider saves without a new key", () => {
+    const next = buildProviderConfigForSave(savedConfig(), input(), "2026-06-09T02:00:00.000Z");
+
+    expect(next.kind).toBe("openai");
+    expect(next.encryptedApiKey).toBe("plain:c2stdZXN0LW9wZW5haS1rZXk=");
+    expect(next.encryption).toBe("localFallback");
+    expect(next.discoveredModels).toEqual([{ id: "gpt-image-2", providerKind: "openai" }]);
+    expect(next.lastModelDiscoveryAt).toBe("2026-06-09T01:02:03.000Z");
+  });
+
+  it("invalidates discovery metadata when the same provider base URL changes", () => {
+    const next = buildProviderConfigForSave(savedConfig(), input({ baseURL: "https://proxy.example.com/v1" }), "2026-06-09T02:00:00.000Z");
+
+    expect(next.kind).toBe("openai");
+    expect(next.encryptedApiKey).toBe("plain:c2stdZXN0LW9wZW5haS1rZXk=");
+    expect(next.discoveredModels).toEqual([]);
+    expect(next.lastModelDiscoveryAt).toBeUndefined();
+    expect(next.lastModelDiscoveryError).toBeUndefined();
+  });
+
+  it("clears saved key and discovery metadata when switching provider without a new key", () => {
+    const next = buildProviderConfigForSave(
+      savedConfig(),
+      input({
+        kind: "gemini",
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        defaultModel: "gemini-3.1-flash-image",
+        activeLaunchId: "nano-banana-3",
+        activeModelId: "gemini-3.1-flash-image"
+      }),
+      "2026-06-09T02:00:00.000Z"
+    );
+
+    expect(next.kind).toBe("gemini");
+    expect(next.encryptedApiKey).toBeUndefined();
+    expect(next.encryption).toBe("none");
+    expect(next.activeLaunchId).toBe("nano-banana-3");
+    expect(next.activeModelId).toBe("gemini-3.1-flash-image");
+    expect(next.discoveredModels).toEqual([]);
+    expect(next.lastModelDiscoveryAt).toBeUndefined();
+    expect(next.lastModelDiscoveryError).toBeUndefined();
+  });
+
+  it("does not clear the key slot before a new provider key is encrypted", () => {
+    const next = buildProviderConfigForSave(
+      savedConfig(),
+      input({
+        kind: "gemini",
+        apiKey: "mock-gemini-key",
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        defaultModel: "gemini-3.1-flash-image",
+        activeLaunchId: "nano-banana-3",
+        activeModelId: "gemini-3.1-flash-image"
+      }),
+      "2026-06-09T02:00:00.000Z"
+    );
+
+    expect(next.kind).toBe("gemini");
+    expect(next.encryptedApiKey).toBe("plain:c2stdZXN0LW9wZW5haS1rZXk=");
+    expect(next.encryption).toBe("localFallback");
+    expect(next.discoveredModels).toEqual([]);
+    expect(next.lastModelDiscoveryAt).toBeUndefined();
+  });
+
+  it("drops incompatible requested launch and model when switching provider", () => {
+    const next = buildProviderConfigForSave(
+      savedConfig(),
+      input({
+        kind: "gemini",
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        defaultModel: "gemini-3.1-flash-image",
+        activeLaunchId: "gpt-image-2",
+        activeModelId: "gpt-image-2"
+      }),
+      "2026-06-09T02:00:00.000Z"
+    );
+
+    expect(next.activeLaunchId).toBe("nano-banana-3");
+    expect(next.activeModelId).toBe("gemini-3.1-flash-image");
+  });
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,15 +34,19 @@ import {
   DEFAULT_IMAGE_PARAMS,
   dataUrlToBase64,
   getValidationError,
-  normalizeBaseURL,
   validateApiKey,
   validateProviderConfigInput,
   validateRunJobRequest,
   validateWorkspaceDraftInput
 } from "../shared/validation.js";
-import { getModelDisplayName, GPT_IMAGE_2_LAUNCH_ID } from "../shared/modelCatalog.js";
+import {
+  GPT_IMAGE_2_LAUNCH_ID,
+  getModelDisplayName
+} from "../shared/modelCatalog.js";
 import { fetchWithTimeout } from "./services/openaiImage.js";
 import { getImageProviderAdapter, getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
+import { discoverModels, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
+import { buildProviderConfigForSave, providerDisplayName } from "./services/providerConfigSave.js";
 import { assertKnownOutputPath, assertManagedRegularFile, collectOwnedJobFilePaths, normalizeManagedAssetPath } from "./services/assetOwnership.js";
 import { recoverInterruptedJobs } from "./services/stateRecovery.js";
 import { type AppStateFile, type StoredProviderConfig, STATE_VERSION, getDefaultState, normalizeImageParams, normalizeState } from "./services/stateMigration.js";
@@ -303,9 +307,13 @@ function maskApiKeyPreview(apiKey: string): string {
 
 async function getApiKeyOrThrow(): Promise<string> {
   const state = await readState();
-  const apiKey = decryptApiKey(state.config);
+  return getApiKeyForConfigOrThrow(state.config);
+}
+
+function getApiKeyForConfigOrThrow(config: StoredProviderConfig): string {
+  const apiKey = decryptApiKey(config);
   if (!apiKey) {
-    throw new Error("缺少 API Key。请先保存 OpenAI API Key。");
+    throw new Error(`缺少 API Key。请先保存 ${providerDisplayName(config.kind)} API Key。`);
   }
   const validation = validateApiKey(apiKey);
   if (!validation.ok) {
@@ -586,20 +594,7 @@ async function handleSaveConfig(_event: IpcMainInvokeEvent, input: ProviderConfi
     throw new Error(configValidation.message ?? "配置参数无效。");
   }
   const now = new Date().toISOString();
-  const activeLaunchId = input.activeLaunchId ?? state.config.activeLaunchId ?? GPT_IMAGE_2_LAUNCH_ID;
-  const activeModelId = input.activeModelId?.trim() || input.defaultModel.trim() || DEFAULT_IMAGE_PARAMS.model;
-  const nextConfig: StoredProviderConfig = {
-    ...state.config,
-    kind: input.kind ?? state.config.kind,
-    baseURL: normalizeBaseURL(input.baseURL),
-    defaultModel: input.defaultModel.trim() || DEFAULT_IMAGE_PARAMS.model,
-    defaultSize: input.defaultSize.trim() || DEFAULT_IMAGE_PARAMS.size,
-    defaultQuality: input.defaultQuality,
-    timeoutMs: input.timeoutMs,
-    activeLaunchId,
-    activeModelId,
-    updatedAt: now
-  };
+  let nextConfig = buildProviderConfigForSave(state.config, input, now);
 
   if (input.apiKey !== undefined && input.apiKey.trim()) {
     const validation = validateApiKey(input.apiKey);
@@ -607,6 +602,10 @@ async function handleSaveConfig(_event: IpcMainInvokeEvent, input: ProviderConfi
       throw new Error(validation.message ?? "API Key 无效。");
     }
     Object.assign(nextConfig, encryptApiKey(input.apiKey));
+  }
+
+  if (input.apiKey !== undefined && input.apiKey.trim()) {
+    nextConfig = await refreshModelDiscovery(nextConfig);
   }
 
   await writeState({ ...state, config: nextConfig });
@@ -619,6 +618,9 @@ async function handleClearApiKey(): Promise<ProviderConfig> {
     ...state.config,
     encryptedApiKey: undefined,
     encryption: "none",
+    discoveredModels: [],
+    lastModelDiscoveryAt: undefined,
+    lastModelDiscoveryError: undefined,
     updatedAt: new Date().toISOString()
   };
   await writeState({ ...state, config: nextConfig });
@@ -648,18 +650,55 @@ async function handleClearDraft(): Promise<void> {
   await writeState({ ...state, draft: undefined });
 }
 
+async function refreshModelDiscovery(config: StoredProviderConfig): Promise<StoredProviderConfig> {
+  const apiKey = getApiKeyForConfigOrThrow(config);
+  try {
+    const adapter = getImageProviderAdapter(config.kind);
+    const models = adapter
+      ? await adapter.discoverModels(config, apiKey, { fetch })
+      : (await discoverModels(config.kind, config.baseURL, apiKey, Math.min(config.timeoutMs, 30000), { fetch })).models;
+    return {
+      ...config,
+      discoveredModels: models,
+      lastModelDiscoveryAt: new Date().toISOString(),
+      lastModelDiscoveryError: undefined,
+      updatedAt: new Date().toISOString()
+    };
+  } catch (error) {
+    return {
+      ...config,
+      discoveredModels: [],
+      lastModelDiscoveryAt: new Date().toISOString(),
+      lastModelDiscoveryError: sanitizeModelDiscoveryError(error, apiKey),
+      updatedAt: new Date().toISOString()
+    };
+  }
+}
+
+async function handleDiscoverModels(): Promise<ProviderConfig> {
+  const state = await readState();
+  const nextConfig = await refreshModelDiscovery(state.config);
+  await writeState({ ...state, config: nextConfig });
+  return toPublicConfig(nextConfig);
+}
+
 async function handleTestConnection(): Promise<ConnectionTestResult> {
   try {
     const state = await readState();
-    const apiKey = await getApiKeyOrThrow();
-    const adapter = getImageProviderAdapter(state.config.kind);
-    if (!adapter) {
+    const nextConfig = await refreshModelDiscovery(state.config);
+    await writeState({ ...state, config: nextConfig });
+    if (nextConfig.lastModelDiscoveryError) {
       return {
         ok: false,
-        message: unsupportedImageProviderMessage()
+        message: nextConfig.lastModelDiscoveryError
       };
     }
-    return adapter.testConnection(state.config, apiKey, { fetch });
+
+    return {
+      ok: true,
+      message: "连接成功。",
+      status: 200
+    };
   } catch (error) {
     return {
       ok: false,
@@ -713,6 +752,9 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
   }
 
   const state = await readState();
+  if (normalizedRequest.params.providerKind !== state.config.kind) {
+    throw new Error("任务 provider 与当前服务配置不一致。请先切换并保存对应服务商。");
+  }
   const apiKey = await getApiKeyOrThrow();
   const { inputs, mask } = await resolveRequestInputs(normalizedRequest);
   const startedAt = Date.now();
@@ -917,6 +959,7 @@ function pathsOwnedByJob(job: GenerationJob): string[] {
 function registerIpcHandlers(): void {
   ipcMain.handle("app:getSnapshot", handleGetSnapshot);
   ipcMain.handle("config:save", handleSaveConfig);
+  ipcMain.handle("config:discoverModels", handleDiscoverModels);
   ipcMain.handle("config:clearApiKey", handleClearApiKey);
   ipcMain.handle("config:testConnection", handleTestConnection);
   ipcMain.handle("draft:save", handleSaveDraft);

--- a/src/main/services/modelDiscovery.test.ts
+++ b/src/main/services/modelDiscovery.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { discoverModels, sanitizeModelDiscoveryError } from "./modelDiscovery";
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "x-request-id": "req_test"
+    }
+  });
+}
+
+describe("model discovery", () => {
+  it("discovers OpenAI-compatible models", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({ data: [{ id: "gpt-image-2", object: "model" }] }));
+
+    const result = await discoverModels("openai", "https://api.openai.com/v1", "sk-test-key-that-is-long-enough", 30000, {
+      fetch: fetchImpl
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-test-key-that-is-long-enough"
+        })
+      })
+    );
+    expect(result.models).toEqual([
+      expect.objectContaining({
+        id: "gpt-image-2",
+        providerKind: "openai"
+      })
+    ]);
+  });
+
+  it("discovers Gemini models and normalizes resource names", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        models: [
+          {
+            name: "models/gemini-3.1-flash-image",
+            displayName: "Gemini 3.1 Flash Image",
+            description: "Image model"
+          }
+        ]
+      })
+    );
+
+    const result = await discoverModels("gemini", "http://127.0.0.1:8788/v1beta", "mock-gemini-key", 30000, {
+      fetch: fetchImpl
+    });
+
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe("http://127.0.0.1:8788/v1beta/models?key=mock-gemini-key");
+    expect(result.models).toEqual([
+      expect.objectContaining({
+        id: "gemini-3.1-flash-image",
+        providerKind: "gemini",
+        displayName: "Gemini 3.1 Flash Image"
+      })
+    ]);
+  });
+
+  it("sanitizes API keys from discovery errors", async () => {
+    const apiKey = "AIzaSyD-mock-redaction-key-should-not-leak-0000";
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse(
+        {
+          error: {
+            message: `API key not valid: ${apiKey}`
+          }
+        },
+        403
+      )
+    );
+
+    await expect(discoverModels("gemini", "http://127.0.0.1:8788/v1beta", apiKey, 30000, { fetch: fetchImpl })).rejects.toThrow(
+      /redacted-api-key/
+    );
+    await expect(discoverModels("gemini", "http://127.0.0.1:8788/v1beta", apiKey, 30000, { fetch: fetchImpl })).rejects.not.toThrow(apiKey);
+    expect(sanitizeModelDiscoveryError(new Error(`Bearer ${apiKey}`), apiKey)).not.toContain(apiKey);
+  });
+});

--- a/src/main/services/modelDiscovery.ts
+++ b/src/main/services/modelDiscovery.ts
@@ -1,0 +1,209 @@
+import type { DiscoveredModel, ProviderKind } from "../../shared/types.js";
+import { DEFAULT_GEMINI_BASE_URL, normalizeBaseURL } from "../../shared/validation.js";
+import { buildEndpoint, fetchWithTimeout } from "./openaiImage.js";
+
+interface OpenAIModelsResponse {
+  data?: unknown;
+}
+
+interface GeminiModelsResponse {
+  models?: unknown;
+}
+
+interface ApiErrorPayload {
+  error?: {
+    message?: unknown;
+    type?: unknown;
+    code?: unknown;
+    status?: unknown;
+  };
+}
+
+export interface ModelDiscoveryResult {
+  models: DiscoveredModel[];
+  status: number;
+  requestId?: string;
+}
+
+export interface ModelDiscoveryRuntime {
+  fetch: typeof fetch;
+}
+
+export async function discoverModels(
+  providerKind: ProviderKind,
+  baseURL: string,
+  apiKey: string,
+  timeoutMs: number,
+  runtime: ModelDiscoveryRuntime
+): Promise<ModelDiscoveryResult> {
+  if (providerKind === "gemini") {
+    return discoverGeminiModels(baseURL || DEFAULT_GEMINI_BASE_URL, apiKey, timeoutMs, runtime);
+  }
+  return discoverOpenAICompatibleModels(providerKind, baseURL, apiKey, timeoutMs, runtime);
+}
+
+export function sanitizeModelDiscoveryError(error: unknown, apiKey?: string): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return redactLikelySecrets(raw, apiKey).replace(/\s+/g, " ").trim();
+}
+
+async function discoverOpenAICompatibleModels(
+  providerKind: ProviderKind,
+  baseURL: string,
+  apiKey: string,
+  timeoutMs: number,
+  runtime: ModelDiscoveryRuntime
+): Promise<ModelDiscoveryResult> {
+  const response = await fetchWithTimeout(
+    runtime.fetch,
+    buildEndpoint(normalizeBaseURL(baseURL), "/models"),
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json"
+      }
+    },
+    timeoutMs
+  );
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, "model discovery", apiKey));
+  }
+
+  const payload = (await response.json()) as OpenAIModelsResponse;
+  return {
+    models: uniqueModels(parseOpenAIModels(payload, providerKind)),
+    status: response.status,
+    requestId: response.headers.get("x-request-id") ?? undefined
+  };
+}
+
+async function discoverGeminiModels(
+  baseURL: string,
+  apiKey: string,
+  timeoutMs: number,
+  runtime: ModelDiscoveryRuntime
+): Promise<ModelDiscoveryResult> {
+  const endpoint = new URL(`${normalizeBaseURL(baseURL).replace(/\/+$/, "")}/models`);
+  endpoint.searchParams.set("key", apiKey);
+  const response = await fetchWithTimeout(
+    runtime.fetch,
+    endpoint.toString(),
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/json"
+      }
+    },
+    timeoutMs
+  );
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, "Gemini model discovery", apiKey));
+  }
+
+  const payload = (await response.json()) as GeminiModelsResponse;
+  return {
+    models: uniqueModels(parseGeminiModels(payload)),
+    status: response.status,
+    requestId: response.headers.get("x-request-id") ?? undefined
+  };
+}
+
+function parseOpenAIModels(payload: OpenAIModelsResponse, providerKind: ProviderKind): DiscoveredModel[] {
+  if (!Array.isArray(payload.data)) return [];
+  return payload.data.flatMap((item) => {
+    if (!isRecord(item) || typeof item.id !== "string" || !item.id.trim()) return [];
+    return [
+      {
+        id: item.id.trim(),
+        providerKind,
+        displayName: typeof item.id === "string" ? item.id.trim() : undefined,
+        raw: item
+      }
+    ];
+  });
+}
+
+function parseGeminiModels(payload: GeminiModelsResponse): DiscoveredModel[] {
+  if (!Array.isArray(payload.models)) return [];
+  return payload.models.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const rawName = typeof item.name === "string" ? item.name.trim() : "";
+    const rawId = typeof item.id === "string" ? item.id.trim() : "";
+    const id = normalizeGeminiModelId(rawId || rawName);
+    if (!id) return [];
+    return [
+      {
+        id,
+        providerKind: "gemini",
+        displayName: optionalString(item.displayName) ?? id,
+        description: optionalString(item.description),
+        raw: item
+      }
+    ];
+  });
+}
+
+function normalizeGeminiModelId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.startsWith("models/") ? trimmed.slice("models/".length) : trimmed;
+}
+
+function uniqueModels(models: DiscoveredModel[]): DiscoveredModel[] {
+  const seen = new Set<string>();
+  const result: DiscoveredModel[] = [];
+  for (const model of models) {
+    const key = `${model.providerKind}:${model.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(model);
+  }
+  return result;
+}
+
+async function readApiError(response: Response, label: string, apiKey?: string): Promise<string> {
+  const requestId = response.headers.get("x-request-id");
+  const requestSuffix = requestId ? ` Request ID: ${requestId}` : "";
+  const fallback = `${label} failed: HTTP ${response.status}.${requestSuffix}`;
+
+  try {
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      const payload = (await response.json()) as ApiErrorPayload;
+      const message = firstString(payload.error?.message, payload.error?.code, payload.error?.type, payload.error?.status);
+      return message ? `${label} failed: ${redactLikelySecrets(message, apiKey)}${requestSuffix}` : fallback;
+    }
+
+    const text = (await response.text()).trim();
+    return text ? `${label} failed: ${redactLikelySecrets(text, apiKey)}${requestSuffix}` : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string" && value.trim().length > 0)?.trim();
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function redactLikelySecrets(value: string, apiKey?: string): string {
+  let result = value;
+  if (apiKey) {
+    result = result.split(apiKey).join("[redacted-api-key]");
+  }
+  return result
+    .replace(/sk-[A-Za-z0-9_-]{8,}/g, "sk-...redacted")
+    .replace(/AIza[A-Za-z0-9_-]{8,}/g, "AIza...redacted")
+    .replace(/([?&]key=)[^&\s]+/gi, "$1[redacted-api-key]")
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}/gi, "$1[redacted-api-key]");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/main/services/providerConfigSave.ts
+++ b/src/main/services/providerConfigSave.ts
@@ -1,0 +1,94 @@
+import type { FocusedLaunchId, ProviderConfig, ProviderConfigInput } from "../../shared/types.js";
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_GEMINI_BASE_URL,
+  DEFAULT_IMAGE_PARAMS,
+  normalizeBaseURL
+} from "../../shared/validation.js";
+import {
+  GENERAL_LAUNCH_ID,
+  GPT_IMAGE_2_LAUNCH_ID,
+  NANO_BANANA_3_LAUNCH_ID,
+  NANO_BANANA_3_MODEL_ID
+} from "../../shared/modelCatalog.js";
+import type { StoredProviderConfig } from "./stateMigration.js";
+
+const LAUNCH_PROVIDER = {
+  [GPT_IMAGE_2_LAUNCH_ID]: "openai",
+  [NANO_BANANA_3_LAUNCH_ID]: "gemini",
+  [GENERAL_LAUNCH_ID]: "custom"
+} as const satisfies Record<FocusedLaunchId, StoredProviderConfig["kind"]>;
+
+export function providerDisplayName(kind: StoredProviderConfig["kind"]): string {
+  if (kind === "gemini") return "Gemini";
+  if (kind === "custom") return "Custom";
+  return "OpenAI";
+}
+
+export function buildProviderConfigForSave(current: StoredProviderConfig, input: ProviderConfigInput, now: string): StoredProviderConfig {
+  const kind = input.kind ?? current.kind;
+  const providerChanged = kind !== current.kind;
+  const hasNewApiKey = input.apiKey !== undefined && input.apiKey.trim().length > 0;
+  const defaultModel = defaultModelForProvider(kind, input.defaultModel);
+  const baseURL = normalizeBaseURL(input.baseURL || defaultBaseURLForProvider(kind, current.baseURL));
+  const discoveryInvalidated = providerChanged || baseURL !== current.baseURL;
+  const requestedLaunchId = compatibleLaunchForProvider(kind, input.activeLaunchId);
+  const activeLaunchId = activeLaunchForProvider(kind, requestedLaunchId ?? (providerChanged ? undefined : current.activeLaunchId));
+  const activeModelId = requestedLaunchId ? input.activeModelId?.trim() || defaultModel : defaultModel;
+  const nextConfig: StoredProviderConfig = {
+    ...current,
+    kind,
+    name: providerDisplayName(kind),
+    baseURL,
+    defaultModel,
+    defaultSize: input.defaultSize.trim() || DEFAULT_IMAGE_PARAMS.size,
+    defaultQuality: input.defaultQuality,
+    timeoutMs: input.timeoutMs,
+    activeLaunchId,
+    activeModelId,
+    discoveredModels: discoveryInvalidated ? [] : current.discoveredModels,
+    lastModelDiscoveryAt: discoveryInvalidated ? undefined : current.lastModelDiscoveryAt,
+    lastModelDiscoveryError: discoveryInvalidated ? undefined : current.lastModelDiscoveryError,
+    updatedAt: now
+  };
+
+  if (providerChanged && !hasNewApiKey) {
+    return {
+      ...nextConfig,
+      encryptedApiKey: undefined,
+      encryption: "none",
+      discoveredModels: [],
+      lastModelDiscoveryAt: undefined,
+      lastModelDiscoveryError: undefined
+    };
+  }
+
+  return nextConfig;
+}
+
+function defaultBaseURLForProvider(kind: StoredProviderConfig["kind"], previousBaseURL: string): string {
+  if (kind === "gemini") return DEFAULT_GEMINI_BASE_URL;
+  if (kind === "custom") return previousBaseURL || DEFAULT_BASE_URL;
+  return DEFAULT_BASE_URL;
+}
+
+function defaultModelForProvider(kind: StoredProviderConfig["kind"], requestedModel: string): string {
+  const model = requestedModel.trim();
+  if (kind === "gemini") return model && model !== DEFAULT_IMAGE_PARAMS.model ? model : NANO_BANANA_3_MODEL_ID;
+  if (model) return model;
+  if (kind === "custom") return "";
+  return DEFAULT_IMAGE_PARAMS.model;
+}
+
+function activeLaunchForProvider(kind: StoredProviderConfig["kind"], requestedLaunchId: ProviderConfigInput["activeLaunchId"]): ProviderConfig["activeLaunchId"] {
+  if (requestedLaunchId) return requestedLaunchId;
+  if (kind === "gemini") return NANO_BANANA_3_LAUNCH_ID;
+  if (kind === "custom") return GENERAL_LAUNCH_ID;
+  return GPT_IMAGE_2_LAUNCH_ID;
+}
+
+function compatibleLaunchForProvider(kind: StoredProviderConfig["kind"], launchId: ProviderConfigInput["activeLaunchId"]): ProviderConfigInput["activeLaunchId"] {
+  if (!launchId) return undefined;
+  if (launchId === GENERAL_LAUNCH_ID) return launchId;
+  return LAUNCH_PROVIDER[launchId] === kind ? launchId : undefined;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -11,6 +11,7 @@ import type {
 const bridge: AppBridge = {
   getSnapshot: () => ipcRenderer.invoke("app:getSnapshot"),
   saveConfig: (input: ProviderConfigInput) => ipcRenderer.invoke("config:save", input),
+  discoverModels: () => ipcRenderer.invoke("config:discoverModels"),
   clearApiKey: () => ipcRenderer.invoke("config:clearApiKey"),
   testConnection: () => ipcRenderer.invoke("config:testConnection"),
   saveDraft: (input: WorkspaceDraftInput) => ipcRenderer.invoke("draft:save", input),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import {
   DEFAULT_BASE_URL,
+  DEFAULT_GEMINI_BASE_URL,
   DEFAULT_IMAGE_PARAMS,
   MAX_GPT_IMAGE_INPUTS,
   maskMimeTypeForSource,
@@ -39,6 +40,7 @@ import {
 } from "../shared/validation";
 import type {
   AppSnapshot,
+  FocusedLaunchId,
   GenerationJob,
   ImageAsset,
   ImageBackground,
@@ -48,10 +50,19 @@ import type {
   ModerationMode,
   OpenAIImageParams,
   ProviderConfig,
+  ProviderKind,
   WorkMode,
   UpdateCheckResult,
   WorkspaceDraft
 } from "../shared/types";
+import {
+  FOCUSED_MODEL_CATALOG,
+  GENERAL_LAUNCH_ID,
+  GPT_IMAGE_2_LAUNCH_ID,
+  GPT_IMAGE_2_MODEL_ID,
+  NANO_BANANA_3_LAUNCH_ID,
+  NANO_BANANA_3_MODEL_ID
+} from "../shared/modelCatalog";
 import { getInitialLanguage, localizeValidationMessage, translations, type Language, type UiCopy } from "./i18n";
 
 type NoticeKind = "info" | "success" | "error";
@@ -91,6 +102,14 @@ interface HistoryModelDetails {
   providerDisplayName?: string;
   providerTitle?: string;
   searchText: string;
+}
+
+interface LaunchButtonState {
+  launchId: FocusedLaunchId;
+  displayName: string;
+  modelId: string;
+  available: boolean;
+  reason: string;
 }
 
 const fallbackConfig: ProviderConfig = {
@@ -182,6 +201,81 @@ function providerLabelFromKind(value: string): string {
   if (value === "gemini") return "Gemini";
   if (value === "custom") return "Custom";
   return value;
+}
+
+function defaultBaseURLForProvider(kind: ProviderKind, currentBaseURL: string): string {
+  if (kind === "openai") return DEFAULT_BASE_URL;
+  if (kind === "gemini") return DEFAULT_GEMINI_BASE_URL;
+  return currentBaseURL || DEFAULT_BASE_URL;
+}
+
+function defaultModelForProvider(kind: ProviderKind): string {
+  if (kind === "gemini") return NANO_BANANA_3_MODEL_ID;
+  if (kind === "custom") return "";
+  return GPT_IMAGE_2_MODEL_ID;
+}
+
+function defaultLaunchForProvider(kind: ProviderKind): FocusedLaunchId {
+  if (kind === "gemini") return NANO_BANANA_3_LAUNCH_ID;
+  if (kind === "custom") return GENERAL_LAUNCH_ID;
+  return GPT_IMAGE_2_LAUNCH_ID;
+}
+
+function generalModelId(config: ProviderConfig): string {
+  return config.discoveredModels[0]?.id ?? config.activeModelId ?? config.defaultModel;
+}
+
+function providerForLaunch(launchId: FocusedLaunchId, fallback: ProviderKind): ProviderKind {
+  const definition = FOCUSED_MODEL_CATALOG.find((item) => item.launchId === launchId);
+  if (!definition || definition.launchId === GENERAL_LAUNCH_ID) return fallback;
+  return definition.providerKind;
+}
+
+function createLaunchParams(launchId: FocusedLaunchId, modelId: string, current: OpenAIImageParams): OpenAIImageParams {
+  if (launchId !== GPT_IMAGE_2_LAUNCH_ID) return current;
+  return {
+    ...current,
+    providerKind: "openai",
+    launchId: GPT_IMAGE_2_LAUNCH_ID,
+    model: modelId || GPT_IMAGE_2_MODEL_ID
+  };
+}
+
+function getLaunchButtonStates(config: ProviderConfig, copy: UiCopy): LaunchButtonState[] {
+  const discoveredIds = new Set(config.discoveredModels.map((model) => model.id));
+  const hasDiscovery = config.discoveredModels.length > 0;
+  const generalId = generalModelId(config);
+  return FOCUSED_MODEL_CATALOG.map((definition) => {
+    const modelId = definition.launchId === GENERAL_LAUNCH_ID ? generalId : definition.defaultModelId;
+    let available = false;
+    let reason = "";
+
+    if (!config.apiKeySaved) {
+      reason = copy.launchUnavailableNoKey;
+    } else if (config.lastModelDiscoveryError) {
+      reason = config.lastModelDiscoveryError;
+    } else if (!hasDiscovery) {
+      reason = copy.launchUnavailableNoDiscovery;
+    } else if (definition.launchId === GENERAL_LAUNCH_ID) {
+      available = Boolean(modelId);
+      reason = available ? copy.launchAvailable : copy.launchUnavailableNoImageModels;
+    } else if (config.kind !== definition.providerKind) {
+      reason = copy.launchUnavailableProvider(providerLabelFromKind(definition.providerKind));
+    } else if (definition.modelIds.some((id) => discoveredIds.has(id))) {
+      available = true;
+      reason = copy.launchAvailable;
+    } else {
+      reason = copy.launchUnavailableModel(definition.modelIds.join(", "));
+    }
+
+    return {
+      launchId: definition.launchId,
+      displayName: definition.displayName,
+      modelId,
+      available,
+      reason
+    };
+  });
 }
 
 function getHistoryModelDetails(job: GenerationJob): HistoryModelDetails {
@@ -302,6 +396,7 @@ export function App() {
   const [prompt, setPrompt] = useState("A clean product photo of a matte black travel mug on a brushed steel counter");
   const [params, setParams] = useState<OpenAIImageParams>(DEFAULT_IMAGE_PARAMS);
   const [apiKey, setApiKey] = useState("");
+  const [providerKind, setProviderKind] = useState<ProviderKind>("openai");
   const [baseURL, setBaseURL] = useState(DEFAULT_BASE_URL);
   const [customSize, setCustomSize] = useState("2048x1152");
   const [inputAssets, setInputAssets] = useState<InputAsset[]>([]);
@@ -316,6 +411,7 @@ export function App() {
   });
   const [isLoadingSnapshot, setIsLoadingSnapshot] = useState(false);
   const [isSavingConfig, setIsSavingConfig] = useState(false);
+  const [isDiscoveringModels, setIsDiscoveringModels] = useState(false);
   const [isClearingApiKey, setIsClearingApiKey] = useState(false);
   const [isTestingConnection, setIsTestingConnection] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
@@ -349,6 +445,9 @@ export function App() {
   const sizeSelectValue = sizePresets.includes(params.size) ? params.size : "custom";
   const previewZoomPercent = Math.round(previewZoom * 100);
   const apiKeyPlaceholder = snapshot.config.apiKeyPreview ?? (snapshot.config.apiKeySaved ? copy.savedLocally : copy.pasteApiKey);
+  const launchButtons = useMemo(() => getLaunchButtonStates(snapshot.config, copy), [copy, snapshot.config]);
+  const activeLaunchDisplay = launchButtons.find((button) => button.launchId === snapshot.config.activeLaunchId)?.displayName ?? modelLabelFromId(snapshot.config.activeModelId);
+  const activeLaunchRuntimeReady = snapshot.config.activeLaunchId === GPT_IMAGE_2_LAUNCH_ID;
   const maxSidebarWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, window.innerWidth - historyWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
   const maxHistoryWidth = Math.min(MAX_HISTORY_WIDTH, Math.max(MIN_HISTORY_WIDTH, window.innerWidth - sidebarWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
 
@@ -376,7 +475,8 @@ export function App() {
     return null;
   }, [copy, inputAssets.length, maskCheck, maskPreview, mode]);
 
-  const validationError = localizeValidationMessage(getValidationError(params, prompt), copy) ?? modeError;
+  const launchRuntimeError = activeLaunchRuntimeReady ? null : copy.launchRuntimeUnavailable(activeLaunchDisplay);
+  const validationError = launchRuntimeError ?? localizeValidationMessage(getValidationError(params, prompt), copy) ?? modeError;
   const canRun = !validationError && !isRunning;
 
   useEffect(() => {
@@ -449,6 +549,8 @@ export function App() {
     const timer = window.setTimeout(() => {
       bridge
         .saveDraft({
+          activeLaunchId: snapshot.config.activeLaunchId,
+          activeModelId: snapshot.config.activeModelId,
           mode,
           prompt,
           params,
@@ -462,7 +564,7 @@ export function App() {
     }, 600);
 
     return () => window.clearTimeout(timer);
-  }, [bridge, brushSize, hasRestoredDraft, hasUserChangedDraft, inputAssets, maskAsset, maskDataUrl, mode, params, prompt]);
+  }, [bridge, brushSize, hasRestoredDraft, hasUserChangedDraft, inputAssets, maskAsset, maskDataUrl, mode, params, prompt, snapshot.config.activeLaunchId, snapshot.config.activeModelId]);
 
   useEffect(() => {
     if (!bridge) return;
@@ -511,6 +613,7 @@ export function App() {
     try {
       const next = await bridge.getSnapshot();
       setSnapshot(next);
+      setProviderKind(next.config.kind);
       setBaseURL(next.config.baseURL);
       setParams((current) => ({
         ...current,
@@ -566,6 +669,12 @@ export function App() {
     }
   }
 
+  function applyConfig(config: ProviderConfig) {
+    setSnapshot((current) => ({ ...current, config }));
+    setProviderKind(config.kind);
+    setBaseURL(config.baseURL);
+  }
+
   async function saveConfig() {
     if (!bridge) {
       setNotice({ kind: "error", text: copy.notices.bridgeSaveConfig });
@@ -573,17 +682,74 @@ export function App() {
     }
     setIsSavingConfig(true);
     try {
+      const providerChanged = providerKind !== snapshot.config.kind;
       const config = await bridge.saveConfig({
+        kind: providerKind,
         apiKey: apiKey.trim() ? apiKey : undefined,
         baseURL,
         defaultModel: params.model,
         defaultSize: params.size,
         defaultQuality: params.quality,
-        timeoutMs: params.timeoutMs
+        timeoutMs: params.timeoutMs,
+        activeLaunchId: providerChanged ? undefined : snapshot.config.activeLaunchId,
+        activeModelId: providerChanged ? undefined : snapshot.config.activeModelId
       });
-      setSnapshot((current) => ({ ...current, config }));
+      applyConfig(config);
       setApiKey("");
-      setNotice({ kind: "success", text: copy.notices.configSaved });
+      setNotice({
+        kind: config.lastModelDiscoveryError ? "error" : "success",
+        text: config.lastModelDiscoveryError ? config.lastModelDiscoveryError : copy.notices.configSaved
+      });
+    } catch (error) {
+      setNotice({ kind: "error", text: normalizeNotice(error) });
+    } finally {
+      setIsSavingConfig(false);
+    }
+  }
+
+  async function discoverModels() {
+    if (!bridge) return;
+    setIsDiscoveringModels(true);
+    try {
+      const config = await bridge.discoverModels();
+      applyConfig(config);
+      setNotice({
+        kind: config.lastModelDiscoveryError ? "error" : "success",
+        text: config.lastModelDiscoveryError ?? copy.notices.modelsDiscovered(config.discoveredModels.length)
+      });
+    } catch (error) {
+      setNotice({ kind: "error", text: normalizeNotice(error) });
+    } finally {
+      setIsDiscoveringModels(false);
+    }
+  }
+
+  function changeProvider(kind: ProviderKind) {
+    markDraftChanged();
+    setProviderKind(kind);
+    setBaseURL(defaultBaseURLForProvider(kind, baseURL));
+  }
+
+  async function launchModel(button: LaunchButtonState) {
+    if (!bridge || !button.available) return;
+    const launchProvider = providerForLaunch(button.launchId, providerKind);
+    const nextParams = createLaunchParams(button.launchId, button.modelId, params);
+    setParams(nextParams);
+    markDraftChanged();
+    setIsSavingConfig(true);
+    try {
+      const config = await bridge.saveConfig({
+        kind: launchProvider,
+        baseURL: defaultBaseURLForProvider(launchProvider, baseURL),
+        defaultModel: button.launchId === GPT_IMAGE_2_LAUNCH_ID ? nextParams.model : button.modelId,
+        defaultSize: nextParams.size,
+        defaultQuality: nextParams.quality,
+        timeoutMs: nextParams.timeoutMs,
+        activeLaunchId: button.launchId,
+        activeModelId: button.modelId
+      });
+      applyConfig(config);
+      setNotice({ kind: "info", text: copy.notices.launchSelected(button.displayName) });
     } catch (error) {
       setNotice({ kind: "error", text: normalizeNotice(error) });
     } finally {
@@ -598,7 +764,7 @@ export function App() {
     }
     setIsTestingConnection(true);
     try {
-      if (apiKey.trim() || baseURL !== snapshot.config.baseURL) {
+      if (apiKey.trim() || baseURL !== snapshot.config.baseURL || providerKind !== snapshot.config.kind) {
         await saveConfig();
       }
       const result = await bridge.testConnection();
@@ -619,7 +785,7 @@ export function App() {
     setIsClearingApiKey(true);
     try {
       const config = await bridge.clearApiKey();
-      setSnapshot((current) => ({ ...current, config }));
+      applyConfig(config);
       setApiKey("");
       setNotice({ kind: "success", text: copy.notices.keyCleared });
     } catch (error) {
@@ -1013,6 +1179,14 @@ export function App() {
             <h2>{copy.provider}</h2>
           </div>
           <label>
+            {copy.providerLabel}
+            <select value={providerKind} onChange={(event) => changeProvider(event.target.value as ProviderKind)}>
+              <option value="openai">OpenAI</option>
+              <option value="gemini">Gemini</option>
+              <option value="custom">Custom</option>
+            </select>
+          </label>
+          <label>
             {copy.apiKey}
             <input
               type="password"
@@ -1043,6 +1217,39 @@ export function App() {
           <div className="config-status">
             <span className={snapshot.config.apiKeySaved ? "dot ok" : "dot"} />
             {snapshot.config.apiKeySaved ? copy.keySaved : copy.noKeySaved}
+          </div>
+          <div className="model-discovery-status" data-kind={snapshot.config.lastModelDiscoveryError ? "error" : "info"}>
+            <span>{copy.discoveryStatus}</span>
+            <strong>
+              {snapshot.config.lastModelDiscoveryError
+                ? snapshot.config.lastModelDiscoveryError
+                : snapshot.config.lastModelDiscoveryAt
+                  ? copy.discoveryLastRun(formatDate(snapshot.config.lastModelDiscoveryAt), snapshot.config.discoveredModels.length)
+                  : copy.discoveryNotRun}
+            </strong>
+          </div>
+          <button type="button" className="secondary discover-button" onClick={discoverModels} disabled={!bridge || isDiscoveringModels || !snapshot.config.apiKeySaved}>
+            {isDiscoveringModels ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+            {isDiscoveringModels ? copy.discoveringModels : copy.discoverModels}
+          </button>
+          <div className="launch-strip" aria-label={copy.launchModels}>
+            <div className="launch-strip-header">
+              <span>{copy.launchModels}</span>
+              <strong>{activeLaunchDisplay}</strong>
+            </div>
+            {launchButtons.map((button) => (
+              <button
+                key={button.launchId}
+                type="button"
+                className={snapshot.config.activeLaunchId === button.launchId ? "launch-button active" : "launch-button"}
+                onClick={() => launchModel(button)}
+                disabled={!button.available || isSavingConfig}
+                title={button.reason}
+              >
+                <span>{button.displayName}</span>
+                <small>{button.available ? button.modelId || copy.generalFallback : button.reason}</small>
+              </button>
+            ))}
           </div>
         </form>
 

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -35,6 +35,8 @@ interface NoticeCopy {
   promptCopied: string;
   clipboardUnavailable: string;
   jobLoaded: string;
+  modelsDiscovered: (count: number) => string;
+  launchSelected: (model: string) => string;
 }
 
 interface ValidationCopy {
@@ -66,8 +68,23 @@ export interface UiCopy {
   chinese: string;
   tagline: string;
   provider: string;
+  providerLabel: string;
   apiKey: string;
   baseURL: string;
+  discoveryStatus: string;
+  discoveryNotRun: string;
+  discoveryLastRun: (date: string, count: number) => string;
+  discoverModels: string;
+  discoveringModels: string;
+  launchModels: string;
+  launchAvailable: string;
+  launchUnavailableNoKey: string;
+  launchUnavailableNoDiscovery: string;
+  launchUnavailableNoImageModels: string;
+  launchUnavailableProvider: (provider: string) => string;
+  launchUnavailableModel: (model: string) => string;
+  launchRuntimeUnavailable: (model: string) => string;
+  generalFallback: string;
   savedLocally: string;
   pasteApiKey: string;
   save: string;
@@ -162,8 +179,23 @@ export const translations: Record<Language, UiCopy> = {
     chinese: "中文",
     tagline: "Generate, edit, inpaint, download.",
     provider: "Provider",
+    providerLabel: "Provider",
     apiKey: "API Key",
     baseURL: "Base URL",
+    discoveryStatus: "Model discovery",
+    discoveryNotRun: "Not run",
+    discoveryLastRun: (date: string, count: number) => `${date} · ${count} model${count === 1 ? "" : "s"}`,
+    discoverModels: "Discover models",
+    discoveringModels: "Discovering",
+    launchModels: "Launch",
+    launchAvailable: "Available",
+    launchUnavailableNoKey: "Save an API key first.",
+    launchUnavailableNoDiscovery: "Run model discovery first.",
+    launchUnavailableNoImageModels: "No image models discovered.",
+    launchUnavailableProvider: (provider: string) => `Switch to ${provider}.`,
+    launchUnavailableModel: (model: string) => `${model} was not discovered.`,
+    launchRuntimeUnavailable: (model: string) => `${model} runtime is not connected yet.`,
+    generalFallback: "Discovered fallback",
     savedLocally: "Saved locally",
     pasteApiKey: "Paste API key",
     save: "Save",
@@ -278,7 +310,9 @@ export const translations: Record<Language, UiCopy> = {
       historyCleared: "History cleared.",
       promptCopied: "Prompt copied.",
       clipboardUnavailable: "Clipboard is unavailable.",
-      jobLoaded: "Job loaded into workspace."
+      jobLoaded: "Job loaded into workspace.",
+      modelsDiscovered: (count: number) => `${count} model${count === 1 ? "" : "s"} discovered.`,
+      launchSelected: (model: string) => `${model} selected.`
     },
     validation: {
       promptInvalid: "Prompt is invalid.",
@@ -309,8 +343,23 @@ export const translations: Record<Language, UiCopy> = {
     chinese: "中文",
     tagline: "生成、编辑、局部重绘、下载。",
     provider: "服务配置",
+    providerLabel: "服务商",
     apiKey: "API Key",
     baseURL: "Base URL",
+    discoveryStatus: "模型探测",
+    discoveryNotRun: "未探测",
+    discoveryLastRun: (date: string, count: number) => `${date} · ${count} 个模型`,
+    discoverModels: "探测模型",
+    discoveringModels: "探测中",
+    launchModels: "启动模型",
+    launchAvailable: "可用",
+    launchUnavailableNoKey: "请先保存 API Key。",
+    launchUnavailableNoDiscovery: "请先探测模型。",
+    launchUnavailableNoImageModels: "未探测到图片模型。",
+    launchUnavailableProvider: (provider: string) => `切换到 ${provider}。`,
+    launchUnavailableModel: (model: string) => `未探测到 ${model}。`,
+    launchRuntimeUnavailable: (model: string) => `${model} 运行时尚未接入。`,
+    generalFallback: "探测到的兜底模型",
     savedLocally: "已本地保存",
     pasteApiKey: "粘贴 API Key",
     save: "保存",
@@ -425,7 +474,9 @@ export const translations: Record<Language, UiCopy> = {
       historyCleared: "历史已清空。",
       promptCopied: "提示词已复制。",
       clipboardUnavailable: "剪贴板不可用。",
-      jobLoaded: "任务已载入工作区。"
+      jobLoaded: "任务已载入工作区。",
+      modelsDiscovered: (count: number) => `已探测到 ${count} 个模型。`,
+      launchSelected: (model: string) => `已选择 ${model}。`
     },
     validation: {
       promptInvalid: "Prompt 格式无效。",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -350,6 +350,7 @@ label {
 }
 
 .config-status,
+.model-discovery-status,
 .inline-check,
 .mask-status {
   display: flex;
@@ -357,6 +358,92 @@ label {
   gap: 7px;
   color: #5d554c;
   font-size: 12px;
+}
+
+.model-discovery-status {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.model-discovery-status strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: #2d2924;
+  font-weight: 650;
+  text-align: right;
+}
+
+.model-discovery-status[data-kind="error"] strong {
+  color: #a33a32;
+}
+
+.discover-button {
+  width: 100%;
+}
+
+.launch-strip {
+  display: grid;
+  gap: 7px;
+  border-top: 1px solid #ded7c9;
+  padding-top: 10px;
+}
+
+.launch-strip-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: #5d554c;
+  font-size: 12px;
+}
+
+.launch-strip-header strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #221f1c;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launch-button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: start;
+  min-height: 48px;
+  width: 100%;
+  gap: 2px;
+  border: 1px solid #d6d0c3;
+  background: #fffdf8;
+  color: #2d2924;
+  text-align: left;
+}
+
+.launch-button span,
+.launch-button small {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launch-button span {
+  font-weight: 700;
+}
+
+.launch-button small {
+  color: #786e62;
+  font-size: 11px;
+}
+
+.launch-button.active {
+  border-color: rgba(31, 111, 97, 0.62);
+  background: #e7f2ee;
+  color: #1f6f61;
+}
+
+.launch-button.active small {
+  color: #2d6e60;
 }
 
 .dot {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -259,6 +259,7 @@ export interface UpdateInstallResult {
 export interface AppBridge {
   getSnapshot: () => Promise<AppSnapshot>;
   saveConfig: (input: ProviderConfigInput) => Promise<ProviderConfig>;
+  discoverModels: () => Promise<ProviderConfig>;
   clearApiKey: () => Promise<ProviderConfig>;
   testConnection: () => Promise<ConnectionTestResult>;
   saveDraft: (input: WorkspaceDraftInput) => Promise<WorkspaceDraft>;

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -113,6 +113,8 @@ describe("gpt-image-2 validation", () => {
 
     expect(validateProviderConfigInput(valid).ok).toBe(true);
     expect(validateProviderConfigInput({ ...valid, kind: "openai", activeLaunchId: "gpt-image-2", activeModelId: "gpt-image-2" }).ok).toBe(true);
+    expect(validateProviderConfigInput({ ...valid, kind: "gemini", defaultModel: "gemini-3.1-flash-image", activeLaunchId: "nano-banana-3" }).ok).toBe(true);
+    expect(validateProviderConfigInput({ ...valid, kind: "custom", defaultModel: "image-model-x", activeLaunchId: "general" }).ok).toBe(true);
     expect(validateProviderConfigInput(null as never).ok).toBe(false);
     expect(validateProviderConfigInput({ ...valid, kind: "anthropic" } as never).ok).toBe(false);
     expect(validateProviderConfigInput({ ...valid, baseURL: null } as never).ok).toBe(false);

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -328,8 +328,9 @@ export function validateProviderConfigInput(input: unknown): ValidationResult {
   if (typeof input.defaultSize !== "string") {
     return { ok: false, message: "默认尺寸格式无效。" };
   }
+  const kind = isOneOf(input.kind, PROVIDER_KIND_OPTIONS) ? input.kind : undefined;
   const defaultModel = input.defaultModel.trim();
-  if (defaultModel && defaultModel !== DEFAULT_IMAGE_PARAMS.model) {
+  if ((kind === undefined || kind === "openai") && defaultModel && defaultModel !== DEFAULT_IMAGE_PARAMS.model) {
     return { ok: false, message: `默认模型仅支持 ${DEFAULT_IMAGE_PARAMS.model}。` };
   }
   const defaultSize = input.defaultSize.trim();


### PR DESCRIPTION
## Summary
- add sanitized model discovery for OpenAI-compatible and Gemini model lists
- wire config:discoverModels IPC plus save/test discovery refresh metadata
- add provider selector, discovery status, and focused launch buttons in the renderer

## Validation
- pnpm typecheck
- pnpm test
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm build:renderer
- git diff --check
- Playwright/Vite preview smoke for provider selector and launch controls