### PR TITLE
Require explicit Gemini real API cost gate

### DIFF
--- a/scripts/verify-real-gemini-api.mjs
+++ b/scripts/verify-real-gemini-api.mjs
@@ -7,7 +7,7 @@ import { deflateSync } from "node:zlib";
 const model = process.env.IMAGE2TOOLS_GEMINI_MODEL ?? "gemini-3.1-flash-image";
 const baseURL = (process.env.IMAGE2TOOLS_GEMINI_BASE_URL ?? process.env.GEMINI_BASE_URL ?? "https://generativelanguage.googleapis.com/v1beta").replace(/\/+$/, "");
 const apiKey = process.env.IMAGE2TOOLS_GEMINI_API_KEY ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY ?? "";
-const acceptCost = process.env.IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST === "1" || process.env.IMAGE2TOOLS_REAL_API_ACCEPT_COST === "1";
+const acceptCost = process.env.IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST === "1";
 const outputRoot = path.resolve("real-api-artifacts", "gemini");
 
 function requireAcceptance() {


### PR DESCRIPTION
## Summary
- require IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 for the real Gemini verifier
- prevent the generic OpenAI real API cost env from authorizing Gemini image calls

## Validation
- IMAGE2TOOLS_GEMINI_API_KEY=mock-gemini-key IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 node scripts/verify-real-gemini-api.mjs refuses without Gemini-specific cost opt-in
- IMAGE2TOOLS_GEMINI_API_KEY=mock-gemini-key IMAGE2TOOLS_GEMINI_BASE_URL=http://127.0.0.1:8788/v1beta IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 node scripts/verify-real-gemini-api.mjs against local mock Gemini server
- git diff --check origin/main...HEAD