### PR TITLE
Add Gemini image adapter runtime

### DIFF
--- a/src/main/services/geminiImageAdapter.test.ts
+++ b/src/main/services/geminiImageAdapter.test.ts
@@ -1,0 +1,298 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GeminiImageParams, GenerationJob, InputAsset, JobProgressEvent } from "../../shared/types";
+import { DEFAULT_GEMINI_BASE_URL, DEFAULT_GEMINI_IMAGE_PARAMS } from "../../shared/validation";
+import type { StoredProviderConfig } from "./stateMigration";
+import {
+  buildGeminiEndpoint,
+  buildGeminiGenerateContentBody,
+  buildGeminiGenerateContentEndpoint,
+  discoverGeminiModels,
+  geminiImageAdapter,
+  geminiImageSizeForResolution,
+  runGeminiImageJob
+} from "./geminiImageAdapter";
+
+const tinyPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lw1m8QAAAABJRU5ErkJggg==";
+const tinyMaskBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8DwQACfsD/QWf36QAAAAASUVORK5CYII=";
+
+let tmpDir: string | null = null;
+
+afterEach(async () => {
+  if (tmpDir) {
+    await rm(tmpDir, { recursive: true, force: true });
+    tmpDir = null;
+  }
+});
+
+function params(patch: Partial<GeminiImageParams> = {}): GeminiImageParams {
+  return {
+    ...DEFAULT_GEMINI_IMAGE_PARAMS,
+    timeoutMs: 30000,
+    ...patch
+  };
+}
+
+type GeminiTestJob = GenerationJob & { params: GeminiImageParams };
+
+function job(patch: Partial<GeminiTestJob> = {}): GeminiTestJob {
+  return {
+    ...baseJob(),
+    ...patch
+  };
+}
+
+function baseJob(): GeminiTestJob {
+  const now = new Date(0).toISOString();
+  return {
+    id: "job_gemini_test",
+    providerKind: "gemini" as const,
+    providerId: "gemini",
+    launchId: "nano-banana-3" as const,
+    modelId: "gemini-3.1-flash-image",
+    modelDisplayName: "Nano Banana 3",
+    mode: "generate" as const,
+    prompt: "Make a clean product render",
+    inputAssets: [],
+    params: params(),
+    status: "queued" as const,
+    createdAt: now,
+    updatedAt: now,
+    outputs: []
+  };
+}
+
+function config(patch: Partial<StoredProviderConfig> = {}): StoredProviderConfig {
+  const now = new Date(0).toISOString();
+  return {
+    id: "gemini",
+    kind: "gemini",
+    name: "Gemini",
+    baseURL: DEFAULT_GEMINI_BASE_URL,
+    enabled: true,
+    defaultModel: DEFAULT_GEMINI_IMAGE_PARAMS.model,
+    defaultSize: "auto",
+    defaultQuality: "auto",
+    timeoutMs: DEFAULT_GEMINI_IMAGE_PARAMS.timeoutMs,
+    discoveredModels: [],
+    activeLaunchId: "nano-banana-3",
+    activeModelId: DEFAULT_GEMINI_IMAGE_PARAMS.model,
+    updatedAt: now,
+    encryption: "none",
+    ...patch
+  };
+}
+
+async function createRuntime(fetchImpl: typeof fetch) {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "image2tools-gemini-"));
+  const events: JobProgressEvent[] = [];
+  return {
+    runtime: {
+      fetch: fetchImpl,
+      imagesDir: tmpDir,
+      ensureDir: async (dirPath: string) => {
+        await import("node:fs/promises").then((fs) => fs.mkdir(dirPath, { recursive: true }));
+      },
+      sendJobEvent: (event: JobProgressEvent) => events.push(event)
+    },
+    events
+  };
+}
+
+describe("Gemini image adapter", () => {
+  it("builds generateContent endpoints and request bodies", () => {
+    expect(buildGeminiEndpoint("https://generativelanguage.googleapis.com/v1beta///", "/models")).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models"
+    );
+    expect(buildGeminiGenerateContentEndpoint("https://api.test/v1beta///", "models/gemini-3.1-flash-image")).toBe(
+      "https://api.test/v1beta/models/gemini-3.1-flash-image:generateContent"
+    );
+    expect(geminiImageSizeForResolution("0.5K")).toBe("512");
+
+    expect(
+      buildGeminiGenerateContentBody(params({ aspectRatio: "16:9", resolution: "2K", thinking: false, searchGrounding: true }), "prompt", [
+        { mimeType: "image/png", data: "abc" }
+      ])
+    ).toEqual({
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "prompt" }, { inlineData: { mimeType: "image/png", data: "abc" } }]
+        }
+      ],
+      generationConfig: {
+        responseModalities: ["TEXT", "IMAGE"],
+        responseFormat: {
+          image: {
+            aspectRatio: "16:9",
+            imageSize: "2K"
+          }
+        },
+        thinkingConfig: {
+          thinkingBudget: 0
+        }
+      },
+      tools: [{ googleSearch: {} }]
+    });
+  });
+
+  it("calls Gemini generateContent and saves inline image results with text metadata", async () => {
+    let requestUrl = "";
+    let requestBody: Record<string, unknown> = {};
+    let requestHeaders = new Headers();
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      requestUrl = String(url);
+      requestHeaders = new Headers(init?.headers);
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Response.json({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: "Mock Gemini text-to-image response." },
+                { inlineData: { mimeType: "image/png", data: tinyPngBase64 } }
+              ]
+            },
+            finishReason: "STOP"
+          }
+        ],
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: 2,
+          totalTokenCount: 3
+        },
+        modelVersion: "gemini-3.1-flash-image"
+      });
+    }) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    const result = await runGeminiImageJob(job(), "mock-gemini-key", "https://api.test/v1beta", runtime);
+
+    expect(requestUrl).toBe("https://api.test/v1beta/models/gemini-3.1-flash-image:generateContent");
+    expect(requestUrl).not.toContain("mock-gemini-key");
+    expect(requestHeaders.get("x-goog-api-key")).toBe("mock-gemini-key");
+    expect(requestBody).toMatchObject({
+      contents: [{ role: "user", parts: [{ text: "Make a clean product render" }] }],
+      generationConfig: {
+        responseModalities: ["TEXT", "IMAGE"],
+        responseFormat: { image: { aspectRatio: "1:1", imageSize: "1K" } }
+      }
+    });
+    expect(result.status).toBe("succeeded");
+    expect(result.outputs[0].fileName).toBe("job_gemini_test-result-0.png");
+    expect(result.usage?.total_tokens).toBe(3);
+    expect(result.providerMetadata).toMatchObject({
+      geminiTextParts: ["Mock Gemini text-to-image response."],
+      geminiFinishReasons: ["STOP"],
+      geminiModelVersion: "gemini-3.1-flash-image"
+    });
+    await expect(readFile(result.outputs[0].path)).resolves.toEqual(Buffer.from(tinyPngBase64, "base64"));
+  });
+
+  it("sends source and mask images as inlineData for guided-region inpaint", async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "image2tools-gemini-inputs-"));
+    const sourcePath = path.join(tmpDir, "source.png");
+    const maskPath = path.join(tmpDir, "mask.png");
+    await writeFile(sourcePath, Buffer.from(tinyPngBase64, "base64"));
+    await writeFile(maskPath, Buffer.from(tinyMaskBase64, "base64"));
+    const source: InputAsset = { id: "source", name: "source.png", path: sourcePath, mimeType: "image/png", sizeBytes: 1 };
+    const mask: InputAsset = { id: "mask", name: "mask.png", path: maskPath, mimeType: "image/png", sizeBytes: 1 };
+    let parts: Array<Record<string, unknown>> = [];
+    const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { contents: Array<{ parts: Array<Record<string, unknown>> }> };
+      parts = body.contents[0]?.parts ?? [];
+      return Response.json({
+        candidates: [{ content: { parts: [{ inlineData: { mimeType: "image/png", data: tinyPngBase64 } }] } }]
+      });
+    }) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    await runGeminiImageJob(
+      job({
+        mode: "inpaint",
+        inputAssets: [source],
+        maskAsset: mask
+      }),
+      "mock-gemini-key",
+      "https://api.test/v1beta",
+      runtime
+    );
+
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toEqual({ text: "Make a clean product render" });
+    expect(parts[1]).toEqual({ inlineData: { mimeType: "image/png", data: tinyPngBase64 } });
+    expect(parts[2]).toEqual({ inlineData: { mimeType: "image/png", data: tinyMaskBase64 } });
+  });
+
+  it("tests connections and discovers generateContent models", async () => {
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe("https://api.test/v1beta/models");
+      expect(new Headers(init?.headers).get("x-goog-api-key")).toBe("mock-gemini-key");
+      return Response.json(
+        {
+          models: [
+            {
+              name: "models/gemini-3.1-flash-image",
+              displayName: "Gemini 3.1 Flash Image",
+              description: "Image model",
+              supportedGenerationMethods: ["generateContent"]
+            },
+            {
+              name: "models/text-only",
+              supportedGenerationMethods: ["countTokens"]
+            }
+          ]
+        },
+        { headers: { "x-request-id": "mock_gemini_req" } }
+      );
+    }) as typeof fetch;
+
+    await expect(geminiImageAdapter.testConnection(config({ baseURL: "https://api.test/v1beta" }), "mock-gemini-key", { fetch: fetchImpl })).resolves.toEqual({
+      ok: true,
+      message: "连接成功。",
+      status: 200,
+      requestId: "mock_gemini_req"
+    });
+    await expect(discoverGeminiModels(config({ baseURL: "https://api.test/v1beta" }), "mock-gemini-key", { fetch: fetchImpl })).resolves.toEqual([
+      {
+        id: "gemini-3.1-flash-image",
+        providerKind: "gemini",
+        displayName: "Gemini 3.1 Flash Image",
+        description: "Image model",
+        raw: {
+          name: "models/gemini-3.1-flash-image",
+          displayName: "Gemini 3.1 Flash Image",
+          description: "Image model",
+          supportedGenerationMethods: ["generateContent"]
+        }
+      }
+    ]);
+  });
+
+  it("redacts OpenAI-style and Google API key-like strings from errors", async () => {
+    const googleKey = ["AIza", "SyD", "-mock-redaction-key-should-not-leak-0000"].join("");
+    const fetchImpl = (async () =>
+      Response.json(
+        { error: { message: `failed for sk-abcdefghijklmnopqrstuvwxyz and ${googleKey}` } },
+        { status: 403 }
+      )) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    await expect(runGeminiImageJob(job(), "mock-gemini-key", "https://api.test/v1beta", runtime)).rejects.toThrow("sk-...redacted");
+    await expect(runGeminiImageJob(job(), "mock-gemini-key", "https://api.test/v1beta", runtime)).rejects.toThrow("AIza...redacted");
+  });
+
+  it("uses OpenAI-compatible timeout behavior", async () => {
+    const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      })) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    await expect(
+      runGeminiImageJob(job({ params: params({ timeoutMs: 1 }) }), "mock-gemini-key", "https://api.test/v1beta", runtime)
+    ).rejects.toThrow("请求超时");
+  });
+});

--- a/src/main/services/geminiImageAdapter.ts
+++ b/src/main/services/geminiImageAdapter.ts
@@ -1,0 +1,489 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type {
+  ConnectionTestResult,
+  DiscoveredModel,
+  GeminiImageParams,
+  GeminiResolution,
+  GenerationJob,
+  ImageAsset,
+  InputAsset,
+  RunJobRequest,
+  UsageDetails
+} from "../../shared/types.js";
+import {
+  dataUrlToBase64,
+  isGeminiImageParams,
+  normalizeImageMimeType,
+  validateGeminiRunJobRequest
+} from "../../shared/validation.js";
+import type { ImageJobRuntime, ImageProviderAdapter, ImageProviderRuntime } from "./imageProviderAdapter.js";
+import { fetchWithTimeout } from "./openaiImageAdapter.js";
+import type { StoredProviderConfig } from "./stateMigration.js";
+
+export interface GeminiInlineData {
+  mimeType: string;
+  data: string;
+}
+
+export interface GeminiGenerateContentPart {
+  text?: string;
+  inlineData?: GeminiInlineData;
+}
+
+export interface GeminiGenerateContentBody {
+  contents: Array<{
+    role: "user";
+    parts: GeminiGenerateContentPart[];
+  }>;
+  generationConfig: {
+    responseModalities: ["TEXT", "IMAGE"];
+    responseFormat: {
+      image: {
+        aspectRatio: GeminiImageParams["aspectRatio"];
+        imageSize: "512" | "1K" | "2K" | "4K";
+      };
+    };
+    thinkingConfig?: {
+      thinkingBudget: 0;
+    };
+  };
+  tools?: Array<{
+    googleSearch: Record<string, never>;
+  }>;
+}
+
+interface GeminiModelsResponse {
+  models?: unknown[];
+}
+
+interface GeminiGenerateContentResponse {
+  candidates?: unknown[];
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
+  modelVersion?: string;
+}
+
+interface GeminiApiErrorPayload {
+  error?: {
+    code?: number;
+    message?: string;
+    status?: string;
+  };
+}
+
+type GeminiImageJob = GenerationJob & { params: GeminiImageParams };
+type GeminiImageRuntime = ImageJobRuntime;
+
+export const geminiImageAdapter: ImageProviderAdapter = {
+  kind: "gemini",
+  discoverModels: discoverGeminiModels,
+  testConnection: testGeminiConnection,
+  validateJob(request: RunJobRequest) {
+    return validateGeminiRunJobRequest(request);
+  },
+  runJob(job: GenerationJob, apiKey: string, config: StoredProviderConfig, runtime: ImageJobRuntime) {
+    return runGeminiImageJob(asGeminiImageJob(job), apiKey, config.baseURL, runtime);
+  }
+};
+
+export function buildGeminiEndpoint(baseURL: string, endpoint: "/models"): string {
+  return `${baseURL.trim().replace(/\/+$/, "")}${endpoint}`;
+}
+
+export function buildGeminiGenerateContentEndpoint(baseURL: string, model: string): string {
+  const modelId = model.trim().replace(/^models\//, "");
+  return `${buildGeminiEndpoint(baseURL, "/models")}/${encodeURIComponent(modelId)}:generateContent`;
+}
+
+export function geminiImageSizeForResolution(resolution: GeminiResolution): "512" | "1K" | "2K" | "4K" {
+  return resolution === "0.5K" ? "512" : resolution;
+}
+
+export function buildGeminiGenerateContentBody(
+  params: GeminiImageParams,
+  prompt: string,
+  inlineDataParts: GeminiInlineData[] = []
+): GeminiGenerateContentBody {
+  const generationConfig: GeminiGenerateContentBody["generationConfig"] = {
+    responseModalities: ["TEXT", "IMAGE"],
+    responseFormat: {
+      image: {
+        aspectRatio: params.aspectRatio,
+        imageSize: geminiImageSizeForResolution(params.resolution)
+      }
+    }
+  };
+
+  if (!params.thinking) {
+    generationConfig.thinkingConfig = { thinkingBudget: 0 };
+  }
+
+  const body: GeminiGenerateContentBody = {
+    contents: [
+      {
+        role: "user",
+        parts: [{ text: prompt }, ...inlineDataParts.map((inlineData) => ({ inlineData }))]
+      }
+    ],
+    generationConfig
+  };
+
+  if (params.searchGrounding) {
+    body.tools = [{ googleSearch: {} }];
+  }
+
+  return body;
+}
+
+export function asGeminiImageJob(job: GenerationJob): GeminiImageJob {
+  if (!isGeminiImageParams(job.params)) {
+    throw new Error("当前版本尚未接入该模型运行时。");
+  }
+  return job as GeminiImageJob;
+}
+
+export async function discoverGeminiModels(
+  config: StoredProviderConfig,
+  apiKey: string,
+  runtime: ImageProviderRuntime
+): Promise<DiscoveredModel[]> {
+  const response = await fetchWithTimeout(
+    runtime.fetch,
+    buildGeminiEndpoint(config.baseURL, "/models"),
+    {
+      method: "GET",
+      headers: geminiJsonHeaders(apiKey)
+    },
+    Math.min(config.timeoutMs, 30000)
+  );
+
+  if (!response.ok) {
+    throw new Error(await readGeminiApiError(response));
+  }
+
+  return readGeminiModelsResponse(response);
+}
+
+export async function testGeminiConnection(
+  config: StoredProviderConfig,
+  apiKey: string,
+  runtime: ImageProviderRuntime
+): Promise<ConnectionTestResult> {
+  try {
+    const response = await fetchWithTimeout(
+      runtime.fetch,
+      buildGeminiEndpoint(config.baseURL, "/models"),
+      {
+        method: "GET",
+        headers: geminiJsonHeaders(apiKey)
+      },
+      Math.min(config.timeoutMs, 30000)
+    );
+
+    const requestId = requestIdFromHeaders(response.headers);
+    if (!response.ok) {
+      return {
+        ok: false,
+        message: await readGeminiApiError(response),
+        status: response.status,
+        requestId
+      };
+    }
+
+    return {
+      ok: true,
+      message: "连接成功。",
+      status: response.status,
+      requestId
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: normalizeGeminiAdapterError(error)
+    };
+  }
+}
+
+export async function runGeminiImageJob(
+  job: GeminiImageJob,
+  apiKey: string,
+  baseURL: string,
+  runtime: GeminiImageRuntime
+): Promise<GenerationJob> {
+  if (job.mode === "generate" && job.inputAssets.length > 0) {
+    throw new Error("文生图不应携带输入图片。");
+  }
+  if ((job.mode === "edit" || job.mode === "inpaint") && job.inputAssets.length === 0) {
+    throw new Error(job.mode === "inpaint" ? "局部重绘至少需要一张源图。" : "图像编辑至少需要一张源图。");
+  }
+  if (job.mode === "inpaint" && !job.maskAsset) {
+    throw new Error("局部重绘需要提供 mask。");
+  }
+
+  const inlineDataParts = await inputAssetsToInlineDataParts(job.inputAssets, job.maskAsset);
+  const response = await fetchWithTimeout(
+    runtime.fetch,
+    buildGeminiGenerateContentEndpoint(baseURL, job.params.model),
+    {
+      method: "POST",
+      headers: geminiJsonHeaders(apiKey),
+      body: JSON.stringify(buildGeminiGenerateContentBody(job.params, job.prompt, inlineDataParts))
+    },
+    job.params.timeoutMs
+  );
+
+  return handleGeminiGenerateContentResponse(response, job, runtime);
+}
+
+async function inputAssetsToInlineDataParts(inputAssets: InputAsset[], maskAsset?: InputAsset): Promise<GeminiInlineData[]> {
+  const imageParts = await Promise.all(inputAssets.map(inputAssetToInlineData));
+  if (!maskAsset) return imageParts;
+  return [...imageParts, await inputAssetToInlineData(maskAsset)];
+}
+
+async function inputAssetToInlineData(asset: InputAsset): Promise<GeminiInlineData> {
+  const mimeType = normalizeSupportedGeminiMimeType(asset.mimeType);
+  if (asset.dataUrl) {
+    return {
+      mimeType,
+      data: dataUrlToBase64(asset.dataUrl)
+    };
+  }
+  const content = await fs.readFile(asset.path);
+  return {
+    mimeType,
+    data: content.toString("base64")
+  };
+}
+
+async function handleGeminiGenerateContentResponse(
+  response: Response,
+  job: GeminiImageJob,
+  runtime: GeminiImageRuntime
+): Promise<GenerationJob> {
+  if (!response.ok) {
+    throw new Error(await readGeminiApiError(response));
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType && !contentType.includes("application/json")) {
+    throw new Error(await readUnexpectedGeminiResponse(response, "JSON 图片结果"));
+  }
+
+  let payload: GeminiGenerateContentResponse;
+  try {
+    payload = (await response.json()) as GeminiGenerateContentResponse;
+  } catch {
+    throw new Error("Gemini API 返回的图片结果不是有效 JSON。请检查 Base URL 是否指向 Gemini generateContent 接口。");
+  }
+
+  const parsed = collectGeminiResponseParts(payload);
+  const outputs = await saveGeminiImages(job.id, parsed.images, runtime);
+  if (outputs.length === 0) {
+    throw new Error("Gemini API 没有返回可保存的图片。");
+  }
+
+  return {
+    ...job,
+    outputs,
+    usage: usageFromGemini(payload.usageMetadata),
+    providerMetadata: {
+      ...job.providerMetadata,
+      geminiTextParts: parsed.textParts,
+      geminiFinishReasons: parsed.finishReasons,
+      geminiModelVersion: payload.modelVersion,
+      geminiRequest: {
+        aspectRatio: job.params.aspectRatio,
+        resolution: job.params.resolution,
+        mode: job.mode
+      }
+    },
+    status: "succeeded",
+    updatedAt: new Date().toISOString()
+  };
+}
+
+function collectGeminiResponseParts(payload: GeminiGenerateContentResponse): {
+  images: GeminiInlineData[];
+  textParts: string[];
+  finishReasons: string[];
+} {
+  const images: GeminiInlineData[] = [];
+  const textParts: string[] = [];
+  const finishReasons: string[] = [];
+
+  const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue;
+    if (typeof candidate.finishReason === "string" && candidate.finishReason.trim()) {
+      finishReasons.push(candidate.finishReason.trim());
+    }
+
+    const content = isRecord(candidate.content) ? candidate.content : undefined;
+    const parts = Array.isArray(content?.parts) ? content.parts : [];
+    for (const part of parts) {
+      if (!isRecord(part)) continue;
+      if (typeof part.text === "string" && part.text.trim()) {
+        textParts.push(part.text);
+      }
+      const inlineData = inlineDataFromResponsePart(part);
+      if (inlineData) {
+        images.push(inlineData);
+      }
+    }
+  }
+
+  return { images, textParts, finishReasons };
+}
+
+function inlineDataFromResponsePart(part: Record<string, unknown>): GeminiInlineData | null {
+  const rawInlineData = isRecord(part.inlineData) ? part.inlineData : isRecord(part.inline_data) ? part.inline_data : undefined;
+  if (!rawInlineData || typeof rawInlineData.data !== "string") return null;
+  const mimeType = typeof rawInlineData.mimeType === "string" ? rawInlineData.mimeType : "image/png";
+  return {
+    mimeType: normalizeSupportedGeminiMimeType(mimeType),
+    data: rawInlineData.data
+  };
+}
+
+async function saveGeminiImages(jobId: string, images: GeminiInlineData[], runtime: GeminiImageRuntime): Promise<ImageAsset[]> {
+  const outputs: ImageAsset[] = [];
+  for (const [index, image] of images.entries()) {
+    outputs.push(await saveBase64Image(jobId, image, index, runtime));
+  }
+  return outputs;
+}
+
+async function saveBase64Image(
+  jobId: string,
+  image: GeminiInlineData,
+  index: number,
+  runtime: GeminiImageRuntime
+): Promise<ImageAsset> {
+  await runtime.ensureDir(runtime.imagesDir);
+  const mimeType = normalizeSupportedGeminiMimeType(image.mimeType);
+  const fileName = `${jobId}-result-${index}.${extensionForMimeType(mimeType)}`;
+  const filePath = path.join(runtime.imagesDir, fileName);
+  await fs.writeFile(filePath, Buffer.from(image.data, "base64"));
+
+  return {
+    id: `img_${randomUUID()}`,
+    jobId,
+    path: filePath,
+    fileName,
+    mimeType,
+    sourceType: "result",
+    createdAt: new Date().toISOString()
+  };
+}
+
+async function readGeminiModelsResponse(response: Response): Promise<DiscoveredModel[]> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType && !contentType.includes("application/json")) {
+    throw new Error(await readUnexpectedGeminiResponse(response, "JSON 模型列表"));
+  }
+
+  let payload: GeminiModelsResponse;
+  try {
+    payload = (await response.json()) as GeminiModelsResponse;
+  } catch {
+    throw new Error("Gemini API 返回的模型列表不是有效 JSON。请检查 Base URL 是否指向 Gemini API。");
+  }
+
+  const models = Array.isArray(payload.models) ? payload.models : [];
+  return models.flatMap((item): DiscoveredModel[] => {
+    if (!isRecord(item)) return [];
+    const rawId = typeof item.name === "string" ? item.name : typeof item.id === "string" ? item.id : "";
+    const id = rawId.replace(/^models\//, "").trim();
+    if (!id) return [];
+    const methods = Array.isArray(item.supportedGenerationMethods) ? item.supportedGenerationMethods : [];
+    if (methods.length > 0 && !methods.includes("generateContent")) return [];
+    return [
+      {
+        id,
+        providerKind: "gemini",
+        displayName: typeof item.displayName === "string" && item.displayName.trim() ? item.displayName.trim() : id,
+        description: typeof item.description === "string" && item.description.trim() ? item.description.trim() : undefined,
+        raw: item
+      }
+    ];
+  });
+}
+
+async function readGeminiApiError(response: Response): Promise<string> {
+  const requestId = requestIdFromHeaders(response.headers);
+  const requestSuffix = requestId ? ` Request ID: ${requestId}` : "";
+  const fallback = `Gemini API 请求失败：HTTP ${response.status}.${requestSuffix}`;
+
+  try {
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      const payload = (await response.json()) as GeminiApiErrorPayload;
+      const message = payload.error?.message ?? payload.error?.status ?? String(payload.error?.code ?? "");
+      return message ? `Gemini API 请求失败：${redactLikelySecrets(message)}${requestSuffix}` : fallback;
+    }
+
+    const text = await response.text();
+    return text.trim() ? `Gemini API 请求失败：${redactLikelySecrets(text.trim())}${requestSuffix}` : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function readUnexpectedGeminiResponse(response: Response, expected: string): Promise<string> {
+  const contentType = response.headers.get("content-type") ?? "unknown";
+  const text = redactLikelySecrets((await response.text()).trim()).slice(0, 240);
+  const suffix = text ? ` 响应开头：${text}` : "";
+  return `Gemini API 返回了非预期响应，期望 ${expected}，实际 Content-Type: ${contentType}.${suffix}`;
+}
+
+function usageFromGemini(usage?: GeminiGenerateContentResponse["usageMetadata"]): UsageDetails | undefined {
+  if (!usage) return undefined;
+  return {
+    input_tokens: usage.promptTokenCount,
+    output_tokens: usage.candidatesTokenCount,
+    total_tokens: usage.totalTokenCount
+  };
+}
+
+function geminiJsonHeaders(apiKey: string): HeadersInit {
+  return {
+    "x-goog-api-key": apiKey,
+    "Content-Type": "application/json",
+    Accept: "application/json"
+  };
+}
+
+function requestIdFromHeaders(headers: Headers): string | undefined {
+  return headers.get("x-request-id") ?? headers.get("x-goog-request-id") ?? undefined;
+}
+
+function normalizeGeminiAdapterError(error: unknown): string {
+  if (error instanceof Error) return redactLikelySecrets(error.message);
+  return redactLikelySecrets(String(error));
+}
+
+function normalizeSupportedGeminiMimeType(mimeType: string): "image/png" | "image/jpeg" | "image/webp" {
+  const normalized = normalizeImageMimeType(mimeType);
+  if (normalized === "image/png" || normalized === "image/jpeg" || normalized === "image/webp") return normalized;
+  throw new Error("Gemini inline images must be PNG, JPEG, or WebP.");
+}
+
+function extensionForMimeType(mimeType: "image/png" | "image/jpeg" | "image/webp"): "png" | "jpg" | "webp" {
+  if (mimeType === "image/jpeg") return "jpg";
+  if (mimeType === "image/webp") return "webp";
+  return "png";
+}
+
+function redactLikelySecrets(value: string): string {
+  return value.replace(/sk-[A-Za-z0-9_-]{8,}/g, "sk-...redacted").replace(/AIza[A-Za-z0-9_-]{8,}/g, "AIza...redacted");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/main/services/imageProviderAdapters.test.ts
+++ b/src/main/services/imageProviderAdapters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { RunJobRequest } from "../../shared/types";
 import { DEFAULT_GEMINI_IMAGE_PARAMS, DEFAULT_IMAGE_PARAMS } from "../../shared/validation";
 import { getImageProviderAdapter, getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./imageProviderAdapters";
+import { geminiImageAdapter } from "./geminiImageAdapter";
 import { openaiImageAdapter } from "./openaiImageAdapter";
 
 function request(params: RunJobRequest["params"] = DEFAULT_IMAGE_PARAMS): RunJobRequest {
@@ -19,10 +20,13 @@ describe("image provider adapter registry", () => {
     expect(getImageProviderAdapterForRequest(request())).toBe(openaiImageAdapter);
   });
 
-  it("leaves Gemini and Custom unsupported until adapters are registered", () => {
-    expect(getImageProviderAdapter("gemini")).toBeUndefined();
+  it("dispatches Gemini requests to the Gemini adapter", () => {
+    expect(getImageProviderAdapter("gemini")).toBe(geminiImageAdapter);
+    expect(getImageProviderAdapterForRequest(request(DEFAULT_GEMINI_IMAGE_PARAMS))).toBe(geminiImageAdapter);
+  });
+
+  it("leaves Custom unsupported until an adapter is registered", () => {
     expect(getImageProviderAdapter("custom")).toBeUndefined();
-    expect(getImageProviderAdapterForRequest(request(DEFAULT_GEMINI_IMAGE_PARAMS))).toBeUndefined();
     expect(unsupportedImageProviderMessage()).toBe("当前版本尚未接入该模型运行时。");
   });
 });

--- a/src/main/services/imageProviderAdapters.ts
+++ b/src/main/services/imageProviderAdapters.ts
@@ -1,8 +1,12 @@
 import type { ProviderKind, RunJobRequest } from "../../shared/types.js";
 import type { ImageProviderAdapter } from "./imageProviderAdapter.js";
+import { geminiImageAdapter } from "./geminiImageAdapter.js";
 import { openaiImageAdapter } from "./openaiImageAdapter.js";
 
-const imageProviderAdapters = new Map<ProviderKind, ImageProviderAdapter>([[openaiImageAdapter.kind, openaiImageAdapter]]);
+const imageProviderAdapters = new Map<ProviderKind, ImageProviderAdapter>([
+  [openaiImageAdapter.kind, openaiImageAdapter],
+  [geminiImageAdapter.kind, geminiImageAdapter]
+]);
 
 export function getImageProviderAdapter(kind: ProviderKind): ImageProviderAdapter | undefined {
   return imageProviderAdapters.get(kind);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -171,6 +171,7 @@ export interface GenerationJob {
   updatedAt: string;
   outputs: ImageAsset[];
   usage?: UsageDetails;
+  providerMetadata?: Record<string, unknown>;
 }
 
 export interface RunJobRequest {

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -90,7 +90,7 @@ describe("gpt-image-2 validation", () => {
     expect(validateApiKey("sk-test-key-that-is-long-enough").ok).toBe(true);
     expect(getValidationError(DEFAULT_IMAGE_PARAMS, "")).toContain("prompt");
     expect(getValidationError(DEFAULT_IMAGE_PARAMS, "Make a compact icon set")).toBeNull();
-    expect(getValidationError(DEFAULT_GEMINI_IMAGE_PARAMS, "Make a compact icon set")).toContain("尚未接入");
+    expect(getValidationError(DEFAULT_GEMINI_IMAGE_PARAMS, "Make a compact icon set")).toBeNull();
     expect(getValidationError(DEFAULT_GENERAL_IMAGE_PARAMS, "Make a compact icon set")).toContain("尚未接入");
   });
 
@@ -159,10 +159,27 @@ describe("gpt-image-2 validation", () => {
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "data:image/png;base64,abc" } as never).ok).toBe(true);
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "data:image/jpeg;base64,abc" } as never).ok).toBe(false);
     expect(validateRunJobRequest({ ...job, mode: "inpaint", inputPaths: ["/tmp/a.png"], maskDataUrl: "not-a-data-url" } as never).ok).toBe(false);
-    expect(validateRunJobRequest({ ...job, params: DEFAULT_GEMINI_IMAGE_PARAMS })).toMatchObject({
-      ok: false,
-      message: "当前版本尚未接入该模型运行时。"
-    });
+    expect(validateRunJobRequest({ ...job, params: DEFAULT_GEMINI_IMAGE_PARAMS }).ok).toBe(true);
+    expect(validateRunJobRequest({ ...job, params: DEFAULT_GEMINI_IMAGE_PARAMS, inputPaths: ["/tmp/a.png"] }).ok).toBe(false);
+    expect(validateRunJobRequest({ ...job, params: DEFAULT_GEMINI_IMAGE_PARAMS, mode: "edit", inputPaths: ["/tmp/a.png"] }).ok).toBe(true);
+    expect(
+      validateRunJobRequest({
+        ...job,
+        params: DEFAULT_GEMINI_IMAGE_PARAMS,
+        mode: "inpaint",
+        inputPaths: ["/tmp/a.jpg"],
+        maskPath: "/tmp/mask.png"
+      }).ok
+    ).toBe(true);
+    expect(
+      validateRunJobRequest({
+        ...job,
+        params: DEFAULT_GEMINI_IMAGE_PARAMS,
+        mode: "edit",
+        inputPaths: ["/tmp/a.png"],
+        maskPath: "/tmp/mask.png"
+      }).ok
+    ).toBe(false);
     expect(validateRunJobRequest({ ...job, params: DEFAULT_GENERAL_IMAGE_PARAMS })).toMatchObject({
       ok: false,
       message: "当前版本尚未接入该模型运行时。"

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -169,6 +169,17 @@ export function isOpenAIImageParams(params: unknown): params is OpenAIImageParam
   );
 }
 
+export function isGeminiImageParams(params: unknown): params is GeminiImageParams {
+  return (
+    isRecord(params) &&
+    params.providerKind === "gemini" &&
+    params.launchId === NANO_BANANA_3_LAUNCH_ID &&
+    typeof params.model === "string" &&
+    typeof params.aspectRatio === "string" &&
+    typeof params.resolution === "string"
+  );
+}
+
 function paramsProviderKind(params: Record<string, unknown>): ProviderKind | undefined {
   return isOneOf(params.providerKind, PROVIDER_KIND_OPTIONS) ? params.providerKind : undefined;
 }
@@ -382,6 +393,13 @@ function hasOpenAIParamsShape(params: unknown): boolean {
   return (providerKind === undefined || providerKind === "openai") && (launchId === undefined || launchId === GPT_IMAGE_2_LAUNCH_ID);
 }
 
+function hasGeminiParamsShape(params: unknown): boolean {
+  if (!isRecord(params)) return false;
+  const providerKind = paramsProviderKind(params);
+  const launchId = paramsLaunchId(params);
+  return providerKind === "gemini" || launchId === NANO_BANANA_3_LAUNCH_ID;
+}
+
 function validateRunJobRequestBase(request: unknown): ValidationResult {
   if (!isRecord(request)) {
     return { ok: false, message: "任务请求格式无效。" };
@@ -444,6 +462,46 @@ export function validateOpenAIRunJobRequest(request: unknown): ValidationResult 
   return validateOpenAIImageParams(request.params);
 }
 
+export function validateGeminiRunJobRequest(request: unknown): ValidationResult {
+  const base = validateRunJobRequestBase(request);
+  if (!base.ok) return base;
+  if (!isRecord(request)) {
+    return { ok: false, message: "任务请求格式无效。" };
+  }
+  const inputPaths = request.inputPaths as string[];
+  if (request.mode === "generate" && inputPaths.length > 0) {
+    return { ok: false, message: "文生图不应携带输入图片。" };
+  }
+  if ((request.mode === "edit" || request.mode === "inpaint") && inputPaths.length === 0) {
+    return { ok: false, message: request.mode === "inpaint" ? "局部重绘至少需要一张源图。" : "图像编辑至少需要一张源图。" };
+  }
+  if (request.maskPath !== undefined && typeof request.maskPath !== "string") {
+    return { ok: false, message: "Mask 路径无效。" };
+  }
+  if (typeof request.maskPath === "string" && request.maskPath && !/\.(png|webp)$/i.test(request.maskPath)) {
+    return { ok: false, message: "Mask 必须是 PNG 或 WebP。" };
+  }
+  if (request.maskDataUrl !== undefined && typeof request.maskDataUrl !== "string") {
+    return { ok: false, message: "Mask 数据无效。" };
+  }
+  if (typeof request.maskDataUrl === "string" && request.maskDataUrl) {
+    const maskMimeType = mimeTypeFromDataUrl(request.maskDataUrl);
+    if (!maskMimeType) {
+      return { ok: false, message: "Mask 数据必须是 PNG 或 WebP data URL。" };
+    }
+    const maskType = validateMaskMimeType(maskMimeType);
+    if (!maskType.ok) return maskType;
+  }
+  const hasMask = Boolean(request.maskPath || request.maskDataUrl);
+  if (request.mode !== "inpaint" && hasMask) {
+    return { ok: false, message: "只有局部重绘可以携带 mask。" };
+  }
+  if (request.mode === "inpaint" && !hasMask) {
+    return { ok: false, message: "局部重绘需要提供 mask。" };
+  }
+  return validateGeminiImageParams(request.params);
+}
+
 export function validateRunJobRequest(request: unknown): ValidationResult {
   const base = validateRunJobRequestBase(request);
   if (!base.ok) return base;
@@ -453,6 +511,9 @@ export function validateRunJobRequest(request: unknown): ValidationResult {
 
   if (hasOpenAIParamsShape(request.params)) {
     return validateOpenAIRunJobRequest(request);
+  }
+  if (hasGeminiParamsShape(request.params)) {
+    return validateGeminiRunJobRequest(request);
   }
 
   const params = validateImageParams(request.params);
@@ -567,10 +628,15 @@ export function dataUrlToBase64(dataUrl: string): string {
 export function getValidationError(params: ImageParams, prompt: string): string | null {
   const promptResult = validatePrompt(prompt);
   if (!promptResult.ok) return promptResult.message ?? "Prompt 无效。";
-  if (!isOpenAIImageParams(params)) {
-    return "当前版本尚未接入该模型运行时。";
+  if (isOpenAIImageParams(params)) {
+    const paramResult = validateOpenAIImageParams(params);
+    if (!paramResult.ok) return paramResult.message ?? "参数无效。";
+    return null;
   }
-  const paramResult = validateOpenAIImageParams(params);
-  if (!paramResult.ok) return paramResult.message ?? "参数无效。";
-  return null;
+  if (isGeminiImageParams(params)) {
+    const paramResult = validateGeminiImageParams(params);
+    if (!paramResult.ok) return paramResult.message ?? "参数无效。";
+    return null;
+  }
+  return "当前版本尚未接入该模型运行时。";
 }


### PR DESCRIPTION
## Summary
- Add a Gemini generateContent image adapter for Nano Banana 3 with header-based API key auth, model discovery, connection testing, prompt-only generation, image edit, and guided-region inpaint requests.
- Register Gemini in the image provider adapter registry and allow validated Gemini run requests while leaving General/custom unsupported.
- Persist Gemini inline image outputs under the managed images directory and retain response text parts/finish reasons/model version in optional provider metadata.

## Validation
- pnpm test
- pnpm typecheck
- pnpm verify:mock-gemini-api
- pnpm verify:mock-api
- git diff --check

## Notes
- No renderer/provider selector UI changes included.
- Guided-region inpaint sends source plus mask as Gemini inlineData; it does not claim OpenAI exact mask equivalence.