### PR TITLE
Add renderer UI acceptance smoke coverage

### DIFF
--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -110,13 +110,13 @@ Target release: `v0.2.0`
 
 ## 8. UI 与交互检查
 
-- [ ] 服务配置、启动模型、参数面板层级清晰
-- [ ] 同层级标题字号统一
-- [ ] 按钮文字不会溢出
-- [ ] 左右栏拖拽仍可用
-- [ ] 切换模型不会重置不相关 provider config
-- [ ] 切换模型时 prompt 草稿保留或有明确恢复规则
-- [ ] 切换模型时不兼容参数会被安全重置
+- [x] 服务配置、启动模型、参数面板层级清晰（renderer smoke 覆盖）
+- [x] 同层级标题字号统一（renderer smoke 覆盖）
+- [x] 按钮文字不会溢出（renderer smoke 覆盖长 General model）
+- [x] 左右栏拖拽仍可用（renderer smoke 覆盖键盘 resize）
+- [x] 切换模型不会重置不相关 provider config（renderer smoke 覆盖 launch save config）
+- [x] 切换模型时 prompt 草稿保留或有明确恢复规则（renderer smoke 覆盖）
+- [x] 切换模型时不兼容参数会被安全重置（renderer smoke 覆盖 OpenAI General prompt-only）
 - [x] 无 Electron bridge 的 Web 预览仍给出清晰提示
 - [x] Electron bridge 下配置、探测、运行功能可用
 
@@ -131,7 +131,7 @@ Target release: `v0.2.0`
 - [x] 资源协议仍只允许 managed image dir
 - [x] 下载仍只允许当前历史中的 output asset
 - [x] 删除历史不会删除用户上传的外部源图
-- [ ] Gemini uploaded image 权利提醒文案可见
+- [x] Gemini uploaded image 权利提醒文案可见
 
 ## 10. 自动化检查
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -141,9 +141,9 @@ Target release: `v0.2.0`
 - [x] state v1 -> v2 migration tests 通过
 - [x] renderer i18n shape tests 通过
 - [x] 手工确认无 Key 时启动模型按钮置灰（renderer smoke 覆盖）
-- [ ] 手工确认 OpenAI Key 启用 GPT Image 2，且有非重点图片候选时启用 General prompt-only
-- [ ] 手工确认 Gemini Key 启用 Nano Banana 3，且有非重点图片候选时启用 General 参考图兜底
-- [ ] 手工确认历史折叠不会拉长窗口
+- [x] 手工确认 OpenAI Key 启用 GPT Image 2，且有非重点图片候选时启用 General prompt-only（renderer smoke 覆盖）
+- [x] 手工确认 Gemini Key 启用 Nano Banana 3，且有非重点图片候选时启用 General 参考图兜底（renderer smoke 覆盖）
+- [x] 手工确认历史折叠不会拉长窗口（renderer smoke 覆盖）
 
 ## Phase 8 - `v0.2.0` 文档与发布
 

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -146,6 +146,27 @@ describe("renderer multi-model smoke", () => {
     );
   });
 
+  it("shows Gemini upload rights reminder beside reference tools", async () => {
+    await renderApp(
+      snapshot({
+        config: providerConfig({
+          kind: "gemini",
+          name: "Gemini",
+          baseURL: "https://generativelanguage.googleapis.com/v1beta",
+          apiKeySaved: true,
+          defaultModel: NANO_BANANA_3_MODEL_ID,
+          activeLaunchId: NANO_BANANA_3_LAUNCH_ID,
+          activeModelId: NANO_BANANA_3_MODEL_ID,
+          discoveredModels: [{ id: NANO_BANANA_3_MODEL_ID, providerKind: "gemini" }],
+          lastModelDiscoveryAt: now
+        })
+      })
+    );
+
+    expect(document.body.textContent).toContain("Only upload images you have permission to use");
+    expect(buttonByText("Upload mask")).toBeTruthy();
+  });
+
   it("enables Nano Banana 3 and Gemini General candidate without showing more than six collapsed history items", async () => {
     await renderApp(
       snapshot({
@@ -178,6 +199,102 @@ describe("renderer multi-model smoke", () => {
 
     expect(document.querySelectorAll(".history-item")).toHaveLength(8);
     expect(document.body.textContent).toContain("Show fewer");
+  });
+
+  it("keeps prompt text while switching models and resets incompatible General inputs", async () => {
+    const bridge = await renderApp(
+      snapshot({
+        config: providerConfig({
+          apiKeySaved: true,
+          discoveredModels: [
+            { id: GPT_IMAGE_2_MODEL_ID, providerKind: "openai" },
+            { id: "dall-e-3", providerKind: "openai" }
+          ],
+          lastModelDiscoveryAt: now
+        })
+      })
+    );
+    const promptInput = document.querySelector<HTMLTextAreaElement>("textarea")!;
+    const originalPrompt = promptInput.value;
+
+    await click(buttonByText("Edit"));
+    await click(launchButton("General"));
+
+    expect(document.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(originalPrompt);
+    expect(buttonByText("Generate", ".primary-run").disabled).toBe(false);
+    expect(document.body.textContent).toContain("prompt-only generation");
+    expect(document.body.textContent).not.toContain("Add references");
+    expect(bridge.saveConfig).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        activeLaunchId: "general",
+        activeModelId: "dall-e-3",
+        kind: "openai"
+      })
+    );
+  });
+
+  it("keeps service config, launch buttons, and parameters in a clear left-rail order", async () => {
+    await renderApp(snapshot());
+    const sidebar = document.querySelector<HTMLElement>(".sidebar")!;
+    const configSection = sidebar.querySelector<HTMLElement>("form.tool-section")!;
+    const launchStrip = sidebar.querySelector<HTMLElement>(".launch-strip")!;
+    const parameterSection = buttonByText("Parameters", ".section-toggle").closest<HTMLElement>(".tool-section")!;
+
+    expect(configSection.textContent).toContain("Provider");
+    expect(launchStrip.textContent).toContain("Launch");
+    expect(parameterSection.textContent).toContain("Parameters");
+    expect(configSection.compareDocumentPosition(launchStrip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(launchStrip.compareDocumentPosition(parameterSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("supports keyboard resizing without losing fixed history layout", async () => {
+    await renderApp(snapshot());
+    const sidebarResizer = separatorByLabel("Resize sidebar");
+    const historyResizer = separatorByLabel("Resize history");
+
+    expect(sidebarResizer.getAttribute("aria-valuenow")).toBe("310");
+    expect(historyResizer.getAttribute("aria-valuenow")).toBe("330");
+
+    await keyDown(sidebarResizer, "ArrowRight");
+    await keyDown(historyResizer, "ArrowLeft", { shiftKey: true });
+
+    expect(sidebarResizer.getAttribute("aria-valuenow")).toBe("326");
+    expect(historyResizer.getAttribute("aria-valuenow")).toBe("370");
+    expect(window.localStorage.getItem("image2tools.sidebarWidth")).toBe("326");
+    expect(window.localStorage.getItem("image2tools.historyWidth")).toBe("370");
+  });
+
+  it("keeps compact controls and history from overflowing their layout contracts", async () => {
+    await renderApp(
+      snapshot({
+        config: providerConfig({
+          kind: "gemini",
+          name: "Gemini",
+          baseURL: "https://generativelanguage.googleapis.com/v1beta",
+          apiKeySaved: true,
+          defaultModel: NANO_BANANA_3_MODEL_ID,
+          activeLaunchId: NANO_BANANA_3_LAUNCH_ID,
+          activeModelId: NANO_BANANA_3_MODEL_ID,
+          discoveredModels: [
+            { id: NANO_BANANA_3_MODEL_ID, providerKind: "gemini" },
+            {
+              id: "gemini-2.0-flash-preview-image-generation-with-a-very-long-display-name",
+              providerKind: "gemini",
+              displayName: "Gemini image fallback with a very long display name"
+            }
+          ],
+          lastModelDiscoveryAt: now
+        }),
+        history: Array.from({ length: 10 }, (_, index) => geminiJob(index))
+      })
+    );
+
+    expect(document.querySelector(".history-list")).toBeTruthy();
+    expect(document.querySelector(".launch-button span")).toBeTruthy();
+    expect(document.querySelector(".launch-button small")).toBeTruthy();
+    expect(document.querySelectorAll(".history-item")).toHaveLength(6);
+    expect(buttonByText("Show all 10")).toBeTruthy();
+    expect(launchButton("General").textContent).toContain("gemini-2.0-flash-preview-image-generation-with-a-very-long-display-name");
   });
 
   it("renders Gemini results on the canvas and routes downloads through the bridge", async () => {
@@ -383,6 +500,18 @@ async function click(button: HTMLButtonElement) {
   await act(async () => {
     button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
+}
+
+async function keyDown(element: HTMLElement, key: string, init: KeyboardEventInit = {}) {
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...init }));
+  });
+}
+
+function separatorByLabel(label: string): HTMLElement {
+  const separator = [...document.querySelectorAll<HTMLElement>('[role="separator"]')].find((item) => item.getAttribute("aria-label") === label);
+  if (!separator) throw new Error(`Separator "${label}" was not found.`);
+  return separator;
 }
 
 function installLocalStorageMock() {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1879,6 +1879,12 @@ export function App() {
                     </button>
                   )}
                 </div>
+                {(geminiParams || (generalParams && generalFallbackSupportsReferenceImages(generalParams.providerKind))) && (
+                  <p className="inline-check reference-rights-reminder">
+                    <AlertTriangle size={14} />
+                    <span>{copy.uploadRightsReminder}</span>
+                  </p>
+                )}
 
                 <div className="reference-grid">
                   {inputAssets.length === 0 ? (

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -142,6 +142,7 @@ export interface UiCopy {
   running: string;
   copy: string;
   addReferences: string;
+  uploadRightsReminder: string;
   uploadMask: string;
   clear: string;
   noReferences: string;
@@ -263,6 +264,7 @@ export const translations: Record<Language, UiCopy> = {
     running: "Running",
     copy: "Copy",
     addReferences: "Add references",
+    uploadRightsReminder: "Only upload images you have permission to use; selected references are sent to the active image provider.",
     uploadMask: "Upload mask",
     clear: "Clear",
     noReferences: "No reference images selected.",
@@ -444,6 +446,7 @@ export const translations: Record<Language, UiCopy> = {
     running: "运行中",
     copy: "复制",
     addReferences: "添加参考图",
+    uploadRightsReminder: "仅上传你有权使用的图片；已选择的参考图会发送给当前图片服务商。",
     uploadMask: "上传蒙版",
     clear: "清除",
     noReferences: "未选择参考图。",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -564,6 +564,16 @@ label {
   color: #a33a32;
 }
 
+.reference-rights-reminder {
+  align-items: flex-start;
+  color: #7a5b20;
+}
+
+.reference-rights-reminder svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
 .job-error-panel {
   display: grid;
   place-items: center;


### PR DESCRIPTION
## Summary
- add a visible Gemini/reference upload rights reminder beside reference tools
- add renderer smoke coverage for UI hierarchy, model switching prompt preservation, prompt-only General reset, keyboard resize handles, long General labels, and history collapse
- mark the corresponding multi-model UI checklist/TODO items as smoke-backed while leaving real API and external platform gates open

## Validation
- pnpm build
- git diff --check