### PR TITLE
docs: update Nano UI progress

### DIFF
--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -22,7 +22,7 @@ Target release: `v0.2.0`
 - [x] `Nano Banana 3` 启动按钮可按需启用/置灰
 - [ ] `General` 启动按钮可按需启用/置灰
 - [x] 不可用按钮有用户能理解的原因
-- [ ] 点击启动模型后主工作区切换到对应模型界面
+- [x] 点击启动模型后主工作区切换到对应模型界面
 - [x] 当前启动模型在 UI 中有清晰状态
 
 ## 2. Provider 与模型探测检查
@@ -67,8 +67,8 @@ Target release: `v0.2.0`
 ## 5. Nano Banana 3 检查
 
 - [x] 启动按钮映射到 `gemini-3.1-flash-image`
-- [ ] UI 显示 Nano Banana 3 专属参数
-- [ ] UI 不显示 OpenAI-only 参数
+- [x] UI 显示 Nano Banana 3 专属参数
+- [x] UI 不显示 OpenAI-only 参数
 - [x] 文生图请求使用 Gemini `generateContent`
 - [x] 参考图编辑请求包含 image `inlineData`
 - [x] 响应 image parts 能保存到本地
@@ -76,11 +76,11 @@ Target release: `v0.2.0`
 - [ ] 生成结果能显示在中间画布
 - [ ] 生成结果能下载
 - [x] 失败错误提示清晰且脱敏
-- [ ] Thinking 开关只在模型支持时显示
-- [ ] Search grounding 开关只在模型支持时显示
-- [ ] Resolution 控件符合 Nano Banana 3 能力
-- [ ] Aspect ratio 控件符合 Nano Banana 3 能力
-- [ ] 局部引导编辑文案不承诺 exact mask
+- [x] Thinking 开关只在模型支持时显示
+- [x] Search grounding 开关只在模型支持时显示
+- [x] Resolution 控件符合 Nano Banana 3 能力
+- [x] Aspect ratio 控件符合 Nano Banana 3 能力
+- [x] 局部引导编辑文案不承诺 exact mask
 - [x] mock Gemini verifier 通过
 
 ## 6. General 模式检查
@@ -103,7 +103,7 @@ Target release: `v0.2.0`
 - [x] 展开后右侧历史区域内部滚动
 - [x] 展开历史不会拉长窗口整体高度
 - [x] 搜索历史时模型字段可参与搜索
-- [ ] 复用历史任务能恢复对应模型参数
+- [x] 复用历史任务能恢复对应模型参数
 - [x] 删除单条历史仍只删除该 job owned files
 - [x] 清空历史仍清理 owned generated files
 

--- a/MULTI_MODEL_PLAN.md
+++ b/MULTI_MODEL_PLAN.md
@@ -13,6 +13,7 @@ Target release: `v0.2.0`
 - 2026-06-09: OpenAI provider adapter extraction and GPT Image 2 regression coverage merged to `main` via PR #77.
 - 2026-06-09: Gemini image adapter runtime, `generateContent` request/response handling, inline image saving, validation, and adapter tests merged to `main` via PR #80.
 - 2026-06-09: Model discovery service/UI, provider selector, launch-button state, automatic save/test discovery refresh, and provider discovery tests merged to `main` via PR #79.
+- 2026-06-09: Nano Banana 3 renderer parameter UI, Gemini launch run path, guided-region copy, General unsupported state, and history reuse restore merged to `main` via PR #82.
 
 ## 1. 目标
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -84,15 +84,15 @@ Target release: `v0.2.0`
 - [x] 实现 Gemini timeout 和错误处理
 - [x] 实现 Gemini API Key 错误脱敏
 - [x] 实现 `GeminiImageParams` validation
-- [ ] Nano Banana UI 增加 aspect ratio 控件
-- [ ] Nano Banana UI 增加 resolution 控件
-- [ ] Nano Banana UI 增加 Thinking 开关
-- [ ] Nano Banana UI 增加 Search grounding 开关
-- [ ] Nano Banana UI 隐藏 OpenAI-only 参数
-- [ ] Nano Banana 模式支持生成
-- [ ] Nano Banana 模式支持参考图编辑
-- [ ] Nano Banana 模式支持局部引导编辑
-- [ ] 局部引导编辑文案说明非 exact mask
+- [x] Nano Banana UI 增加 aspect ratio 控件
+- [x] Nano Banana UI 增加 resolution 控件
+- [x] Nano Banana UI 增加 Thinking 开关
+- [x] Nano Banana UI 增加 Search grounding 开关
+- [x] Nano Banana UI 隐藏 OpenAI-only 参数
+- [x] Nano Banana 模式支持生成
+- [x] Nano Banana 模式支持参考图编辑
+- [x] Nano Banana 模式支持局部引导编辑
+- [x] 局部引导编辑文案说明非 exact mask
 - [x] 为 Gemini request builder 写单元测试
 - [x] 为 Gemini response parser 写单元测试
 - [x] 新增 mock Gemini Image API
@@ -119,7 +119,7 @@ Target release: `v0.2.0`
 - [x] 展开后历史列表内部滚动
 - [x] 搜索历史时显示匹配数量
 - [x] 搜索历史时仍支持 6 条折叠规则
-- [ ] 复用历史任务时恢复对应 provider/model/params
+- [x] 复用历史任务时恢复对应 provider/model/params
 - [x] 删除历史任务继续只删除 owned output files
 - [x] 清空历史仍清理所有 owned outputs
 


### PR DESCRIPTION
## Summary
- add PR #82 progress log entry for Nano Banana 3 renderer UI and guided-region workflow
- mark Nano parameter UI, OpenAI-only hiding, Gemini renderer run paths, guided-region copy, and history reuse restore complete
- leave General fallback/runtime, real API acceptance, and release docs unchecked

## Validation
- git diff --check
- git diff --check HEAD~1..HEAD