### PR TITLE
Guard release checklist evidence alignment

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -11,6 +11,9 @@ Validate the ledger after every evidence update:
 pnpm verify:release-evidence
 ```
 
+The verifier also checks guarded checklist and TODO items. External acceptance
+items must stay unchecked until their matching evidence gate is marked `passed`.
+
 Before publishing a release, require every required gate to be passed:
 
 ```bash

--- a/scripts/verify-release-evidence.mjs
+++ b/scripts/verify-release-evidence.mjs
@@ -12,6 +12,148 @@ const requiredGateIds = [
   "linux-native-release",
   "update-manifest-assets"
 ];
+const checklistGuards = [
+  {
+    file: "TODO.md",
+    text: "用真实 API Key 做一次实际生成、编辑、局部重绘手工验收",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "TODO.md",
+    text: "用真实 Gemini Key 完成 Nano Banana 3 生成、参考图编辑、局部引导编辑和下载/历史验收",
+    gateIds: ["real-gemini-api"]
+  },
+  {
+    file: "TODO.md",
+    text: "完成签名、公证并补充正式分发资产 URL / hash / size 证据",
+    gateIds: ["macos-signed-notarized", "update-manifest-assets"]
+  },
+  {
+    file: "TODO.md",
+    text: "非 macOS 平台安装验证；Windows 与原生 Linux 桌面 shell 行为仍待验证",
+    gateIds: ["windows-native-release", "linux-native-release"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "文本提示可成功出图（需真实 API Key 手工验收）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "单图编辑可用（需真实 API Key 手工验收）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "多图参考编辑可用（需真实 API Key 手工验收）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "局部重绘可用（需真实 API Key 手工验收）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "Windows 原生安装与启动验证完成",
+    gateIds: ["windows-native-release"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "Linux 原生桌面 AppImage 直接运行、下载、打开文件夹行为验证完成",
+    gateIds: ["linux-native-release"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "Gemini / Nano Banana 3 真实 API 验收完成（已有受成本保护 verifier，仍需真实 Key 跑通并记录证据）",
+    gateIds: ["real-gemini-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "仅输入 prompt 生成一张图（需真实 API Key）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "输入长 prompt 生成一张图（需真实 API Key）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "上传一张参考图后编辑（需真实 API Key）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "上传多张参考图后编辑（需真实 API Key）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "用 mask 对图局部重绘（需真实 API Key）",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "真实 OpenAI / Gemini 外部验收完成",
+    gateIds: ["real-openai-api", "real-gemini-api"]
+  },
+  {
+    file: "CHECKLIST.md",
+    text: "正式更新 manifest 已补充分发资产 URL、hash 和 size",
+    gateIds: ["update-manifest-assets"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "`v0.2.0` 发布前完成至少一轮真实 OpenAI / Gemini API 外部验收",
+    gateIds: ["real-openai-api", "real-gemini-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "OpenAI Key 可发现 `gpt-image-2`",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "OpenAI Key 可完成一次文生图",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "OpenAI Key 可完成一次参考图编辑",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "OpenAI Key 可完成一次 mask 局部重绘",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "Gemini Key 可发现 `gemini-3.1-flash-image`",
+    gateIds: ["real-gemini-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "Gemini Key 可完成一次 Nano Banana 3 文生图",
+    gateIds: ["real-gemini-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "Gemini Key 可完成一次 Nano Banana 3 参考图编辑",
+    gateIds: ["real-gemini-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "Gemini Key 可完成一次 Nano Banana 3 局部引导编辑",
+    gateIds: ["real-gemini-api"]
+  },
+  {
+    file: "MULTI_MODEL_CHECKLIST.md",
+    text: "历史中能区分 OpenAI 与 Gemini 任务",
+    gateIds: ["real-openai-api", "real-gemini-api"]
+  }
+];
 
 function usage() {
   return [
@@ -248,10 +390,42 @@ function validateLedger(ledger, packageJson, { requireComplete }) {
   }
 
   return {
+    gatesById,
     passedRequiredCount: [...gatesById.values()].filter((gate) => gate.required && gate.status === "passed").length,
     requiredCount: [...gatesById.values()].filter((gate) => gate.required).length,
     incompleteRequiredGates
   };
+}
+
+async function validateChecklistAlignment(gatesById) {
+  const fileCache = new Map();
+  for (const guard of checklistGuards) {
+    if (!fileCache.has(guard.file)) {
+      fileCache.set(guard.file, await readFile(path.resolve(guard.file), "utf8"));
+    }
+    const fileText = fileCache.get(guard.file);
+    const line = findChecklistLine(fileText, guard.text, guard.file);
+    const isChecked = /^-\s+\[x\]\s+/.test(line);
+    if (!isChecked) continue;
+
+    const missingGateIds = guard.gateIds.filter((gateId) => gatesById.get(gateId)?.status !== "passed");
+    if (missingGateIds.length > 0) {
+      throw new Error(
+        `${guard.file} marks "${guard.text}" complete before release evidence gate(s) passed: ${missingGateIds.join(", ")}`
+      );
+    }
+  }
+}
+
+function findChecklistLine(fileText, text, file) {
+  const matches = fileText.split(/\r?\n/).filter((line) => /^-\s+\[[ x]\]\s+/.test(line) && line.includes(text));
+  if (matches.length === 0) {
+    throw new Error(`${file} is missing guarded checklist item: ${text}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`${file} has multiple guarded checklist items matching: ${text}`);
+  }
+  return matches[0];
 }
 
 async function main() {
@@ -260,6 +434,7 @@ async function main() {
   const packageJson = await readJson(path.resolve("package.json"));
   const ledger = await readJson(evidencePath);
   const result = validateLedger(ledger, packageJson, { requireComplete: args.requireComplete });
+  await validateChecklistAlignment(result.gatesById);
 
   console.log(`Release evidence validated: ${result.passedRequiredCount}/${result.requiredCount} required gate(s) passed.`);
   if (result.incompleteRequiredGates.length > 0) {

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -8,10 +8,11 @@ import { describe, expect, it } from "vitest";
 
 const scriptPath = path.resolve("scripts/verify-release-evidence.mjs");
 const execFileAsync = promisify(execFile);
+const checklistFiles = ["TODO.md", "CHECKLIST.md", "MULTI_MODEL_CHECKLIST.md"];
 
-async function run(args) {
+async function run(args, options = {}) {
   try {
-    const result = await execFileAsync("node", [scriptPath, ...args]);
+    const result = await execFileAsync("node", [scriptPath, ...args], options);
     return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
   } catch (error) {
     if (error && typeof error === "object" && "code" in error) {
@@ -108,4 +109,40 @@ describe("release evidence verifier", () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it("rejects checklist completion before matching evidence passes", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "image2tools-release-evidence-"));
+    try {
+      await copyChecklistFixture(tempRoot);
+      await copyFile(path.resolve("package.json"), path.join(tempRoot, "package.json"));
+      const scriptsDir = path.join(tempRoot, "scripts");
+      await mkdir(scriptsDir, { recursive: true });
+      await copyFile(scriptPath, path.join(scriptsDir, "verify-release-evidence.mjs"));
+
+      const docsReleaseDir = path.join(tempRoot, "docs", "release");
+      await mkdir(docsReleaseDir, { recursive: true });
+      await copyFile(path.resolve("docs/release/evidence.json"), path.join(docsReleaseDir, "evidence.json"));
+
+      const checklistPath = path.join(tempRoot, "MULTI_MODEL_CHECKLIST.md");
+      const checklist = await readFile(checklistPath, "utf8");
+      await writeFile(
+        checklistPath,
+        checklist.replace("- [ ] OpenAI Key 可发现 `gpt-image-2`", "- [x] OpenAI Key 可发现 `gpt-image-2`")
+      );
+
+      const result = await run([], { cwd: tempRoot });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("OpenAI Key 可发现 `gpt-image-2`");
+      expect(result.stderr).toContain("real-openai-api");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
+
+async function copyChecklistFixture(tempRoot) {
+  for (const file of checklistFiles) {
+    await copyFile(path.resolve(file), path.join(tempRoot, file));
+  }
+}


### PR DESCRIPTION
## Summary
- make release evidence validation reject guarded checklist/TODO items that are checked before their evidence gates pass
- add a regression fixture for premature OpenAI checklist completion
- document the checklist guard in the release evidence runbook

## Validation
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm verify:release-evidence
- node scripts/verify-release-evidence.mjs --require-complete (expected failure while gates are pending)