### PR TITLE
Add mock model discovery verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Verify mock API
         run: pnpm verify:mock-api
 
+      - name: Verify mock Gemini API
+        run: pnpm verify:mock-gemini-api
+
+      - name: Verify mock model discovery
+        run: pnpm verify:mock-model-discovery
+
   mac-package:
     name: macOS package
     runs-on: macos-latest

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -137,7 +137,7 @@ Target release: `v0.2.0`
 - [x] OpenAI mock inpaint 通过
 - [x] Gemini mock 生成通过
 - [x] Gemini mock 参考图编辑通过
-- [ ] 模型 discovery mock 通过
+- [x] 模型 discovery mock 通过
 - [x] state v1 -> v2 migration tests 通过
 - [x] renderer i18n shape tests 通过
 - [ ] 手工确认无 Key 时启动模型按钮置灰

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.main.json",
     "verify:mock-gemini-api": "node scripts/verify-mock-gemini-api.mjs",
+    "verify:mock-model-discovery": "node scripts/verify-mock-model-discovery.mjs",
     "verify:mock-api": "node scripts/verify-mock-api.mjs",
     "verify:release:linux": "node scripts/verify-linux-release.mjs",
     "verify:release:mac": "node scripts/verify-mac-release.mjs",

--- a/scripts/mock-gemini-image-api.mjs
+++ b/scripts/mock-gemini-image-api.mjs
@@ -6,8 +6,17 @@ const port = Number(process.env.PORT ?? 8788);
 const host = process.env.HOST ?? "127.0.0.1";
 const focusedModelId = "gemini-3.1-flash-image";
 const generalModelId = "gemini-2.0-flash-preview-image-generation";
-const supportedModelIds = new Set([focusedModelId, generalModelId]);
+const modelIds = parseModelIds(process.env.MOCK_GEMINI_MODELS, [focusedModelId, generalModelId]);
+const supportedModelIds = new Set(modelIds);
 const recentRequests = [];
+
+function parseModelIds(value, fallback) {
+  const ids = String(value ?? "")
+    .split(",")
+    .map((item) => item.trim().replace(/^models\//, ""))
+    .filter(Boolean);
+  return ids.length > 0 ? ids : fallback;
+}
 
 function redactionFixtureKey() {
   return ["AIza", "SyD", "-mock-redaction-key-should-not-leak-0000"].join("");
@@ -203,7 +212,7 @@ const server = http.createServer(async (request, response) => {
 
     if (request.method === "GET" && url.pathname === "/v1beta/models") {
       sendJson(response, 200, {
-        models: [modelResource(focusedModelId), modelResource(generalModelId)]
+        models: modelIds.map(modelResource)
       });
       return;
     }

--- a/scripts/mock-openai-image-api.mjs
+++ b/scripts/mock-openai-image-api.mjs
@@ -4,7 +4,16 @@ import http from "node:http";
 const tinyPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lw1m8QAAAABJRU5ErkJggg==";
 const port = Number(process.env.PORT ?? 8787);
 const host = process.env.HOST ?? "127.0.0.1";
+const modelIds = parseModelIds(process.env.MOCK_OPENAI_MODELS, ["gpt-image-2"]);
 const recentRequests = [];
+
+function parseModelIds(value, fallback) {
+  const ids = String(value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return ids.length > 0 ? ids : fallback;
+}
 
 function sendJson(response, status, payload) {
   response.writeHead(status, {
@@ -107,7 +116,7 @@ const server = http.createServer(async (request, response) => {
     const url = new URL(request.url, `http://${request.headers.host ?? `${host}:${port}`}`);
 
     if (request.method === "GET" && url.pathname === "/v1/models") {
-      sendJson(response, 200, { data: [{ id: "gpt-image-2", object: "model" }] });
+      sendJson(response, 200, { data: modelIds.map((id) => ({ id, object: "model" })) });
       return;
     }
 

--- a/scripts/verify-mock-model-discovery.mjs
+++ b/scripts/verify-mock-model-discovery.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const host = process.env.HOST ?? "127.0.0.1";
+const openAIApiKey = "sk-mock-image2tools";
+const geminiApiKey = "mock-gemini-key";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function startMockServer(script, env) {
+  const server = spawn(process.execPath, [script], {
+    cwd: process.cwd(),
+    env: { ...process.env, HOST: host, ...env },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  let output = "";
+  server.stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  server.stderr.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  return { server, getOutput: () => output };
+}
+
+async function stopMockServer(server) {
+  if (server.exitCode !== null || server.signalCode !== null) return;
+  await new Promise((resolve) => {
+    server.once("exit", resolve);
+    server.kill("SIGTERM");
+    setTimeout(resolve, 1500).unref();
+  });
+}
+
+async function waitForOpenAIModels(baseURL) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/models`, {
+        headers: { Authorization: `Bearer ${openAIApiKey}` }
+      });
+      if (response.ok) return;
+    } catch {
+      // Retry until the server is listening.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Mock OpenAI discovery server did not start at ${baseURL}`);
+}
+
+async function waitForGeminiModels(baseURL) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseURL}/models?key=${encodeURIComponent(geminiApiKey)}`);
+      if (response.ok) return;
+    } catch {
+      // Retry until the server is listening.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Mock Gemini discovery server did not start at ${baseURL}`);
+}
+
+async function withOpenAIMock(port, modelIds, callback) {
+  const baseURL = `http://${host}:${port}/v1`;
+  const { server, getOutput } = startMockServer("scripts/mock-openai-image-api.mjs", {
+    PORT: String(port),
+    MOCK_OPENAI_MODELS: modelIds.join(",")
+  });
+  try {
+    await waitForOpenAIModels(baseURL);
+    await callback(baseURL);
+  } catch (error) {
+    console.error(getOutput());
+    throw error;
+  } finally {
+    await stopMockServer(server);
+  }
+}
+
+async function withGeminiMock(port, modelIds, callback) {
+  const baseURL = `http://${host}:${port}/v1beta`;
+  const { server, getOutput } = startMockServer("scripts/mock-gemini-image-api.mjs", {
+    PORT: String(port),
+    MOCK_GEMINI_MODELS: modelIds.join(",")
+  });
+  try {
+    await waitForGeminiModels(baseURL);
+    await callback(baseURL);
+  } catch (error) {
+    console.error(getOutput());
+    throw error;
+  } finally {
+    await stopMockServer(server);
+  }
+}
+
+async function openAIModelIds(baseURL) {
+  const response = await fetch(`${baseURL}/models`, {
+    headers: { Authorization: `Bearer ${openAIApiKey}` }
+  });
+  assert(response.ok, `OpenAI-compatible discovery failed with HTTP ${response.status}`);
+  const payload = await response.json();
+  return (payload.data ?? []).map((model) => model.id).filter(Boolean);
+}
+
+async function geminiModelIds(baseURL, key = geminiApiKey) {
+  const response = await fetch(`${baseURL}/models?key=${encodeURIComponent(key)}`);
+  assert(response.ok, `Gemini discovery failed with HTTP ${response.status}`);
+  const payload = await response.json();
+  return (payload.models ?? []).map((model) => String(model.name ?? model.id ?? "").replace(/^models\//, "")).filter(Boolean);
+}
+
+function hasImageLikeCandidate(modelIds) {
+  return modelIds.some((id) => /image|imagen|dall-e|dalle|stable-diffusion|sdxl|flux|recraft/i.test(id) && id !== "gpt-image-2" && id !== "gemini-3.1-flash-image");
+}
+
+async function verifyOpenAIFocusedDiscovery() {
+  await withOpenAIMock(8791, ["gpt-image-2", "gpt-4.1"], async (baseURL) => {
+    const ids = await openAIModelIds(baseURL);
+    assert(ids.includes("gpt-image-2"), "OpenAI mock did not expose gpt-image-2");
+  });
+}
+
+async function verifyOpenAIMissingFocusedDiscovery() {
+  await withOpenAIMock(8792, ["gpt-4.1", "dall-e-3"], async (baseURL) => {
+    const ids = await openAIModelIds(baseURL);
+    assert(!ids.includes("gpt-image-2"), "OpenAI mock unexpectedly exposed gpt-image-2");
+    assert(ids.includes("dall-e-3"), "OpenAI mock did not expose the non-focused image-like model fixture");
+  });
+}
+
+async function verifyGeminiFocusedAndGeneralDiscovery() {
+  await withGeminiMock(8793, ["gemini-3.1-flash-image", "gemini-2.0-flash-preview-image-generation"], async (baseURL) => {
+    const ids = await geminiModelIds(baseURL);
+    assert(ids.includes("gemini-3.1-flash-image"), "Gemini mock did not expose gemini-3.1-flash-image");
+    assert(hasImageLikeCandidate(ids), "Gemini mock did not expose a non-focused image-like General candidate");
+  });
+}
+
+async function verifyGeminiMissingFocusedDiscovery() {
+  await withGeminiMock(8794, ["gemini-1.5-pro", "gemini-2.0-flash-preview-image-generation"], async (baseURL) => {
+    const ids = await geminiModelIds(baseURL);
+    assert(!ids.includes("gemini-3.1-flash-image"), "Gemini mock unexpectedly exposed gemini-3.1-flash-image");
+    assert(hasImageLikeCandidate(ids), "Gemini mock did not retain the General image candidate fixture");
+  });
+}
+
+async function verifyGeminiDiscoveryAuthErrors() {
+  await withGeminiMock(8795, ["gemini-3.1-flash-image"], async (baseURL) => {
+    const missingKey = await fetch(`${baseURL}/models`);
+    assert(missingKey.status === 401, `Gemini missing-key discovery returned HTTP ${missingKey.status}, expected 401`);
+    const invalidKey = await fetch(`${baseURL}/models?key=bad`);
+    assert(invalidKey.status === 403, `Gemini invalid-key discovery returned HTTP ${invalidKey.status}, expected 403`);
+    const payload = await invalidKey.json();
+    assert(payload.error?.message?.includes("redaction-key"), "Gemini invalid-key error did not include the redaction fixture");
+  });
+}
+
+async function main() {
+  await verifyOpenAIFocusedDiscovery();
+  await verifyOpenAIMissingFocusedDiscovery();
+  await verifyGeminiFocusedAndGeneralDiscovery();
+  await verifyGeminiMissingFocusedDiscovery();
+  await verifyGeminiDiscoveryAuthErrors();
+  console.log("Mock model discovery verification passed.");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a reusable mock model discovery verifier covering OpenAI and Gemini model-list states
- allow mock OpenAI/Gemini servers to vary model fixtures through env vars while preserving defaults
- mark the multi-model discovery mock TODO item complete

## Validation
- pnpm typecheck
- pnpm test
- pnpm verify:mock-model-discovery
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- git diff --check