### PR TITLE
Require update manifest asset sizes

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -88,6 +88,7 @@
 - [x] macOS dmg/zip 可生成
 - [x] macOS ad-hoc signed、未公证本地预览包可生成
 - [x] `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据已补齐
+- [x] 更新 manifest 资产 schema 会要求并校验 `sha256` 与 `sizeBytes`
 - [x] dmg 可挂载、复制 app 并启动
 - [x] macOS 临时目录卸载与重装 smoke test 正常
 - [x] macOS dmg 安装 smoke test 可通过 `pnpm verify:release:mac` 自动复跑

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -197,7 +197,7 @@ pnpm verify:release:mac
 ```
 
 After success, update `docs/updates/latest.json` with the signed asset URL,
-hash, and size metadata, then update `CHECKLIST.md`, `TODO.md`, and
+sha256, and `sizeBytes` metadata, then update `CHECKLIST.md`, `TODO.md`, and
 `COMPLETION_AUDIT.md`. Close the related tracking issue if one exists.
 
 ## 5. Windows And Linux Native Validation

--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -7,6 +7,7 @@ Target release: `v0.2.0`
 - [x] 多生图模型支持被确认为 `v0.2.0` 核心版本目标
 - [x] `v0.2.0` release notes 覆盖 GPT Image 2、Nano Banana 3、General 支持
 - [x] `v0.2.0` package metadata 和更新 manifest 已对齐多模型发布目标
+- [x] `v0.2.0` 更新 manifest schema 会要求并校验资产 `sha256` 与 `sizeBytes`
 - [x] `v0.2.0` 发布前完成多模型 mock 验证
 - [ ] `v0.2.0` 发布前完成至少一轮真实 OpenAI / Gemini API 外部验收
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -156,5 +156,6 @@ Target release: `v0.2.0`
 - [x] 更新 mock API 文档
 - [x] 更新 release verifier 说明
 - [x] 补齐 `v0.2.0` 发布包版本、描述、版权和更新 manifest 元数据
+- [x] 更新 manifest schema 和安装器下载校验要求 `sha256` 与 `sizeBytes`
 - [x] 重新跑开源 secret scan
 - [x] 确认文档没有写死未验证的 Nano Banana 能力

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,4 +47,4 @@ Re-run the secret scan in [SECURITY.md](./SECURITY.md) after every release-note 
 
 The staged app package metadata is `0.2.0`. Do not publish `docs/updates/latest.json`
 with downloadable assets until the signed/notarized artifacts have verified URL,
-hash, and size metadata.
+hash, and `sizeBytes` metadata.

--- a/TODO.md
+++ b/TODO.md
@@ -118,6 +118,7 @@
 - [x] 增加 macOS 签名/公证 readiness 检查脚本
 - [x] 增加显式 Developer ID signed macOS 打包命令，默认 ad-hoc signed 试用包不受影响
 - [x] 补齐 `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据
+- [x] 更新 manifest schema 和安装器下载校验要求 `sha256` 与 `sizeBytes`
 - [x] 在 Ubuntu ARM64 Docker 环境补充 Linux build、mock verifier、AppImage 打包、AppImage 解包与 Xvfb 启动烟测证据
 - [x] 增加 `pnpm verify:release:windows` 并接入 Windows CI package gate
 - [x] 将 Windows release verifier 扩展到 silent install / launch / uninstall 烟测

--- a/docs/updates/README.md
+++ b/docs/updates/README.md
@@ -12,8 +12,9 @@ https://bliveren.github.io/image2tools/updates/latest.json
 For each release:
 
 1. Upload installers to a GitHub Release.
-2. Compute SHA-256 hashes for each installer. Every asset must include a
-   lowercase 64-character `sha256` value before the app will open it.
+2. Compute SHA-256 hashes and byte sizes for each installer. Every asset must
+   include a lowercase 64-character `sha256` value and positive integer
+   `sizeBytes` value before the app will open it.
 3. Update `latest.json` so `version` is greater than the app version and each
    asset URL points to the matching GitHub Release download URL.
 4. Commit and push this directory to `main`.
@@ -26,7 +27,8 @@ Example asset:
   "arch": "x64",
   "url": "https://github.com/Bliveren/image2tools/releases/download/v0.2.0/Image2Tools-0.2.0-win-x64.exe",
   "fileName": "Image2Tools-0.2.0-win-x64.exe",
-  "sha256": "64-char-lowercase-sha256"
+  "sha256": "64-char-lowercase-sha256",
+  "sizeBytes": 12345678
 }
 ```
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -25,8 +25,6 @@ import type {
   RunJobRequest,
   UpdateCheckResult,
   UpdateInstallResult,
-  UpdateManifestAsset,
-  UpdatePlatform,
   WorkspaceDraft,
   WorkspaceDraftInput
 } from "../shared/types.js";
@@ -43,6 +41,7 @@ import {
   GPT_IMAGE_2_LAUNCH_ID,
   getModelDisplayName
 } from "../shared/modelCatalog.js";
+import { compareVersions, isAllowedUpdateUrl, parseUpdateManifest, safeUpdateFileName, selectUpdateAsset } from "../shared/updateManifest.js";
 import { fetchWithTimeout } from "./services/openaiImage.js";
 import { getImageProviderAdapter, getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModels, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
@@ -50,6 +49,7 @@ import { buildProviderConfigForSave, providerDisplayName } from "./services/prov
 import { assertKnownOutputPath, assertManagedRegularFile, collectOwnedJobFilePaths, normalizeManagedAssetPath } from "./services/assetOwnership.js";
 import { recoverInterruptedJobs } from "./services/stateRecovery.js";
 import { type AppStateFile, type StoredProviderConfig, STATE_VERSION, getDefaultState, normalizeImageParams, normalizeState } from "./services/stateMigration.js";
+import { verifyUpdateAssetBytes } from "./services/updateInstallerVerification.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MAX_HISTORY = 100;
@@ -68,13 +68,6 @@ protocol.registerSchemesAsPrivileged([
     }
   }
 ]);
-
-interface UpdateManifest {
-  version?: unknown;
-  notes?: unknown;
-  pubDate?: unknown;
-  assets?: unknown;
-}
 
 interface PackageMetadata {
   image2tools?: {
@@ -333,114 +326,6 @@ function sanitizeError(error: unknown): string {
 
 function redactLikelySecrets(value: string): string {
   return value.replace(/sk-[A-Za-z0-9_-]{8,}/g, "sk-...redacted");
-}
-
-function compareVersions(a: string, b: string): number {
-  const left = parseVersion(a);
-  const right = parseVersion(b);
-  const length = Math.max(left.length, right.length);
-  for (let index = 0; index < length; index += 1) {
-    const diff = (left[index] ?? 0) - (right[index] ?? 0);
-    if (diff !== 0) return diff > 0 ? 1 : -1;
-  }
-  return 0;
-}
-
-function parseVersion(version: string): number[] {
-  return version
-    .replace(/^v/i, "")
-    .split(/[.-]/)
-    .map((part) => Number.parseInt(part, 10))
-    .map((part) => (Number.isFinite(part) ? part : 0));
-}
-
-function parseUpdateManifest(payload: unknown): { version: string; notes?: string; pubDate?: string; assets: UpdateManifestAsset[] } {
-  if (!isRecord(payload)) {
-    throw new Error("更新 manifest 格式无效。");
-  }
-
-  const manifest = payload as UpdateManifest;
-  if (typeof manifest.version !== "string" || !manifest.version.trim()) {
-    throw new Error("更新 manifest 缺少 version。");
-  }
-  if (!Array.isArray(manifest.assets)) {
-    throw new Error("更新 manifest 缺少 assets。");
-  }
-
-  return {
-    version: manifest.version.trim(),
-    notes: typeof manifest.notes === "string" ? manifest.notes : undefined,
-    pubDate: typeof manifest.pubDate === "string" ? manifest.pubDate : undefined,
-    assets: manifest.assets.map(parseUpdateAsset)
-  };
-}
-
-function parseUpdateAsset(value: unknown): UpdateManifestAsset {
-  if (!isRecord(value)) {
-    throw new Error("更新资源格式无效。");
-  }
-  if (!isUpdatePlatform(value.platform)) {
-    throw new Error("更新资源平台无效。");
-  }
-  if (typeof value.url !== "string" || !isAllowedUpdateUrl(value.url)) {
-    throw new Error("更新资源 URL 必须是 https，或本地调试用 http loopback。");
-  }
-  if (value.arch !== undefined && typeof value.arch !== "string") {
-    throw new Error("更新资源架构无效。");
-  }
-  if (value.fileName !== undefined && typeof value.fileName !== "string") {
-    throw new Error("更新资源文件名无效。");
-  }
-  if (typeof value.sha256 !== "string" || !/^[a-f0-9]{64}$/i.test(value.sha256)) {
-    throw new Error("更新资源必须提供 64 位 sha256。");
-  }
-  return {
-    platform: value.platform,
-    arch: typeof value.arch === "string" && value.arch.trim() ? value.arch.trim() : undefined,
-    url: value.url,
-    fileName: typeof value.fileName === "string" && value.fileName.trim() ? value.fileName.trim() : undefined,
-    sha256: value.sha256.toLowerCase()
-  };
-}
-
-function selectUpdateAsset(assets: UpdateManifestAsset[]): UpdateManifestAsset | undefined {
-  const platform = process.platform as UpdatePlatform;
-  const arch = process.arch;
-  return (
-    assets.find((asset) => asset.platform === platform && asset.arch === arch) ??
-    assets.find((asset) => asset.platform === platform && !asset.arch) ??
-    assets.find((asset) => asset.platform === "all" && asset.arch === arch) ??
-    assets.find((asset) => asset.platform === "all" && !asset.arch)
-  );
-}
-
-function isUpdatePlatform(value: unknown): value is UpdatePlatform {
-  return value === "darwin" || value === "win32" || value === "linux" || value === "all";
-}
-
-function isAllowedUpdateUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    if (url.protocol === "https:") return true;
-    return url.protocol === "http:" && isLoopbackHostname(url.hostname);
-  } catch {
-    return false;
-  }
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function safeUpdateFileName(asset: UpdateManifestAsset): string {
-  const fromManifest = asset.fileName?.trim();
-  if (fromManifest) return path.basename(fromManifest);
-  const fromUrl = path.basename(new URL(asset.url).pathname);
-  return fromUrl || `Image2Tools-update-${Date.now()}`;
 }
 
 function getUpdatesDir(): string {
@@ -870,7 +755,7 @@ async function handleCheckForUpdates(): Promise<UpdateCheckResult> {
     }
 
     const manifest = parseUpdateManifest(await response.json());
-    const asset = selectUpdateAsset(manifest.assets);
+    const asset = selectUpdateAsset(manifest.assets, process.platform, process.arch);
     const updateAvailable = compareVersions(manifest.version, currentVersion) > 0;
     latestUpdateCheck = {
       status: updateAvailable && asset ? "available" : "current",
@@ -912,10 +797,7 @@ async function handleDownloadAndInstallUpdate(): Promise<UpdateInstallResult> {
   }
 
   const bytes = Buffer.from(await response.arrayBuffer());
-  const actual = createHash("sha256").update(bytes).digest("hex");
-  if (actual !== update.asset.sha256) {
-    throw new Error("更新包校验失败。");
-  }
+  verifyUpdateAssetBytes(update.asset, bytes);
 
   await fs.writeFile(filePath, bytes);
   if (process.platform !== "win32") {

--- a/src/main/services/updateInstallerVerification.test.ts
+++ b/src/main/services/updateInstallerVerification.test.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { verifyUpdateAssetBytes } from "./updateInstallerVerification";
+
+describe("update installer verification", () => {
+  it("verifies downloaded installer size and sha256", () => {
+    const bytes = new TextEncoder().encode("installer");
+    const digest = createHash("sha256").update(bytes).digest("hex");
+    const asset = {
+      platform: "all" as const,
+      url: "https://example.com/Image2Tools.dmg",
+      sha256: digest,
+      sizeBytes: bytes.byteLength
+    };
+
+    expect(() => verifyUpdateAssetBytes(asset, bytes)).not.toThrow();
+    expect(() => verifyUpdateAssetBytes({ ...asset, sizeBytes: bytes.byteLength + 1 }, bytes)).toThrow("大小");
+    expect(() => verifyUpdateAssetBytes({ ...asset, sha256: "b".repeat(64) }, bytes)).toThrow("校验");
+  });
+});

--- a/src/main/services/updateInstallerVerification.ts
+++ b/src/main/services/updateInstallerVerification.ts
@@ -1,0 +1,12 @@
+import { createHash } from "node:crypto";
+import type { UpdateManifestAsset } from "../../shared/types.js";
+
+export function verifyUpdateAssetBytes(asset: UpdateManifestAsset, bytes: Uint8Array): void {
+  if (bytes.byteLength !== asset.sizeBytes) {
+    throw new Error("更新包大小校验失败。");
+  }
+  const actual = createHash("sha256").update(bytes).digest("hex");
+  if (actual !== asset.sha256) {
+    throw new Error("更新包校验失败。");
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -236,6 +236,7 @@ export interface UpdateManifestAsset {
   url: string;
   fileName?: string;
   sha256: string;
+  sizeBytes: number;
 }
 
 export interface UpdateCheckResult {

--- a/src/shared/updateManifest.test.ts
+++ b/src/shared/updateManifest.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { parseUpdateManifest, safeUpdateFileName, selectUpdateAsset } from "./updateManifest";
+
+const sha256 = "a".repeat(64);
+
+describe("update manifest", () => {
+  it("parses signed asset metadata including sha256 and size", () => {
+    const manifest = parseUpdateManifest({
+      version: " v0.2.1 ",
+      notes: "Release",
+      pubDate: "2026-06-09T00:00:00.000Z",
+      assets: [
+        {
+          platform: "win32",
+          arch: "x64",
+          url: "https://github.com/Bliveren/image2tools/releases/download/v0.2.1/Image2Tools-Setup.exe",
+          fileName: "Image2Tools-Setup.exe",
+          sha256: sha256.toUpperCase(),
+          sizeBytes: 123456
+        }
+      ]
+    });
+
+    expect(manifest.version).toBe("v0.2.1");
+    expect(manifest.assets[0]).toEqual({
+      platform: "win32",
+      arch: "x64",
+      url: "https://github.com/Bliveren/image2tools/releases/download/v0.2.1/Image2Tools-Setup.exe",
+      fileName: "Image2Tools-Setup.exe",
+      sha256,
+      sizeBytes: 123456
+    });
+  });
+
+  it("rejects assets without positive integer sizeBytes", () => {
+    expect(() =>
+      parseUpdateManifest({
+        version: "0.2.1",
+        assets: [
+          {
+            platform: "darwin",
+            url: "https://github.com/Bliveren/image2tools/releases/download/v0.2.1/Image2Tools-0.2.1-mac-arm64.dmg",
+            sha256,
+            sizeBytes: 0
+          }
+        ]
+      })
+    ).toThrow("sizeBytes");
+  });
+
+  it("selects exact platform and arch before platform-only fallback", () => {
+    const exact = {
+      platform: "linux" as const,
+      arch: "arm64",
+      url: "https://example.com/arm64.AppImage",
+      sha256,
+      sizeBytes: 10
+    };
+    const fallback = {
+      platform: "linux" as const,
+      url: "https://example.com/generic.AppImage",
+      sha256,
+      sizeBytes: 20
+    };
+
+    expect(selectUpdateAsset([fallback, exact], "linux", "arm64")).toBe(exact);
+    expect(selectUpdateAsset([fallback, exact], "linux", "x64")).toBe(fallback);
+  });
+
+  it("uses a safe basename for manifest file names", () => {
+    expect(
+      safeUpdateFileName({
+        platform: "win32",
+        url: "https://example.com/download.exe",
+        fileName: "../Image2Tools-Setup.exe",
+        sha256,
+        sizeBytes: 10
+      })
+    ).toBe("Image2Tools-Setup.exe");
+  });
+});

--- a/src/shared/updateManifest.ts
+++ b/src/shared/updateManifest.ts
@@ -1,0 +1,135 @@
+import type { UpdateManifestAsset, UpdatePlatform } from "./types.js";
+
+interface RawUpdateManifest {
+  version?: unknown;
+  notes?: unknown;
+  pubDate?: unknown;
+  assets?: unknown;
+}
+
+export interface ParsedUpdateManifest {
+  version: string;
+  notes?: string;
+  pubDate?: string;
+  assets: UpdateManifestAsset[];
+}
+
+export function compareVersions(a: string, b: string): number {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const diff = (left[index] ?? 0) - (right[index] ?? 0);
+    if (diff !== 0) return diff > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+export function parseVersion(version: string): number[] {
+  return version
+    .replace(/^v/i, "")
+    .split(/[.-]/)
+    .map((part) => Number.parseInt(part, 10))
+    .map((part) => (Number.isFinite(part) ? part : 0));
+}
+
+export function parseUpdateManifest(payload: unknown): ParsedUpdateManifest {
+  if (!isRecord(payload)) {
+    throw new Error("更新 manifest 格式无效。");
+  }
+
+  const manifest = payload as RawUpdateManifest;
+  if (typeof manifest.version !== "string" || !manifest.version.trim()) {
+    throw new Error("更新 manifest 缺少 version。");
+  }
+  if (!Array.isArray(manifest.assets)) {
+    throw new Error("更新 manifest 缺少 assets。");
+  }
+
+  return {
+    version: manifest.version.trim(),
+    notes: typeof manifest.notes === "string" ? manifest.notes : undefined,
+    pubDate: typeof manifest.pubDate === "string" ? manifest.pubDate : undefined,
+    assets: manifest.assets.map(parseUpdateAsset)
+  };
+}
+
+export function parseUpdateAsset(value: unknown): UpdateManifestAsset {
+  if (!isRecord(value)) {
+    throw new Error("更新资源格式无效。");
+  }
+  if (!isUpdatePlatform(value.platform)) {
+    throw new Error("更新资源平台无效。");
+  }
+  if (typeof value.url !== "string" || !isAllowedUpdateUrl(value.url)) {
+    throw new Error("更新资源 URL 必须是 https，或本地调试用 http loopback。");
+  }
+  if (value.arch !== undefined && typeof value.arch !== "string") {
+    throw new Error("更新资源架构无效。");
+  }
+  if (value.fileName !== undefined && typeof value.fileName !== "string") {
+    throw new Error("更新资源文件名无效。");
+  }
+  if (typeof value.sha256 !== "string" || !/^[a-f0-9]{64}$/i.test(value.sha256)) {
+    throw new Error("更新资源必须提供 64 位 sha256。");
+  }
+  const sizeBytes = value.sizeBytes;
+  if (!Number.isSafeInteger(sizeBytes) || typeof sizeBytes !== "number" || sizeBytes <= 0) {
+    throw new Error("更新资源必须提供正整数 sizeBytes。");
+  }
+  return {
+    platform: value.platform,
+    arch: typeof value.arch === "string" && value.arch.trim() ? value.arch.trim() : undefined,
+    url: value.url,
+    fileName: typeof value.fileName === "string" && value.fileName.trim() ? value.fileName.trim() : undefined,
+    sha256: value.sha256.toLowerCase(),
+    sizeBytes
+  };
+}
+
+export function selectUpdateAsset(
+  assets: UpdateManifestAsset[],
+  platform: string,
+  arch: string
+): UpdateManifestAsset | undefined {
+  return (
+    assets.find((asset) => asset.platform === platform && asset.arch === arch) ??
+    assets.find((asset) => asset.platform === platform && !asset.arch) ??
+    assets.find((asset) => asset.platform === "all" && asset.arch === arch) ??
+    assets.find((asset) => asset.platform === "all" && !asset.arch)
+  );
+}
+
+export function isUpdatePlatform(value: unknown): value is UpdatePlatform {
+  return value === "darwin" || value === "win32" || value === "linux" || value === "all";
+}
+
+export function isAllowedUpdateUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol === "https:") return true;
+    return url.protocol === "http:" && isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function safeUpdateFileName(asset: UpdateManifestAsset): string {
+  const fromManifest = asset.fileName?.trim();
+  if (fromManifest) return basename(fromManifest);
+  const fromUrl = basename(new URL(asset.url).pathname);
+  return fromUrl || `Image2Tools-update-${Date.now()}`;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function basename(value: string): string {
+  const normalized = value.replace(/\\/g, "/");
+  return normalized.split("/").filter(Boolean).pop() ?? "";
+}


### PR DESCRIPTION
## Summary
- extract update manifest parsing/selection into a shared helper with tests
- require release update assets to declare positive integer sizeBytes alongside sha256
- verify downloaded installer byte length before sha256/opening
- update release runbook/docs/checklists to name the sizeBytes requirement without closing the signed asset evidence gate

## Validation
- pnpm exec vitest run src/shared/updateManifest.test.ts src/main/services/updateInstallerVerification.test.ts src/shared/package-config.test.ts
- pnpm typecheck
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery