### PR TITLE
Add real Gemini API verifier

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -101,7 +101,7 @@
 - [ ] Linux 原生桌面 AppImage 直接运行、下载、打开文件夹行为验证完成
 - [x] 真实 API 验收脚本默认受成本确认保护
 - [x] 真实 streaming 验收需要额外成本确认
-- [ ] Gemini / Nano Banana 3 真实 API 验收完成（当前只有 mock 自动化和外部手工 runbook）
+- [ ] Gemini / Nano Banana 3 真实 API 验收完成（已有受成本保护 verifier，仍需真实 Key 跑通并记录证据）
 - [x] 签名/公证 readiness 脚本不会暴露 secret 且不会尝试签名
 - [x] 配置迁移到当前 state v1 正常
 - [x] 长时间生成不会轻易超时

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -68,10 +68,6 @@ tracking issue if one exists.
 
 Use a public tracking issue after the repository is public.
 
-Main currently has `pnpm verify:mock-gemini-api`, but no automated paid Gemini
-real API verifier. Treat Gemini real acceptance as a manual external gate until
-one is added.
-
 Prerequisites:
 
 - Real Gemini API key with access to `gemini-3.1-flash-image`
@@ -87,7 +83,27 @@ pnpm verify:mock-gemini-api
 pnpm verify:mock-model-discovery
 ```
 
-Then run the app against the real Gemini endpoint:
+Then run the cost-gated real Gemini verifier:
+
+```bash
+IMAGE2TOOLS_GEMINI_API_KEY=... \
+IMAGE2TOOLS_GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta \
+IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 \
+pnpm verify:real-gemini-api
+```
+
+Expected verifier coverage:
+
+- `models` discovery includes `gemini-3.1-flash-image`
+- text-to-image generation returns at least one inline image part
+- reference-image editing sends a PNG reference image and returns image output
+- guided-region editing sends a source image plus region-guide image and returns
+  image output
+- Gemini text parts, if returned, are saved as local artifact metadata
+
+Artifacts are written to ignored `real-api-artifacts/gemini/`.
+
+After the verifier passes, run the app against the real Gemini endpoint:
 
 ```bash
 pnpm dev:electron
@@ -113,8 +129,9 @@ Expected results:
 - Any Gemini text parts are stored as provider metadata.
 - Errors shown in the UI do not include raw Gemini API keys, `key=...` query
   values, or `x-goog-api-key` values.
-- General remains Gemini-only: use a discovered non-focused Gemini image model
-  if available, and do not mark broad any-provider General support complete.
+- General uses provider-specific fallback behavior: use a discovered
+  non-focused Gemini image model if available to confirm the prompt/reference
+  path; OpenAI-compatible General remains prompt-only.
 
 After success, update `MULTI_MODEL_CHECKLIST.md`, `CHECKLIST.md`, `TODO.md`,
 and `COMPLETION_AUDIT.md` with OS/version, app commit, provider/model IDs, and

--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -160,7 +160,7 @@ Target release: `v0.2.0`
 - [ ] Gemini Key 可完成一次 Nano Banana 3 参考图编辑
 - [ ] Gemini Key 可完成一次 Nano Banana 3 局部引导编辑
 - [ ] 历史中能区分 OpenAI 与 Gemini 任务
-- [ ] 真实 API 验收仍受成本确认环境变量保护
+- [x] 真实 API 验收仍受成本确认环境变量保护
 
 ## 12. 发布前检查
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ pnpm verify:mock-model-discovery
 
 ## Real API Acceptance
 
-`pnpm verify:real-api` is intentionally cost-gated and currently covers the OpenAI GPT Image 2 path. It only sends real image requests when an API key is present and cost acceptance is explicit:
+`pnpm verify:real-api` is intentionally cost-gated and covers the OpenAI GPT Image 2 path. It only sends real image requests when an API key is present and cost acceptance is explicit:
 
 ```bash
 IMAGE2TOOLS_API_KEY=sk-... IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 pnpm verify:real-api
@@ -179,7 +179,13 @@ IMAGE2TOOLS_REAL_API_ACCEPT_STREAM_COST=1
 
 Generated acceptance artifacts are written to `real-api-artifacts/`, which is ignored by git.
 
-Gemini / Nano Banana 3 real API acceptance is documented in [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md). Main currently has mock Gemini automation, but no automated real Gemini verifier; run the external manual flow before marking Gemini real acceptance complete.
+`pnpm verify:real-gemini-api` is also cost-gated and covers Gemini / Nano Banana 3 discovery, text-to-image generation, reference editing, and guided-region editing:
+
+```bash
+IMAGE2TOOLS_GEMINI_API_KEY=... IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 pnpm verify:real-gemini-api
+```
+
+Gemini / Nano Banana 3 real API acceptance still needs the app-level history and download checks documented in [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md) before it can be marked complete.
 
 ## Icon
 
@@ -389,7 +395,7 @@ pnpm verify:mock-model-discovery
 
 ## 真实 API 验收
 
-`pnpm verify:real-api` 默认不会产生真实图片请求，且当前覆盖 OpenAI GPT Image 2 链路。必须设置 API Key 且显式确认成本后才会运行：
+`pnpm verify:real-api` 默认不会产生真实图片请求，覆盖 OpenAI GPT Image 2 链路。必须设置 API Key 且显式确认成本后才会运行：
 
 ```bash
 IMAGE2TOOLS_API_KEY=sk-... IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 pnpm verify:real-api
@@ -403,7 +409,13 @@ IMAGE2TOOLS_REAL_API_ACCEPT_STREAM_COST=1
 
 验收输出会写入被 git 忽略的 `real-api-artifacts/`。
 
-Gemini / Nano Banana 3 真实 API 验收流程见 [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md)。当前 main 已有 Gemini mock 自动化，但尚无自动化真实 Gemini verifier；在完成外部手工流程前，不应把 Gemini 真实验收标记为完成。
+`pnpm verify:real-gemini-api` 同样受成本确认保护，覆盖 Gemini / Nano Banana 3 模型探测、文生图、参考图编辑和局部引导编辑：
+
+```bash
+IMAGE2TOOLS_GEMINI_API_KEY=... IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 pnpm verify:real-gemini-api
+```
+
+Gemini / Nano Banana 3 真实 API 验收仍需完成 [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md) 中的应用内历史与下载检查后，才能标记为完成。
 
 ## 图标
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,7 +27,13 @@ OpenAI real API acceptance is cost-gated through:
 IMAGE2TOOLS_API_KEY=sk-... IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 pnpm verify:real-api
 ```
 
-Gemini / Nano Banana 3 real API acceptance is still an external manual gate on main. Follow [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md) and do not mark Gemini real acceptance complete until discovery, generation, reference editing, guided-region editing, and history/download checks pass with a real Gemini key.
+Gemini / Nano Banana 3 real API acceptance is cost-gated through:
+
+```bash
+IMAGE2TOOLS_GEMINI_API_KEY=... IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 pnpm verify:real-gemini-api
+```
+
+The verifier covers discovery, generation, reference editing, and guided-region editing. Do not mark Gemini real acceptance complete until the verifier and app-level history/download checks pass with a real Gemini key.
 
 Release package verification remains platform-specific:
 

--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@
 - [x] 增加 Gemini Key handling、Gemini 错误脱敏和上传图片权利提醒到安全文档
 - [x] 明确 General provider-specific fallback 边界：Gemini 支持 prompt/reference，OpenAI / Custom 为 prompt-only OpenAI 兼容契约
 - [ ] 用真实 Gemini Key 完成 Nano Banana 3 生成、参考图编辑、局部引导编辑和下载/历史验收
-- [ ] 为 Gemini 真实 API 验收增加自动化 verifier，或继续按外部手工流程记录证据
+- [x] 为 Gemini 真实 API 验收增加自动化 verifier，或继续按外部手工流程记录证据
 - [x] 运行 `pnpm package:dir` 和 `pnpm package:mac` 产出本机试用包
 - [x] 完成 macOS 临时目录卸载与重装 smoke test
 - [x] 增加 GitHub Actions CI（build、mock verifier、macOS / Windows / Linux package）

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "verify:release:mac": "node scripts/verify-mac-release.mjs",
     "verify:release:windows": "node scripts/verify-windows-release.mjs",
     "verify:real-api": "node scripts/verify-real-api.mjs",
+    "verify:real-gemini-api": "node scripts/verify-real-gemini-api.mjs",
     "verify:signing-ready": "node scripts/verify-signing-readiness.mjs"
   },
   "build": {

--- a/scripts/verify-real-gemini-api.mjs
+++ b/scripts/verify-real-gemini-api.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { deflateSync } from "node:zlib";
+
+const model = process.env.IMAGE2TOOLS_GEMINI_MODEL ?? "gemini-3.1-flash-image";
+const baseURL = (process.env.IMAGE2TOOLS_GEMINI_BASE_URL ?? process.env.GEMINI_BASE_URL ?? "https://generativelanguage.googleapis.com/v1beta").replace(/\/+$/, "");
+const apiKey = process.env.IMAGE2TOOLS_GEMINI_API_KEY ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY ?? "";
+const acceptCost = process.env.IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST === "1" || process.env.IMAGE2TOOLS_REAL_API_ACCEPT_COST === "1";
+const outputRoot = path.resolve("real-api-artifacts", "gemini");
+
+function requireAcceptance() {
+  if (!apiKey) {
+    throw new Error("Missing IMAGE2TOOLS_GEMINI_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY. No real Gemini API calls were made.");
+  }
+  if (!acceptCost) {
+    throw new Error(
+      "Refusing to make paid real Gemini image calls. Set IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 to run Nano Banana 3 discovery, generation, reference editing, and guided-region acceptance."
+    );
+  }
+}
+
+function redactSecrets(value) {
+  let redacted = String(value);
+  if (apiKey) {
+    redacted = redacted.split(apiKey).join("[REDACTED_GEMINI_API_KEY]");
+  }
+  return redacted
+    .replace(/AIza[0-9A-Za-z_-]{20,}/g, "[REDACTED_GEMINI_API_KEY]")
+    .replace(/([?&]key=)[^&\s"']+/gi, "$1[REDACTED]")
+    .replace(/(x-goog-api-key["']?\s*[:=]\s*["']?)[^"',\s]+/gi, "$1[REDACTED]");
+}
+
+function endpoint(pathname, params = {}) {
+  const url = new URL(`${baseURL}${pathname}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  url.searchParams.set("key", apiKey);
+  return url;
+}
+
+async function parseJsonResponse(response, label) {
+  const text = await response.text();
+  let payload;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(redactSecrets(`${label} returned non-JSON response with HTTP ${response.status}: ${text.slice(0, 500)}`));
+  }
+
+  if (!response.ok) {
+    const message = payload?.error?.message ?? JSON.stringify(payload).slice(0, 500);
+    throw new Error(redactSecrets(`${label} failed with HTTP ${response.status}: ${message}`));
+  }
+  return payload;
+}
+
+async function verifyModels() {
+  let pageToken = "";
+  const modelIds = new Set();
+
+  do {
+    const response = await fetch(endpoint("/models", { pageSize: 1000, pageToken }));
+    const payload = await parseJsonResponse(response, "models");
+    for (const item of payload.models ?? []) {
+      const id = item.id ?? item.name?.replace(/^models\//, "");
+      if (id) modelIds.add(id);
+    }
+    pageToken = payload.nextPageToken ?? "";
+  } while (pageToken);
+
+  if (!modelIds.has(model)) {
+    throw new Error(`models response did not include ${model}.`);
+  }
+}
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type, data) {
+  const typeBuffer = Buffer.from(type);
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(Buffer.concat([typeBuffer, data])));
+  return Buffer.concat([length, typeBuffer, data, checksum]);
+}
+
+function createPng({ width, height, color, mask = false }) {
+  const bytesPerPixel = 4;
+  const rowLength = width * bytesPerPixel + 1;
+  const raw = Buffer.alloc(rowLength * height);
+  const centerX0 = Math.floor(width * 0.28);
+  const centerX1 = Math.floor(width * 0.72);
+  const centerY0 = Math.floor(height * 0.28);
+  const centerY1 = Math.floor(height * 0.72);
+
+  for (let y = 0; y < height; y += 1) {
+    const rowOffset = y * rowLength;
+    raw[rowOffset] = 0;
+    for (let x = 0; x < width; x += 1) {
+      const offset = rowOffset + 1 + x * bytesPerPixel;
+      const inCenter = x >= centerX0 && x <= centerX1 && y >= centerY0 && y <= centerY1;
+      raw[offset] = color[0];
+      raw[offset + 1] = color[1];
+      raw[offset + 2] = color[2];
+      raw[offset + 3] = mask && inCenter ? 0 : 255;
+    }
+  }
+
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  ihdr[10] = 0;
+  ihdr[11] = 0;
+  ihdr[12] = 0;
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(raw)),
+    pngChunk("IEND", Buffer.alloc(0))
+  ]);
+}
+
+function mimeExtension(mimeType) {
+  if (mimeType === "image/jpeg") return "jpg";
+  if (mimeType === "image/webp") return "webp";
+  return "png";
+}
+
+async function saveB64(label, b64, mimeType, outputDir) {
+  const buffer = Buffer.from(b64, "base64");
+  const digest = createHash("sha256").update(buffer).digest("hex").slice(0, 12);
+  const outputPath = path.join(outputDir, `${label}-${digest}.${mimeExtension(mimeType)}`);
+  await writeFile(outputPath, buffer);
+  return outputPath;
+}
+
+async function saveGeminiOutputs(label, payload, outputDir) {
+  const parts = (payload.candidates ?? []).flatMap((candidate) => candidate?.content?.parts ?? []);
+  const imageParts = parts
+    .map((part) => part.inlineData ?? part.inline_data)
+    .filter((part) => part?.data && part?.mimeType);
+  if (imageParts.length === 0) {
+    throw new Error(`${label} did not return any inline image parts.`);
+  }
+
+  const textParts = parts.map((part) => part.text).filter((part) => typeof part === "string" && part.trim());
+  if (textParts.length > 0) {
+    await writeFile(path.join(outputDir, `${label}-text-parts.json`), JSON.stringify(textParts, null, 2));
+  }
+
+  const outputs = [];
+  for (const [index, image] of imageParts.entries()) {
+    outputs.push(await saveB64(`${label}-${index + 1}`, image.data, image.mimeType, outputDir));
+  }
+  return outputs;
+}
+
+async function generateContent(label, prompt, inlineImages, outputDir) {
+  const response = await fetch(endpoint(`/models/${encodeURIComponent(model)}:generateContent`), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      contents: [
+        {
+          role: "user",
+          parts: [
+            { text: prompt },
+            ...inlineImages.map((image) => ({
+              inlineData: {
+                mimeType: image.mimeType,
+                data: image.buffer.toString("base64")
+              }
+            }))
+          ]
+        }
+      ],
+      generationConfig: {
+        responseModalities: ["TEXT", "IMAGE"]
+      }
+    })
+  });
+
+  const payload = await parseJsonResponse(response, label);
+  return saveGeminiOutputs(label, payload, outputDir);
+}
+
+async function main() {
+  requireAcceptance();
+  const outputDir = path.join(outputRoot, new Date().toISOString().replace(/[:.]/g, "-"));
+  await mkdir(outputDir, { recursive: true });
+
+  const source = createPng({ width: 512, height: 512, color: [224, 235, 244] });
+  const mask = createPng({ width: 512, height: 512, color: [255, 255, 255], mask: true });
+  await writeFile(path.join(outputDir, "source.png"), source);
+  await writeFile(path.join(outputDir, "guided-region-mask.png"), mask);
+
+  await verifyModels();
+  const sourceImage = { mimeType: "image/png", buffer: source };
+  const maskImage = { mimeType: "image/png", buffer: mask };
+  const outputs = [
+    ...(await generateContent("generation", "Create a clean product-style icon for a desktop image editing tool on a neutral background.", [], outputDir)),
+    ...(await generateContent("reference-edit", "Edit this reference into a cleaner product shot while preserving the square composition.", [sourceImage], outputDir)),
+    ...(await generateContent(
+      "guided-region-edit",
+      "Use the transparent area in the second image as a guided region. Change only that area into a bright green circle and keep the rest stable.",
+      [sourceImage, maskImage],
+      outputDir
+    ))
+  ];
+
+  console.log("Real Gemini / Nano Banana 3 API acceptance passed.");
+  for (const output of outputs) {
+    console.log(output);
+  }
+  console.log(`Artifacts saved in ${outputDir}`);
+  console.log(`Acceptance id: ${randomUUID()}`);
+}
+
+main().catch((error) => {
+  console.error(redactSecrets(error instanceof Error ? error.message : String(error)));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a cost-gated real Gemini / Nano Banana 3 verifier for discovery, text-to-image, reference edit, and guided-region edit
- wire pnpm verify:real-gemini-api into package scripts
- update acceptance docs and checklist wording without marking real external Gemini acceptance complete

## Validation
- pnpm build
- pnpm verify:mock-gemini-api
- IMAGE2TOOLS_GEMINI_API_KEY=mock-gemini-key IMAGE2TOOLS_GEMINI_BASE_URL=http://127.0.0.1:8788/v1beta IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 pnpm verify:real-gemini-api against local mock Gemini server
- IMAGE2TOOLS_GEMINI_API_KEY=mock-gemini-key node scripts/verify-real-gemini-api.mjs refuses without cost opt-in
- git diff --check