### PR TITLE
Stage v0.2.0 release metadata

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Release tag to publish, for example v0.1.0
+        description: Release tag to publish, for example v0.2.0
         required: true
         type: string
   push:

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -87,6 +87,7 @@
 - [x] 本机未压缩 app 可启动
 - [x] macOS dmg/zip 可生成
 - [x] macOS ad-hoc signed、未公证本地预览包可生成
+- [x] `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据已补齐
 - [x] dmg 可挂载、复制 app 并启动
 - [x] macOS 临时目录卸载与重装 smoke test 正常
 - [x] macOS dmg 安装 smoke test 可通过 `pnpm verify:release:mac` 自动复跑
@@ -103,6 +104,7 @@
 - [x] 真实 streaming 验收需要额外成本确认
 - [ ] Gemini / Nano Banana 3 真实 API 验收完成（已有受成本保护 verifier，仍需真实 Key 跑通并记录证据）
 - [x] 签名/公证 readiness 脚本不会暴露 secret 且不会尝试签名
+- [x] macOS release verifier 不再写死旧版本 dmg 文件名
 - [x] 配置迁移到当前 state v1 正常
 - [x] 长时间生成不会轻易超时
 
@@ -132,6 +134,7 @@
 - [x] release verifier 命令与平台限制已记录
 - [x] 文档未声明未验证的 Nano Banana 真实输出质量或 exact-mask 能力
 - [ ] 真实 OpenAI / Gemini 外部验收完成
+- [ ] 正式更新 manifest 已补充分发资产 URL、hash 和 size
 - [x] General 任意 provider fallback 完成
 
 ## 10. GPT Image 2 API 检查

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -196,8 +196,9 @@ pnpm package:mac:signed
 pnpm verify:release:mac
 ```
 
-After success, update release metadata, `CHECKLIST.md`, `TODO.md`, and
-`COMPLETION_AUDIT.md`, then close the related tracking issue if one exists.
+After success, update `docs/updates/latest.json` with the signed asset URL,
+hash, and size metadata, then update `CHECKLIST.md`, `TODO.md`, and
+`COMPLETION_AUDIT.md`. Close the related tracking issue if one exists.
 
 ## 5. Windows And Linux Native Validation
 

--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -6,6 +6,7 @@ Target release: `v0.2.0`
 
 - [x] 多生图模型支持被确认为 `v0.2.0` 核心版本目标
 - [x] `v0.2.0` release notes 覆盖 GPT Image 2、Nano Banana 3、General 支持
+- [x] `v0.2.0` package metadata 和更新 manifest 已对齐多模型发布目标
 - [x] `v0.2.0` 发布前完成多模型 mock 验证
 - [ ] `v0.2.0` 发布前完成至少一轮真实 OpenAI / Gemini API 外部验收
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -155,5 +155,6 @@ Target release: `v0.2.0`
 - [x] 更新 SECURITY.md 增加 Gemini Key 处理说明
 - [x] 更新 mock API 文档
 - [x] 更新 release verifier 说明
+- [x] 补齐 `v0.2.0` 发布包版本、描述、版权和更新 manifest 元数据
 - [x] 重新跑开源 secret scan
 - [x] 确认文档没有写死未验证的 Nano Banana 能力

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Image2Tools v0.2.0 Release Notes Draft
 
-Status: draft until real API acceptance, CI, signing/notarization, and native platform release gates are complete.
+Status: draft until real API acceptance, signed/notarized distribution assets, and native platform release gates are complete.
 
 ## Highlights
 
@@ -44,3 +44,7 @@ pnpm verify:release:linux
 ```
 
 Re-run the secret scan in [SECURITY.md](./SECURITY.md) after every release-note or packaging metadata update.
+
+The staged app package metadata is `0.2.0`. Do not publish `docs/updates/latest.json`
+with downloadable assets until the signed/notarized artifacts have verified URL,
+hash, and size metadata.

--- a/TODO.md
+++ b/TODO.md
@@ -117,6 +117,7 @@
 - [x] 增加受额外成本确认保护的真实 streaming 生成/编辑验收路径
 - [x] 增加 macOS 签名/公证 readiness 检查脚本
 - [x] 增加显式 Developer ID signed macOS 打包命令，默认 ad-hoc signed 试用包不受影响
+- [x] 补齐 `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据
 - [x] 在 Ubuntu ARM64 Docker 环境补充 Linux build、mock verifier、AppImage 打包、AppImage 解包与 Xvfb 启动烟测证据
 - [x] 增加 `pnpm verify:release:windows` 并接入 Windows CI package gate
 - [x] 将 Windows release verifier 扩展到 silent install / launch / uninstall 烟测
@@ -124,7 +125,7 @@
 - [x] 增加 `pnpm verify:release:linux` 并接入 Linux CI package gate
 - [x] 将 Linux release verifier 扩展到可选直接 AppImage 启动，原生验收可通过环境变量强制要求 FUSE
 - [x] 取得绿色 CI
-- [ ] 补充签名、公证与正式分发元数据
+- [ ] 完成签名、公证并补充正式分发资产 URL / hash / size 证据
 - [ ] 非 macOS 平台安装验证；Windows 与原生 Linux 桌面 shell 行为仍待验证
 - [x] 增加中英文界面切换
 

--- a/docs/updates/latest.json
+++ b/docs/updates/latest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.0",
-  "pubDate": "2026-05-19T00:00:00.000Z",
-  "notes": "Initial public update manifest. Add release assets when publishing the next version.",
+  "version": "0.2.0",
+  "pubDate": "2026-06-09T00:00:00.000Z",
+  "notes": "Multi-model workspace release metadata staged. Add signed and externally verified release assets before publishing the update manifest.",
   "assets": []
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image2tools",
-  "version": "0.1.0",
-  "description": "A simple GPT Image 2 desktop tool for generation, edits, inpainting, downloads, and local history.",
+  "version": "0.2.0",
+  "description": "A multi-model desktop image workspace for GPT Image 2, Nano Banana 3, and compatible image providers.",
   "author": "Nowo, Corgnitor, and Image2Tools contributors",
   "license": "MIT",
   "image2tools": {
@@ -40,6 +40,7 @@
   "build": {
     "appId": "com.bliveren.image2tools",
     "productName": "Image2Tools",
+    "copyright": "Copyright (c) 2026 Nowo, Corgnitor, and Image2Tools contributors",
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
     "directories": {
       "output": "release"

--- a/scripts/verify-mac-release.mjs
+++ b/scripts/verify-mac-release.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const dmgPath = path.resolve("release/Image2Tools-0.1.0-mac-arm64.dmg");
+const releaseDir = path.resolve("release");
+const dmgPattern = /^Image2Tools-.*-mac-.*\.dmg$/;
 const appName = "Image2Tools.app";
 const processName = "Image2Tools";
 const appExecutable = "Contents/MacOS/Image2Tools";
@@ -23,6 +24,17 @@ async function run(command, args, options = {}) {
   });
 }
 
+async function findDmg() {
+  const entries = await readdir(releaseDir, { withFileTypes: true });
+  const candidates = entries
+    .filter((entry) => entry.isFile() && dmgPattern.test(entry.name))
+    .map((entry) => path.join(releaseDir, entry.name));
+  if (candidates.length !== 1) {
+    throw new Error(`Expected one Image2Tools macOS dmg, found ${candidates.length}: ${candidates.join(", ") || "none"}`);
+  }
+  return candidates[0];
+}
+
 function parseMountPoint(output) {
   const line = output
     .split("\n")
@@ -38,7 +50,7 @@ function parseMountPoint(output) {
   return mountPoint;
 }
 
-async function attachDmg() {
+async function attachDmg(dmgPath) {
   const { stdout } = await run("hdiutil", ["attach", "-nobrowse", "-readonly", dmgPath]);
   return parseMountPoint(stdout);
 }
@@ -198,7 +210,8 @@ async function main() {
   const tempRoot = await mkdtemp(path.join("/tmp", "Image2Tools-release-test-"));
   let mountPoint;
   try {
-    mountPoint = await attachDmg();
+    const dmgPath = await findDmg();
+    mountPoint = await attachDmg(dmgPath);
     await runInstallCycle(mountPoint, tempRoot, 1);
     await runInstallCycle(mountPoint, tempRoot, 2);
     console.log("macOS release verification passed.");

--- a/src/shared/package-config.test.ts
+++ b/src/shared/package-config.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from "vitest";
 import packageJson from "../../package.json";
+import updateManifest from "../../docs/updates/latest.json";
 
 describe("package release configuration", () => {
+  it("stages the v0.2.0 multi-model release metadata", () => {
+    expect(packageJson.version).toBe("0.2.0");
+    expect(packageJson.description).toContain("multi-model desktop image workspace");
+    expect(packageJson.description).toContain("GPT Image 2");
+    expect(packageJson.description).toContain("Nano Banana 3");
+    expect(packageJson.build.copyright).toContain("Nowo");
+    expect(packageJson.build.copyright).toContain("Corgnitor");
+  });
+
+  it("keeps the update manifest staged until signed assets are published", () => {
+    expect(updateManifest.version).toBe(packageJson.version);
+    expect(updateManifest.assets).toEqual([]);
+    expect(updateManifest.notes).toContain("signed and externally verified release assets");
+  });
+
   it("keeps the Windows installer asset name stable for latest-release download links", () => {
     expect(packageJson.build.win.target).toContain("nsis");
     expect(packageJson.build.nsis.artifactName).toBe("Image2Tools-Setup.${ext}");


### PR DESCRIPTION
## Summary
- bump app package metadata to v0.2.0 with multi-model description and copyright metadata
- stage the update manifest for v0.2.0 while keeping downloadable assets empty until signed/external evidence exists
- make the macOS release verifier discover the current versioned dmg instead of hardcoding v0.1.0
- update release docs/checklists to distinguish staged metadata from signed asset URL/hash/size evidence

## Validation
- pnpm exec vitest run src/shared/package-config.test.ts src/shared/electron-builder-pnpm.test.ts
- pnpm typecheck
- node --check scripts/verify-mac-release.mjs
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery