### PR TITLE
docs: sync multi-model smoke evidence

### DIFF
--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -74,8 +74,8 @@ Target release: `v0.2.0`
 - [x] 参考图编辑请求包含 image `inlineData`
 - [x] 响应 image parts 能保存到本地
 - [x] 响应 text parts 能保存为 job metadata
-- [ ] 生成结果能显示在中间画布
-- [ ] 生成结果能下载
+- [x] 生成结果能显示在中间画布
+- [x] 生成结果能下载
 - [x] 失败错误提示清晰且脱敏
 - [x] Thinking 开关只在模型支持时显示
 - [x] Search grounding 开关只在模型支持时显示
@@ -96,7 +96,7 @@ Target release: `v0.2.0`
 
 - [x] 每条历史显示模型 chip
 - [x] 模型 chip 显示 `GPT Image 2`
-- [ ] 模型 chip 显示 `Nano Banana 3`
+- [x] 模型 chip 显示 `Nano Banana 3`
 - [x] General 历史显示真实 model id 或 `General`
 - [x] 默认只展示 6 条历史
 - [x] 超过 6 条出现展开入口
@@ -117,8 +117,8 @@ Target release: `v0.2.0`
 - [ ] 切换模型不会重置不相关 provider config
 - [ ] 切换模型时 prompt 草稿保留或有明确恢复规则
 - [ ] 切换模型时不兼容参数会被安全重置
-- [ ] 无 Electron bridge 的 Web 预览仍给出清晰提示
-- [ ] Electron bridge 下配置、探测、运行功能可用
+- [x] 无 Electron bridge 的 Web 预览仍给出清晰提示
+- [x] Electron bridge 下配置、探测、运行功能可用
 
 ## 9. 安全检查
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -140,7 +140,7 @@ Target release: `v0.2.0`
 - [x] 模型 discovery mock 通过
 - [x] state v1 -> v2 migration tests 通过
 - [x] renderer i18n shape tests 通过
-- [ ] 手工确认无 Key 时启动模型按钮置灰
+- [x] 手工确认无 Key 时启动模型按钮置灰（renderer smoke 覆盖）
 - [ ] 手工确认 OpenAI Key 启用 GPT Image 2，且有非重点图片候选时启用 General prompt-only
 - [ ] 手工确认 Gemini Key 启用 Nano Banana 3，且有非重点图片候选时启用 General 参考图兜底
 - [ ] 手工确认历史折叠不会拉长窗口


### PR DESCRIPTION
## Summary\n- mark multi-model checklist items proven by merged renderer smoke coverage\n- keep visual, manual provider-key, and real API acceptance gates open\n\n## Validation\n- git diff --check\n- Targeted Vitest was not rerun in this fresh docs-only worktree because node_modules is not installed here; evidence comes from merged PR #89 CI.