### PR TITLE
Add release evidence validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 dist-renderer/
 release/
+!docs/release/
+!docs/release/**
 real-api-artifacts/
 coverage/
 .DS_Store

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -90,6 +90,7 @@
 - [x] `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据已补齐
 - [x] 更新 manifest 资产 schema 会要求并校验 `sha256` 与 `sizeBytes`
 - [x] update manifest 资产条目生成脚本会从本地 artifact 计算 `sha256` 与 `sizeBytes`
+- [x] 外部发布证据 ledger 可校验 schema、脱敏和最终完成状态
 - [x] dmg 可挂载、复制 app 并启动
 - [x] macOS 临时目录卸载与重装 smoke test 正常
 - [x] macOS dmg 安装 smoke test 可通过 `pnpm verify:release:mac` 自动复跑

--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -34,6 +34,7 @@ license without leaking secrets or private local artifacts.
 | Windows packaging | `package.json` has `package:win`; electron-builder has an NSIS Windows target; `.github/workflows/ci.yml` includes a Windows package job; `scripts/verify-windows-release.mjs` validates installer metadata and unpacked app launch in CI package-smoke mode, and defaults to full silent install / installed app launch / silent uninstall for native release validation | Configured; native Windows execution required for final binary acceptance |
 | macOS packaging | `package:mac`, mac icon, DMG/ZIP targets, and macOS release verifier are present | Configured |
 | Linux packaging | AppImage target and Linux verifier are present | Configured |
+| External release evidence | `docs/release/evidence.json` records real API, signing, native platform, and update-manifest gates; `pnpm verify:release-evidence` validates schema and redaction while `--require-complete` blocks publishing until all required gates pass | Configured; external evidence still pending |
 | Tests | `pnpm build`, targeted Vitest, `pnpm verify:mock-api`, dependency license scan, and `git diff --check` pass on the current worktree | Done |
 
 ## Current Verification Commands
@@ -63,7 +64,8 @@ blocking hits.
 ## Remaining External Gates
 
 - Real API acceptance requires a user-provided key and explicit cost
-  confirmation through `pnpm verify:real-api`.
+  confirmation through `pnpm verify:real-api`; evidence must be recorded in
+  `docs/release/evidence.json`.
 - Windows installer verification must be run on Windows with:
 
   ```powershell
@@ -73,5 +75,8 @@ blocking hits.
 
 - Signed and notarized macOS distribution requires external Developer ID and
   Apple notarization credentials supplied through local env vars or CI secrets.
+- Final publication should run
+  `pnpm verify:release-evidence -- --require-complete` after all external
+  evidence is recorded.
 - Public release artifacts should be generated after rerunning the
   pre-publication scan documented in `SECURITY.md`.

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -61,6 +61,7 @@ Expected coverage:
 - optional streaming generation and edit partial/final events
 
 Artifacts are written to ignored `real-api-artifacts/`. After success, update
+`docs/release/evidence.json`, run `pnpm verify:release-evidence`, update
 `CHECKLIST.md`, `TODO.md`, and `COMPLETION_AUDIT.md`, then close the related
 tracking issue if one exists.
 
@@ -133,10 +134,11 @@ Expected results:
   non-focused Gemini image model if available to confirm the prompt/reference
   path; OpenAI-compatible General remains prompt-only.
 
-After success, update `MULTI_MODEL_CHECKLIST.md`, `CHECKLIST.md`, `TODO.md`,
-and `COMPLETION_AUDIT.md` with OS/version, app commit, provider/model IDs, and
-redacted evidence. Do not commit real generated artifacts unless they are
-approved public assets.
+After success, update `docs/release/evidence.json`,
+`MULTI_MODEL_CHECKLIST.md`, `CHECKLIST.md`, `TODO.md`, and
+`COMPLETION_AUDIT.md` with OS/version, app commit, provider/model IDs, and
+redacted evidence. Run `pnpm verify:release-evidence` before committing. Do not
+commit real generated artifacts unless they are approved public assets.
 
 ## 3. GitHub Actions Billing Gate
 
@@ -199,8 +201,10 @@ pnpm verify:release:mac
 After success, use `pnpm update:manifest-asset -- --file <signed-artifact>
 --platform darwin --arch <arch> --url <release-asset-url>` to generate the
 signed asset URL, sha256, and `sizeBytes` metadata for
-`docs/updates/latest.json`, then update `CHECKLIST.md`, `TODO.md`, and
-`COMPLETION_AUDIT.md`. Close the related tracking issue if one exists.
+`docs/updates/latest.json`, then update `docs/release/evidence.json`,
+`CHECKLIST.md`, `TODO.md`, and `COMPLETION_AUDIT.md`. Run
+`pnpm verify:release-evidence` before committing. Close the related tracking
+issue if one exists.
 
 ## 5. Windows And Linux Native Validation
 
@@ -260,8 +264,9 @@ Manual platform checks:
 - open-folder behavior works for that OS
 
 Record OS/version, package artifact paths, launch results, and any
-platform-specific notes in `CHECKLIST.md` and `COMPLETION_AUDIT.md`, then close
-the related tracking issue if one exists.
+platform-specific notes in `docs/release/evidence.json`, `CHECKLIST.md`, and
+`COMPLETION_AUDIT.md`, then run `pnpm verify:release-evidence` and close the
+related tracking issue if one exists.
 
 ## Final Completion Pass
 
@@ -273,6 +278,7 @@ pnpm verify:mock-api
 pnpm verify:mock-gemini-api
 pnpm verify:mock-model-discovery
 pnpm verify:release:mac
+pnpm verify:release-evidence -- --require-complete
 git status --short --branch
 ```
 

--- a/MULTI_MODEL_CHECKLIST.md
+++ b/MULTI_MODEL_CHECKLIST.md
@@ -9,6 +9,7 @@ Target release: `v0.2.0`
 - [x] `v0.2.0` package metadata 和更新 manifest 已对齐多模型发布目标
 - [x] `v0.2.0` 更新 manifest schema 会要求并校验资产 `sha256` 与 `sizeBytes`
 - [x] `v0.2.0` update manifest 资产条目可由脚本从本地 artifact 生成
+- [x] `v0.2.0` 外部发布证据有统一 ledger 和 validator
 - [x] `v0.2.0` 发布前完成多模型 mock 验证
 - [ ] `v0.2.0` 发布前完成至少一轮真实 OpenAI / Gemini API 外部验收
 

--- a/MULTI_MODEL_TODO.md
+++ b/MULTI_MODEL_TODO.md
@@ -158,5 +158,6 @@ Target release: `v0.2.0`
 - [x] 补齐 `v0.2.0` 发布包版本、描述、版权和更新 manifest 元数据
 - [x] 更新 manifest schema 和安装器下载校验要求 `sha256` 与 `sizeBytes`
 - [x] 增加 update manifest 资产条目生成脚本，降低正式分发元数据手工出错风险
+- [x] 增加外部发布证据 ledger 与 validator，避免真实 API、签名、原生平台和正式 manifest 证据自由散落
 - [x] 重新跑开源 secret scan
 - [x] 确认文档没有写死未验证的 Nano Banana 能力

--- a/README.md
+++ b/README.md
@@ -118,11 +118,14 @@ pnpm package:win
 pnpm verify:release:mac
 pnpm verify:release:windows
 pnpm verify:release:linux
+pnpm verify:release-evidence
 ```
 
 `pnpm build` runs type checks, Vitest, the renderer build, and the Electron main build. `pnpm verify:mock-api` exercises the mock OpenAI Image API path. `pnpm verify:mock-gemini-api` exercises Gemini `generateContent`, guided-region requests, request recording, and Gemini-style error paths. `pnpm verify:mock-model-discovery` checks OpenAI/Gemini discovery fixtures, missing focused-model cases, General Gemini candidate detection, and Gemini discovery auth errors. `pnpm package:dir` creates an unpacked app for local inspection. `pnpm package:mac` creates local ad-hoc macOS packages; use `pnpm package:mac:signed` only when Developer ID and notarization environment variables are configured.
 
 `pnpm verify:release:windows` defaults to full native Windows verification, including the NSIS silent install, installed-app launch, and silent uninstall cycle. Hosted GitHub workflows use `IMAGE2TOOLS_WINDOWS_VERIFY_MODE=package-smoke` to keep installer PE checks and unpacked-app launch smoke coverage without depending on the hosted runner's installer policy.
+
+`pnpm verify:release-evidence` validates the external-gate ledger in [`docs/release/evidence.json`](./docs/release/evidence.json). Use `pnpm verify:release-evidence -- --require-complete` before publishing to require every real API, signing, native platform, and update-manifest gate to have passed evidence.
 
 ## Mock API
 
@@ -186,6 +189,8 @@ IMAGE2TOOLS_GEMINI_API_KEY=... IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 pnpm ve
 ```
 
 Gemini / Nano Banana 3 real API acceptance still needs the app-level history and download checks documented in [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md) before it can be marked complete.
+
+Record real API, signing, native platform, and formal update-manifest evidence in [`docs/release/evidence.json`](./docs/release/evidence.json). The ledger must stay redacted and pass `pnpm verify:release-evidence` before checklist items are marked complete.
 
 ## Icon
 
@@ -348,11 +353,14 @@ pnpm package:win
 pnpm verify:release:mac
 pnpm verify:release:windows
 pnpm verify:release:linux
+pnpm verify:release-evidence
 ```
 
 `pnpm build` 会执行类型检查、Vitest、renderer 构建和 Electron main 构建。`pnpm verify:mock-api` 覆盖 mock OpenAI Image API 链路。`pnpm verify:mock-gemini-api` 覆盖 Gemini `generateContent`、引导式区域请求、请求记录和 Gemini 风格错误路径。`pnpm verify:mock-model-discovery` 覆盖 OpenAI/Gemini 探测 fixture、缺少重点模型时的状态、General Gemini 候选模型识别和 Gemini 探测鉴权错误。`pnpm package:dir` 生成未压缩应用目录，适合本地检查。`pnpm package:mac` 生成本地 ad-hoc macOS 包；具备 Developer ID 和公证环境变量后再使用 `pnpm package:mac:signed`。
 
 `pnpm verify:release:windows` 默认执行完整原生 Windows 验证，包括 NSIS 静默安装、已安装应用启动和静默卸载。Hosted GitHub workflow 使用 `IMAGE2TOOLS_WINDOWS_VERIFY_MODE=package-smoke` 保留安装包 PE 检查和未压缩应用启动烟测，同时避开托管 runner 的安装器策略差异。
+
+`pnpm verify:release-evidence` 校验 [`docs/release/evidence.json`](./docs/release/evidence.json) 中的外部验收证据。发布前使用 `pnpm verify:release-evidence -- --require-complete` 强制要求真实 API、签名、原生平台和更新 manifest 证据全部通过。
 
 ## Mock API 验证
 
@@ -416,6 +424,8 @@ IMAGE2TOOLS_GEMINI_API_KEY=... IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 pnpm ve
 ```
 
 Gemini / Nano Banana 3 真实 API 验收仍需完成 [EXTERNAL_ACCEPTANCE.md](./EXTERNAL_ACCEPTANCE.md) 中的应用内历史与下载检查后，才能标记为完成。
+
+真实 API、签名、原生平台和正式更新 manifest 证据统一记录在 [`docs/release/evidence.json`](./docs/release/evidence.json)。证据必须脱敏并通过 `pnpm verify:release-evidence` 后，才能把 checklist 项改为完成。
 
 ## 图标
 

--- a/TODO.md
+++ b/TODO.md
@@ -120,6 +120,7 @@
 - [x] 补齐 `v0.2.0` 多模型发布包版本、描述、版权和更新 manifest 元数据
 - [x] 更新 manifest schema 和安装器下载校验要求 `sha256` 与 `sizeBytes`
 - [x] 增加 update manifest 资产条目生成脚本，降低正式分发元数据手工出错风险
+- [x] 增加外部发布证据 ledger 与 `pnpm verify:release-evidence`，统一记录真实 API、签名、公证、原生平台和正式 manifest 证据
 - [x] 在 Ubuntu ARM64 Docker 环境补充 Linux build、mock verifier、AppImage 打包、AppImage 解包与 Xvfb 启动烟测证据
 - [x] 增加 `pnpm verify:release:windows` 并接入 Windows CI package gate
 - [x] 将 Windows release verifier 扩展到 silent install / launch / uninstall 烟测

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -1,0 +1,30 @@
+# Release Evidence
+
+`evidence.json` records the external gates that cannot be completed from a
+normal local development shell: real provider API acceptance, signed/notarized
+macOS release artifacts, native Windows and Linux validation, and formal update
+manifest assets.
+
+Validate the ledger after every evidence update:
+
+```bash
+pnpm verify:release-evidence
+```
+
+Before publishing a release, require every required gate to be passed:
+
+```bash
+pnpm verify:release-evidence -- --require-complete
+```
+
+Rules for updating evidence:
+
+- Never include raw API keys, GitHub tokens, Apple credentials, private key
+  blocks, or private home-directory paths.
+- Record the exact commit SHA, OS/version, commands run, and a short summary for
+  each passed gate.
+- Prefer public HTTPS references such as GitHub Actions runs, release asset
+  URLs, or tracking issues. Keep generated real API artifacts out of git unless
+  they are explicitly approved public samples.
+- Do not change checklist items from pending to complete until the matching
+  evidence gate is marked `passed` and the validator succeeds.

--- a/docs/release/evidence.json
+++ b/docs/release/evidence.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": 1,
+  "releaseVersion": "0.2.0",
+  "lastUpdated": "2026-06-09T00:00:00.000Z",
+  "gates": [
+    {
+      "id": "real-openai-api",
+      "title": "Real OpenAI GPT Image 2 API acceptance",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Model discovery confirms gpt-image-2 is available to the tested key.",
+        "Text-to-image generation succeeds with real OpenAI Image API output.",
+        "Reference-image editing succeeds with real OpenAI Image API output.",
+        "Mask-based inpaint succeeds with real OpenAI Image API output.",
+        "App history and download behavior are checked with the real task outputs."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [],
+        "artifacts": [],
+        "summary": "Pending real OpenAI key and explicit cost approval."
+      }
+    },
+    {
+      "id": "real-gemini-api",
+      "title": "Real Gemini / Nano Banana 3 API acceptance",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Model discovery confirms gemini-3.1-flash-image is available to the tested key.",
+        "Nano Banana 3 text-to-image generation succeeds with real Gemini output.",
+        "Reference-image editing succeeds with real Gemini output.",
+        "Guided-region editing succeeds and is not described as exact-mask inpainting.",
+        "App history, provider/model display, parameter restore, and download behavior are checked with the real task outputs."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [],
+        "artifacts": [],
+        "summary": "Pending real Gemini key and explicit cost approval."
+      }
+    },
+    {
+      "id": "macos-signed-notarized",
+      "title": "Signed and notarized macOS release package",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Developer ID signing readiness passes without exposing secret values.",
+        "package:mac:signed produces signed and notarized macOS artifacts.",
+        "macOS release verification passes against the signed artifact.",
+        "The artifact intended for distribution is the same artifact used for update manifest metadata."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [],
+        "artifacts": [],
+        "summary": "Pending Developer ID identity and Apple notarization credentials."
+      }
+    },
+    {
+      "id": "windows-native-release",
+      "title": "Native Windows release package validation",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Windows package verifier runs in full native install mode.",
+        "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass.",
+        "Packaged app can configure mock OpenAI and Gemini endpoints.",
+        "Download and open-folder behavior are checked on native Windows."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [],
+        "artifacts": [],
+        "summary": "Pending native Windows shell validation."
+      }
+    },
+    {
+      "id": "linux-native-release",
+      "title": "Native Linux desktop AppImage validation",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Linux release verifier runs on a native desktop shell.",
+        "Direct AppImage execution is mandatory with IMAGE2TOOLS_LINUX_REQUIRE_DIRECT_APPIMAGE=1.",
+        "Packaged app can configure mock OpenAI and Gemini endpoints.",
+        "Download and open-folder behavior are checked on native Linux."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [],
+        "artifacts": [],
+        "summary": "Pending native Linux desktop validation with direct AppImage execution."
+      }
+    },
+    {
+      "id": "update-manifest-assets",
+      "title": "Formal update manifest distribution assets",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Distribution artifacts are uploaded to a public HTTPS release URL.",
+        "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata.",
+        "Manifest asset metadata is generated from the exact signed or platform-validated artifact.",
+        "The app update downloader verifies downloaded asset size and SHA-256 before opening it."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [],
+        "artifacts": [],
+        "summary": "Pending signed and externally validated release artifacts."
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "verify:release:linux": "node scripts/verify-linux-release.mjs",
     "verify:release:mac": "node scripts/verify-mac-release.mjs",
     "verify:release:windows": "node scripts/verify-windows-release.mjs",
+    "verify:release-evidence": "node scripts/verify-release-evidence.mjs",
     "verify:real-api": "node scripts/verify-real-api.mjs",
     "verify:real-gemini-api": "node scripts/verify-real-gemini-api.mjs",
     "verify:signing-ready": "node scripts/verify-signing-readiness.mjs",

--- a/scripts/verify-release-evidence.mjs
+++ b/scripts/verify-release-evidence.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const defaultEvidenceFile = "docs/release/evidence.json";
+const allowedStatuses = new Set(["pending", "passed", "failed", "blocked"]);
+const requiredGateIds = [
+  "real-openai-api",
+  "real-gemini-api",
+  "macos-signed-notarized",
+  "windows-native-release",
+  "linux-native-release",
+  "update-manifest-assets"
+];
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/verify-release-evidence.mjs [--file <path>] [--require-complete]",
+    "",
+    "Validates docs/release/evidence.json. By default pending required gates are allowed.",
+    "Use --require-complete before publishing a release."
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = { file: defaultEvidenceFile, requireComplete: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--require-complete") {
+      args.requireComplete = true;
+      continue;
+    }
+    if (arg === "--file") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`Missing value for --file.\n${usage()}`);
+      }
+      args.file = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unexpected argument: ${arg}\n${usage()}`);
+  }
+  return args;
+}
+
+async function readJson(filePath) {
+  const raw = await readFile(filePath, "utf8");
+  assertNoSensitiveValues(raw, filePath);
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${filePath} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function assertNoSensitiveValues(raw, filePath) {
+  const checks = [
+    {
+      label: "OpenAI API key",
+      pattern: /\bsk-(?:proj-)?(?!mock\b|test\b|\.{3})[A-Za-z0-9_-]{16,}\b/
+    },
+    {
+      label: "Google API key",
+      pattern: /\bAIza(?!\.\.\.redacted\b)[A-Za-z0-9_-]{20,}\b/
+    },
+    {
+      label: "GitHub token",
+      pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/
+    },
+    {
+      label: "Bearer token",
+      pattern: /\bBearer\s+(?!\[?redacted\b)[A-Za-z0-9._~+/=-]{16,}\b/i
+    },
+    {
+      label: "private key block",
+      pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/
+    },
+    {
+      label: "private home-directory path",
+      pattern: /(?:\/Users\/[^/"'\s]+|\/home\/[^/"'\s]+|[A-Za-z]:\\Users\\[^\\/"'\s]+)/
+    }
+  ];
+  for (const check of checks) {
+    if (check.pattern.test(raw)) {
+      throw new Error(`${filePath} appears to contain a ${check.label}; redact evidence before committing it.`);
+    }
+  }
+}
+
+function assertObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+}
+
+function assertNonEmptyString(value, label) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+}
+
+function assertNullableString(value, label) {
+  if (value !== null && typeof value !== "string") {
+    throw new Error(`${label} must be a string or null.`);
+  }
+}
+
+function assertStringArray(value, label, { requireNonEmpty = false } = {}) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array.`);
+  }
+  if (requireNonEmpty && value.length === 0) {
+    throw new Error(`${label} must contain at least one item.`);
+  }
+  for (const [index, item] of value.entries()) {
+    assertNonEmptyString(item, `${label}[${index}]`);
+  }
+}
+
+function assertIsoTimestamp(value, label) {
+  assertNonEmptyString(value, label);
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp) || new Date(timestamp).toISOString() !== value) {
+    throw new Error(`${label} must be an ISO-8601 UTC timestamp.`);
+  }
+}
+
+function assertCommit(value, label) {
+  assertNonEmptyString(value, label);
+  if (!/^[a-f0-9]{40}$/.test(value)) {
+    throw new Error(`${label} must be a full lowercase 40-character git commit SHA.`);
+  }
+}
+
+function assertHttpsUrl(value, label) {
+  assertNonEmptyString(value, label);
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid HTTPS URL.`);
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`${label} must use HTTPS.`);
+  }
+}
+
+function validateReference(reference, label) {
+  assertObject(reference, label);
+  assertNonEmptyString(reference.label, `${label}.label`);
+  assertHttpsUrl(reference.url, `${label}.url`);
+}
+
+function validateArtifact(artifact, label) {
+  assertObject(artifact, label);
+  assertNonEmptyString(artifact.kind, `${label}.kind`);
+  if ("path" in artifact) {
+    assertNonEmptyString(artifact.path, `${label}.path`);
+  }
+  if ("url" in artifact) {
+    assertHttpsUrl(artifact.url, `${label}.url`);
+  }
+  if (!("path" in artifact) && !("url" in artifact)) {
+    throw new Error(`${label} must include path or url.`);
+  }
+  if ("public" in artifact && typeof artifact.public !== "boolean") {
+    throw new Error(`${label}.public must be a boolean when present.`);
+  }
+  if ("description" in artifact) {
+    assertNonEmptyString(artifact.description, `${label}.description`);
+  }
+}
+
+function validateEvidence(evidence, label, status) {
+  assertObject(evidence, label);
+  assertNullableString(evidence.verifiedAt, `${label}.verifiedAt`);
+  assertNullableString(evidence.commit, `${label}.commit`);
+  assertNullableString(evidence.environment, `${label}.environment`);
+  assertStringArray(evidence.commands, `${label}.commands`);
+  assertNonEmptyString(evidence.summary, `${label}.summary`);
+
+  if (!Array.isArray(evidence.references)) {
+    throw new Error(`${label}.references must be an array.`);
+  }
+  evidence.references.forEach((reference, index) => validateReference(reference, `${label}.references[${index}]`));
+
+  if (!Array.isArray(evidence.artifacts)) {
+    throw new Error(`${label}.artifacts must be an array.`);
+  }
+  evidence.artifacts.forEach((artifact, index) => validateArtifact(artifact, `${label}.artifacts[${index}]`));
+
+  if (status === "passed") {
+    assertIsoTimestamp(evidence.verifiedAt, `${label}.verifiedAt`);
+    assertCommit(evidence.commit, `${label}.commit`);
+    assertNonEmptyString(evidence.environment, `${label}.environment`);
+    assertStringArray(evidence.commands, `${label}.commands`, { requireNonEmpty: true });
+  }
+}
+
+function validateLedger(ledger, packageJson, { requireComplete }) {
+  assertObject(ledger, "release evidence");
+  if (ledger.schemaVersion !== 1) {
+    throw new Error("release evidence schemaVersion must be 1.");
+  }
+  assertNonEmptyString(ledger.releaseVersion, "release evidence releaseVersion");
+  if (ledger.releaseVersion !== packageJson.version) {
+    throw new Error(`release evidence releaseVersion ${ledger.releaseVersion} does not match package version ${packageJson.version}.`);
+  }
+  assertIsoTimestamp(ledger.lastUpdated, "release evidence lastUpdated");
+  if (!Array.isArray(ledger.gates)) {
+    throw new Error("release evidence gates must be an array.");
+  }
+
+  const gatesById = new Map();
+  for (const [index, gate] of ledger.gates.entries()) {
+    const label = `release evidence gates[${index}]`;
+    assertObject(gate, label);
+    assertNonEmptyString(gate.id, `${label}.id`);
+    if (gatesById.has(gate.id)) {
+      throw new Error(`Duplicate release evidence gate id: ${gate.id}`);
+    }
+    if (!requiredGateIds.includes(gate.id)) {
+      throw new Error(`Unknown release evidence gate id: ${gate.id}`);
+    }
+    gatesById.set(gate.id, gate);
+    assertNonEmptyString(gate.title, `${label}.title`);
+    if (typeof gate.required !== "boolean") {
+      throw new Error(`${label}.required must be a boolean.`);
+    }
+    if (!allowedStatuses.has(gate.status)) {
+      throw new Error(`${label}.status must be one of: ${[...allowedStatuses].join(", ")}.`);
+    }
+    assertStringArray(gate.acceptanceCriteria, `${label}.acceptanceCriteria`, { requireNonEmpty: true });
+    validateEvidence(gate.evidence, `${label}.evidence`, gate.status);
+  }
+
+  const missingGateIds = requiredGateIds.filter((id) => !gatesById.has(id));
+  if (missingGateIds.length > 0) {
+    throw new Error(`Missing required release evidence gate(s): ${missingGateIds.join(", ")}`);
+  }
+
+  const incompleteRequiredGates = [...gatesById.values()].filter((gate) => gate.required && gate.status !== "passed");
+  if (requireComplete && incompleteRequiredGates.length > 0) {
+    throw new Error(`Required release evidence gates are not passed: ${incompleteRequiredGates.map((gate) => gate.id).join(", ")}`);
+  }
+
+  return {
+    passedRequiredCount: [...gatesById.values()].filter((gate) => gate.required && gate.status === "passed").length,
+    requiredCount: [...gatesById.values()].filter((gate) => gate.required).length,
+    incompleteRequiredGates
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const evidencePath = path.resolve(args.file);
+  const packageJson = await readJson(path.resolve("package.json"));
+  const ledger = await readJson(evidencePath);
+  const result = validateLedger(ledger, packageJson, { requireComplete: args.requireComplete });
+
+  console.log(`Release evidence validated: ${result.passedRequiredCount}/${result.requiredCount} required gate(s) passed.`);
+  if (result.incompleteRequiredGates.length > 0) {
+    console.log(`Pending required gate(s): ${result.incompleteRequiredGates.map((gate) => gate.id).join(", ")}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = path.resolve("scripts/verify-release-evidence.mjs");
+const execFileAsync = promisify(execFile);
+
+async function run(args) {
+  try {
+    const result = await execFileAsync("node", [scriptPath, ...args]);
+    return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error) {
+      return {
+        exitCode: Number(error.code),
+        stdout: "stdout" in error ? String(error.stdout ?? "") : "",
+        stderr: "stderr" in error ? String(error.stderr ?? "") : ""
+      };
+    }
+    throw error;
+  }
+}
+
+function passedEvidence(summary) {
+  return {
+    verifiedAt: "2026-06-09T12:00:00.000Z",
+    commit: "d40a84ebf7e66fe2509546d4fff7fe8cdbe972f9",
+    environment: "CI fixture",
+    commands: ["pnpm verify:mock-api"],
+    references: [{ label: "GitHub Actions run", url: "https://github.com/Bliveren/image2tools/actions/runs/1" }],
+    artifacts: [{ kind: "local-directory", path: "real-api-artifacts/", public: false, description: "Ignored verifier output." }],
+    summary
+  };
+}
+
+function completeLedger() {
+  const gateIds = [
+    "real-openai-api",
+    "real-gemini-api",
+    "macos-signed-notarized",
+    "windows-native-release",
+    "linux-native-release",
+    "update-manifest-assets"
+  ];
+  return {
+    schemaVersion: 1,
+    releaseVersion: "0.2.0",
+    lastUpdated: "2026-06-09T12:00:00.000Z",
+    gates: gateIds.map((id) => ({
+      id,
+      title: `Fixture ${id}`,
+      required: true,
+      status: "passed",
+      acceptanceCriteria: [`${id} passed`],
+      evidence: passedEvidence(`${id} evidence recorded with redacted values only.`)
+    }))
+  };
+}
+
+describe("release evidence verifier", () => {
+  it("validates the staged release evidence ledger with pending gates", async () => {
+    const result = await run([]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Release evidence validated: 0/6 required gate(s) passed.");
+    expect(result.stdout).toContain("real-openai-api");
+  });
+
+  it("requires all release evidence gates when requested", async () => {
+    const result = await run(["--require-complete"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Required release evidence gates are not passed");
+  });
+
+  it("accepts a complete redacted evidence ledger", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "image2tools-release-evidence-"));
+    try {
+      const filePath = path.join(tempRoot, "evidence.json");
+      await writeFile(filePath, JSON.stringify(completeLedger(), null, 2));
+
+      const result = await run(["--file", filePath, "--require-complete"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Release evidence validated: 6/6 required gate(s) passed.");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects secret-looking values in evidence", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "image2tools-release-evidence-"));
+    try {
+      const ledger = completeLedger();
+      ledger.gates[0].evidence.summary = `Unexpected key ${["sk", "live", "abcdefghijklmnopqrstuvwxyz123456"].join("-")}`;
+      const filePath = path.join(tempRoot, "evidence.json");
+      await writeFile(filePath, JSON.stringify(ledger, null, 2));
+
+      const result = await run(["--file", filePath]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("OpenAI API key");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a machine-checkable external release evidence ledger for real API, signing, native platform, and update manifest gates
- add pnpm verify:release-evidence with a final --require-complete mode
- document the evidence workflow in release, acceptance, README, todo, and checklist files

## Validation
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm verify:release-evidence
- node scripts/verify-release-evidence.mjs --require-complete (expected failure while gates are pending)