### PR TITLE
Add update manifest asset helper

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -89,6 +89,7 @@
 - [x] macOS ad-hoc signed、未公证本地预览包可生成
 - [x] `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据已补齐
 - [x] 更新 manifest 资产 schema 会要求并校验 `sha256` 与 `sizeBytes`
+- [x] update manifest 资产条目生成脚本会从本地 artifact 计算 `sha256` 与 `sizeBytes`
 - [x] dmg 可挂载、复制 app 并启动
 - [x] macOS 临时目录卸载与重装 smoke test 正常
 - [x] macOS dmg 安装 smoke test 可通过 `pnpm verify:release:mac` 自动复跑

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -196,8 +196,10 @@ pnpm package:mac:signed
 pnpm verify:release:mac
 ```
 
-After success, update `docs/updates/latest.json` with the signed asset URL,
-sha256, and `sizeBytes` metadata, then update `CHECKLIST.md`, `TODO.md`, and
+After success, use `pnpm update:manifest-asset -- --file <signed-artifact>
+--platform darwin --arch <arch> --url <release-asset-url>` to generate the
+signed asset URL, sha256, and `sizeBytes` metadata for
+`docs/updates/latest.json`, then update `CHECKLIST.md`, `TODO.md`, and
 `COMPLETION_AUDIT.md`. Close the related tracking issue if one exists.
 
 ## 5. Windows And Linux Native Validation

--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -8,6 +8,7 @@ Target release: `v0.2.0`
 - [x] `v0.2.0` release notes 覆盖 GPT Image 2、Nano Banana 3、General 支持
 - [x] `v0.2.0` package metadata 和更新 manifest 已对齐多模型发布目标
 - [x] `v0.2.0` 更新 manifest schema 会要求并校验资产 `sha256` 与 `sizeBytes`
+- [x] `v0.2.0` update manifest 资产条目可由脚本从本地 artifact 生成
 - [x] `v0.2.0` 发布前完成多模型 mock 验证
 - [ ] `v0.2.0` 发布前完成至少一轮真实 OpenAI / Gemini API 外部验收
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -157,5 +157,6 @@ Target release: `v0.2.0`
 - [x] 更新 release verifier 说明
 - [x] 补齐 `v0.2.0` 发布包版本、描述、版权和更新 manifest 元数据
 - [x] 更新 manifest schema 和安装器下载校验要求 `sha256` 与 `sizeBytes`
+- [x] 增加 update manifest 资产条目生成脚本，降低正式分发元数据手工出错风险
 - [x] 重新跑开源 secret scan
 - [x] 确认文档没有写死未验证的 Nano Banana 能力

--- a/TODO.md
+++ b/TODO.md
@@ -119,6 +119,7 @@
 - [x] 增加显式 Developer ID signed macOS 打包命令，默认 ad-hoc signed 试用包不受影响
 - [x] 补齐 `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据
 - [x] 更新 manifest schema 和安装器下载校验要求 `sha256` 与 `sizeBytes`
+- [x] 增加 update manifest 资产条目生成脚本，降低正式分发元数据手工出错风险
 - [x] 在 Ubuntu ARM64 Docker 环境补充 Linux build、mock verifier、AppImage 打包、AppImage 解包与 Xvfb 启动烟测证据
 - [x] 增加 `pnpm verify:release:windows` 并接入 Windows CI package gate
 - [x] 将 Windows release verifier 扩展到 silent install / launch / uninstall 烟测

--- a/docs/updates/README.md
+++ b/docs/updates/README.md
@@ -15,9 +15,11 @@ For each release:
 2. Compute SHA-256 hashes and byte sizes for each installer. Every asset must
    include a lowercase 64-character `sha256` value and positive integer
    `sizeBytes` value before the app will open it.
-3. Update `latest.json` so `version` is greater than the app version and each
+3. Generate asset entries with `pnpm update:manifest-asset -- --file <path>
+   --platform <darwin|win32|linux|all> --url <https-url> [--arch <arch>]`.
+4. Update `latest.json` so `version` is greater than the app version and each
    asset URL points to the matching GitHub Release download URL.
-4. Commit and push this directory to `main`.
+5. Commit and push this directory to `main`.
 
 Example asset:
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "verify:release:windows": "node scripts/verify-windows-release.mjs",
     "verify:real-api": "node scripts/verify-real-api.mjs",
     "verify:real-gemini-api": "node scripts/verify-real-gemini-api.mjs",
-    "verify:signing-ready": "node scripts/verify-signing-readiness.mjs"
+    "verify:signing-ready": "node scripts/verify-signing-readiness.mjs",
+    "update:manifest-asset": "node scripts/update-manifest-asset.mjs"
   },
   "build": {
     "appId": "com.bliveren.image2tools",

--- a/scripts/update-manifest-asset.mjs
+++ b/scripts/update-manifest-asset.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+const validPlatforms = new Set(["darwin", "win32", "linux", "all"]);
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/update-manifest-asset.mjs --file <path> --platform <darwin|win32|linux|all> --url <https-url> [--arch <arch>] [--file-name <name>]",
+    "",
+    "Outputs a docs/updates/latest.json asset entry with sha256 and sizeBytes."
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}\n${usage()}`);
+    }
+    const key = arg.slice(2);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}\n${usage()}`);
+    }
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function assertHttpsUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("--url must be a valid HTTPS URL.");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("--url must use HTTPS for release manifests.");
+  }
+}
+
+async function buildAsset({ file, platform, url, arch, fileName }) {
+  if (!file) throw new Error(`Missing --file.\n${usage()}`);
+  if (!validPlatforms.has(platform)) {
+    throw new Error(`--platform must be one of: ${[...validPlatforms].join(", ")}`);
+  }
+  if (!url) throw new Error(`Missing --url.\n${usage()}`);
+  assertHttpsUrl(url);
+
+  const filePath = path.resolve(file);
+  const fileStat = await stat(filePath);
+  if (!fileStat.isFile()) {
+    throw new Error(`--file must point to a regular file: ${filePath}`);
+  }
+  const bytes = await readFile(filePath);
+  const asset = {
+    platform,
+    url,
+    fileName: fileName?.trim() || path.basename(filePath),
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    sizeBytes: fileStat.size
+  };
+  if (arch?.trim()) {
+    asset.arch = arch.trim();
+  }
+  return asset;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const asset = await buildAsset({
+    file: args.file,
+    platform: args.platform,
+    url: args.url,
+    arch: args.arch,
+    fileName: args["file-name"]
+  });
+  console.log(JSON.stringify(asset, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/update-manifest-asset.test.mjs
+++ b/scripts/update-manifest-asset.test.mjs
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = path.resolve("scripts/update-manifest-asset.mjs");
+const execFileAsync = promisify(execFile);
+
+async function run(args) {
+  try {
+    const result = await execFileAsync("node", [scriptPath, ...args]);
+    return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error) {
+      return {
+        exitCode: Number(error.code),
+        stdout: "stdout" in error ? String(error.stdout ?? "") : "",
+        stderr: "stderr" in error ? String(error.stderr ?? "") : ""
+      };
+    }
+    throw error;
+  }
+}
+
+describe("update manifest asset helper", () => {
+  it("prints a manifest asset with sha256 and sizeBytes", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "image2tools-update-asset-"));
+    try {
+      const artifactPath = path.join(tempRoot, "Image2Tools-0.2.0-mac-arm64.dmg");
+      const bytes = Buffer.from("signed artifact bytes");
+      await writeFile(artifactPath, bytes);
+
+      const result = await run([
+        "--file",
+        artifactPath,
+        "--platform",
+        "darwin",
+        "--arch",
+        "arm64",
+        "--url",
+        "https://github.com/Bliveren/image2tools/releases/download/v0.2.0/Image2Tools-0.2.0-mac-arm64.dmg"
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        platform: "darwin",
+        arch: "arm64",
+        url: "https://github.com/Bliveren/image2tools/releases/download/v0.2.0/Image2Tools-0.2.0-mac-arm64.dmg",
+        fileName: "Image2Tools-0.2.0-mac-arm64.dmg",
+        sha256: createHash("sha256").update(bytes).digest("hex"),
+        sizeBytes: bytes.length
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-HTTPS release URLs", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "image2tools-update-asset-"));
+    try {
+      const artifactPath = path.join(tempRoot, "Image2Tools-Setup.exe");
+      await writeFile(artifactPath, "installer");
+
+      const result = await run([
+        "--file",
+        artifactPath,
+        "--platform",
+        "win32",
+        "--url",
+        "http://example.com/Image2Tools-Setup.exe"
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("HTTPS");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,6 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"]
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "scripts/**/*.test.mjs"]
   }
 });


### PR DESCRIPTION
## Summary
- add pnpm update:manifest-asset to generate release manifest asset JSON from a local artifact
- compute sha256 and sizeBytes automatically while requiring HTTPS release URLs
- include the helper in Vitest coverage and update the external acceptance/update feed docs
- mark only the helper/tooling guardrail complete; signed asset evidence remains open

## Validation
- pnpm exec vitest run scripts/update-manifest-asset.test.mjs src/shared/updateManifest.test.ts src/shared/package-config.test.ts
- pnpm update:manifest-asset -- --file <tmpfile> --platform all --url https://example.com/Image2Tools-test.dmg
- pnpm typecheck
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery