### PR TITLE
docs: update General fallback progress

### DIFF
--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -20,7 +20,7 @@ Target release: `v0.2.0`
 - [x] 启动模型区位于服务配置区下方
 - [x] `GPT Image 2` 启动按钮可按需启用/置灰
 - [x] `Nano Banana 3` 启动按钮可按需启用/置灰
-- [ ] `General` 启动按钮可按需启用/置灰
+- [x] `General` 启动按钮可按需启用/置灰
 - [x] 不可用按钮有用户能理解的原因
 - [x] 点击启动模型后主工作区切换到对应模型界面
 - [x] 当前启动模型在 UI 中有清晰状态
@@ -31,7 +31,8 @@ Target release: `v0.2.0`
 - [x] OpenAI `/models` 不含 `gpt-image-2` 时按钮置灰
 - [x] Gemini `/models` 探测成功时能识别 `gemini-3.1-flash-image`
 - [x] Gemini `/models` 不含目标模型时按钮置灰
-- [ ] General 能识别非重点但可用的图片模型
+- [x] General 能识别 Gemini 非重点图片模型
+- [ ] General 能识别任意 provider 的非重点可用图片模型
 - [x] 探测请求不会把 API Key 写入日志
 - [x] 探测错误会脱敏
 - [x] 切换 provider 不会误用另一个 provider 的 Key
@@ -85,18 +86,18 @@ Target release: `v0.2.0`
 
 ## 6. General 模式检查
 
-- [ ] General 只在存在可尝试图片模型时启用
-- [ ] General UI 不显示未确认高级能力
-- [ ] General 运行失败时提示模型未适配或 provider 不兼容
-- [ ] General 历史任务记录真实 model id
-- [ ] General 不影响重点模型按钮状态
+- [x] General 只在存在可尝试图片模型时启用
+- [x] General UI 不显示未确认高级能力
+- [x] General 运行失败时提示模型未适配或 provider 不兼容
+- [x] General 历史任务记录真实 model id
+- [x] General 不影响重点模型按钮状态
 
 ## 7. 历史任务检查
 
 - [x] 每条历史显示模型 chip
 - [x] 模型 chip 显示 `GPT Image 2`
 - [ ] 模型 chip 显示 `Nano Banana 3`
-- [ ] General 历史显示真实 model id 或 `General`
+- [x] General 历史显示真实 model id 或 `General`
 - [x] 默认只展示 6 条历史
 - [x] 超过 6 条出现展开入口
 - [x] 展开后出现收起入口

--- a/MULTI_MODEL_PLAN.md
+++ b/MULTI_MODEL_PLAN.md
@@ -14,6 +14,7 @@ Target release: `v0.2.0`
 - 2026-06-09: Gemini image adapter runtime, `generateContent` request/response handling, inline image saving, validation, and adapter tests merged to `main` via PR #80.
 - 2026-06-09: Model discovery service/UI, provider selector, launch-button state, automatic save/test discovery refresh, and provider discovery tests merged to `main` via PR #79.
 - 2026-06-09: Nano Banana 3 renderer parameter UI, Gemini launch run path, guided-region copy, General unsupported state, and history reuse restore merged to `main` via PR #82.
+- 2026-06-09: General minimal Gemini fallback, Gemini-only image-model candidate selection, unsupported OpenAI/Custom General rejection, and General UI/runtime validation merged to `main` via PR #84.
 
 ## 1. 目标
 
@@ -107,6 +108,7 @@ Gemini 图片能力侧重点：
 - 支持输入 prompt
 - 支持基础参考图上传，前提是 provider adapter 可处理
 - 不承诺高级参数、mask、streaming、批量生成
+- 截至 PR #84，仅 Gemini provider 的非重点图片候选模型接入最小 fallback；OpenAI、Custom 和其他 provider 暂不通过 General 运行，避免伪适配。
 
 ## 4. 核心设计
 
@@ -394,7 +396,7 @@ const visibleHistory = historyExpanded ? filteredHistory : filteredHistory.slice
 | Nano Banana mask 语义与 OpenAI 不同 | 用户误解局部编辑精度 | UI 命名为“局部引导编辑”，不承诺精确 mask |
 | state v2 迁移破坏旧历史 | 用户历史丢失 | 写迁移测试，保留 v1 读取路径和备份 |
 | 参数 union 增加复杂度 | 类型和 UI 分支混乱 | adapter 层拥有 provider-specific validation |
-| General 过度承诺 | 体验不稳定 | 首期只做 minimal generation |
+| General 过度承诺 | 体验不稳定 | 首期只做 Gemini-only minimal fallback，其他 provider 明确拒绝 |
 | Gemini 输出 text+image 混合 | 历史和结果解析复杂 | image parts 保存为 outputs，text parts 保存为 metadata |
 | API Key 多 provider 管理 | 配置区复杂 | 首期一次只激活一个 provider，后续再做多 provider 列表 |
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -48,6 +48,7 @@ Target release: `v0.2.0`
 - [x] 新增启动模型按钮区
 - [x] `GPT Image 2` 按钮根据 OpenAI discovery 启用
 - [x] `Nano Banana 3` 按钮根据 Gemini discovery 启用
+- [x] `General` 按钮根据 Gemini 非重点图片候选模型启用
 - [ ] `General` 按钮根据任意可用图片模型启用
 - [x] 点击启动模型更新 active launch/model
 - [x] 不可用按钮显示不可用原因
@@ -100,13 +101,14 @@ Target release: `v0.2.0`
 
 ## Phase 5 - `v0.2.0` General 模式
 
-- [ ] 定义 General launch 的最小能力
-- [ ] General UI 只显示 prompt、基础输入和运行按钮
-- [ ] General 模式显示“高级能力未适配”的提示
-- [ ] General 模式接入 provider-specific fallback
-- [ ] General 模式失败时给出清晰模型不兼容提示
-- [ ] General 历史任务正常记录 provider/model
-- [ ] General 不显示 mask、streaming、format 等未确认能力
+- [x] 定义 General launch 的最小能力
+- [x] General UI 只显示 prompt、基础输入和运行按钮
+- [x] General 模式显示“高级能力未适配”的提示
+- [x] General 模式接入 Gemini provider-specific fallback
+- [ ] General 模式接入任意 provider fallback
+- [x] General 模式失败时给出清晰模型不兼容提示
+- [x] General 历史任务正常记录 provider/model
+- [x] General 不显示 mask、streaming、format 等未确认能力
 
 ## Phase 6 - `v0.2.0` 历史任务体验
 


### PR DESCRIPTION
## Summary
- record PR #84 General minimal Gemini fallback progress in the multi-model plan
- split Gemini-only General enablement from the broader any-provider fallback goal
- mark completed General UI/runtime checklist items while leaving real API and broad provider coverage open

## Validation
- git diff --check