### PR TITLE
Record Windows native release completion

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -101,8 +101,8 @@
 - [x] Linux ARM64 容器环境可 build、通过 mock verifier、生成 AppImage、解包并在 Xvfb 下启动
 - [x] Linux package gate 已接入 `pnpm verify:release:linux`
 - [x] Linux verifier 在 FUSE 可用时覆盖直接 AppImage 启动，并支持 `IMAGE2TOOLS_LINUX_REQUIRE_DIRECT_APPIMAGE=1` 强制原生验收
-- [ ] Windows 原生安装与启动验证完成
-  - 2026-06-10: Windows full-install verifier 已通过并记录证据；该 guarded checklist 项仍保持未完成，直到 `windows-native-release` gate 的 download/open-folder 证据也补齐。
+- [x] Windows 原生安装与启动验证完成
+  - 2026-06-10: Windows full-install verifier、packaged-app mock provider、native download 和 open-folder 证据已记录；`windows-native-release` gate 已通过。
 - [ ] Linux 原生桌面 AppImage 直接运行、下载、打开文件夹行为验证完成
 - [x] 真实 API 验收脚本默认受成本确认保护
 - [x] 真实 streaming 验收需要额外成本确认

--- a/COMPLETION_AUDIT.md
+++ b/COMPLETION_AUDIT.md
@@ -41,7 +41,7 @@ governance without leaking secrets or private local artifacts.
 | Update manifest safety | `src/shared/updateManifest.ts`, installer byte verification, update manifest tests, and `pnpm update:manifest-asset` require URL/hash/size metadata | Done; formal signed asset metadata pending |
 | Release evidence governance | `docs/release/evidence.json` records required external gates; `pnpm verify:release-evidence` validates schema, redaction, and guarded checklist alignment | Done; required gates still pending |
 | macOS packaging | `package:mac`, DMG/ZIP targets, ad-hoc preview build path, signed packaging command, signing-readiness script, and mac release verifier are present | Configured; Developer ID signed/notarized evidence pending |
-| Windows packaging | `package:win`, NSIS target, CI package-smoke mode, and full native installer verifier are present; Windows full-install verifier evidence is recorded in `docs/release/windows-full-install-2026-06-10.md` | Partial external evidence recorded; native download/open-folder evidence pending |
+| Windows packaging | `package:win`, NSIS target, CI package-smoke mode, and full native installer verifier are present; Windows full-install plus native download/open-folder evidence is recorded in `docs/release/windows-full-install-2026-06-10.md` and `docs/release/windows-native-download-open-folder-2026-06-10.md` | Done |
 | Linux packaging | AppImage target, CI verifier, extracted app Xvfb launch, and direct AppImage requirement flag are present | Configured; native Linux desktop evidence pending |
 | GitHub Actions | CI includes build/mock verification plus macOS, Windows, and Linux package jobs; recent PR gates have been green before merge | Done |
 | Secret handling and open-source scan | `.gitignore`, `SECURITY.md`, and `OPEN_SOURCE_AUDIT.md` document secret handling, ignored outputs, and scan expectations | Done; re-run before publication |
@@ -64,10 +64,9 @@ git diff --check
 and Electron main build. As of this audit refresh, the Vitest suite reports 20
 test files / 112 tests.
 
-`pnpm verify:release-evidence` passes with 0/6 required external gates passed,
-which is expected until real API, signed/notarized, native platform, and formal
-update-manifest evidence exists. `--require-complete` intentionally fails while
-those gates are pending.
+`pnpm verify:release-evidence` passes with 1/6 required external gates passed.
+`--require-complete` intentionally fails while real API, signed/notarized,
+native Linux desktop, and formal update-manifest evidence remain pending.
 
 ## Remaining External Gates
 
@@ -86,12 +85,6 @@ checklist items complete without redacted evidence in
   `pnpm verify:signing-ready`, `pnpm package:mac:signed`, and
   `pnpm verify:release:mac` with Developer ID and Apple notarization
   credentials.
-- Native Windows release validation:
-  a native Windows full-install verifier passed for commit
-  `e6587d2e3e2bff7d586164b4dd4294aed026c953`, covering PE checks, unpacked and
-  installed app launch, main-window detection, silent install, and silent
-  uninstall. The gate remains pending until native download/open-folder behavior
-  is checked and recorded.
 - Native Linux desktop validation:
   `IMAGE2TOOLS_LINUX_REQUIRE_DIRECT_APPIMAGE=1 pnpm verify:release:linux` on a
   native Linux desktop shell, plus download/open-folder checks.

--- a/EXTERNAL_ACCEPTANCE.md
+++ b/EXTERNAL_ACCEPTANCE.md
@@ -210,7 +210,7 @@ issue if one exists.
 
 Use a public tracking issue after the repository is public.
 
-Current partial evidence:
+Current platform evidence:
 
 - Ubuntu/Debian Bookworm ARM64 Docker validation on the macOS host passed
   `pnpm build`, `pnpm verify:mock-api`, Linux AppImage packaging, AppImage
@@ -223,11 +223,13 @@ Current partial evidence:
   `IMAGE2TOOLS_WINDOWS_VERIFY_MODE=package-smoke` so the installer PE and
   unpacked-app smoke checks stay gated without relying on the hosted runner's
   silent installer policy.
-- On 2026-06-10, a native Windows full-install verifier run passed for commit
-  `e6587d2e3e2bff7d586164b4dd4294aed026c953`; see
-  `docs/release/windows-full-install-2026-06-10.md`. This is partial evidence:
-  native download/open-folder behavior was not counted as passed, so the
-  `windows-native-release` gate remains pending.
+- On 2026-06-10, native Windows validation passed for commit
+  `4b4dd18ff4255fcb4bfb2a25fadde7bbf788eafd`; see
+  `docs/release/windows-full-install-2026-06-10.md` and
+  `docs/release/windows-native-download-open-folder-2026-06-10.md`. The run
+  covered full-install verifier checks, packaged-app mock OpenAI/Gemini
+  configuration and generation, native download, and native open-folder
+  behavior. The `windows-native-release` gate is passed.
 - `pnpm verify:release:linux` now automates the Linux package checks that can be
   safely run in CI or a Linux shell: AppImage/unpacked executable inspection,
   unpacked app Xvfb launch, direct AppImage launch when FUSE is available,
@@ -236,8 +238,8 @@ Current partial evidence:
   to make direct AppImage execution mandatory.
 - Direct AppImage execution in Docker remains blocked by missing FUSE device
   support, so this is not a substitute for native Linux desktop validation.
-- Windows native full-install validation has been performed, but native
-  download/open-folder validation is still pending.
+- Windows native release validation is complete; native Linux desktop
+  validation is still pending.
 
 Run on each native platform:
 

--- a/MULTI_MODEL_PLAN.md
+++ b/MULTI_MODEL_PLAN.md
@@ -19,11 +19,11 @@ Target release: `v0.2.0`
 - 2026-06-09: Mock model discovery verifier, renderer multi-model smoke coverage, multi-model release/security docs, real Gemini verifier, release metadata, update manifest hash/size enforcement, and manifest asset helper merged through PRs #86-#97.
 - 2026-06-09: Release evidence ledger, checklist/evidence alignment guard, and refreshed completion audit merged through PRs #98-#100.
 - 2026-06-10: v0.2.0 release blockers are explicitly tracked below and linked to release evidence gates / GitHub issues.
-- 2026-06-10: Windows native full-install verifier evidence was recorded; `windows-native-release` remains pending until native download/open-folder behavior is checked.
+- 2026-06-10: Windows native full-install, packaged-app mock provider, download, and open-folder evidence was recorded; `windows-native-release` is passed.
 
 ## 0.1 v0.2.0 当前卡点（发布阻塞）
 
-当前状态：`BLOCKED_FOR_EXTERNAL_EVIDENCE`。代码实现、mock 验证、release verifier、evidence ledger、checklist guard、manifest asset helper 和 CI package gates 已进入 `main`；`v0.2.0` 不能宣称完成或发布，是因为以下 6 个 release evidence 必需 gate 仍为 `pending`。
+当前状态：`BLOCKED_FOR_EXTERNAL_EVIDENCE`。代码实现、mock 验证、release verifier、evidence ledger、checklist guard、manifest asset helper 和 CI package gates 已进入 `main`；Windows 原生发布验证已通过，`v0.2.0` 仍不能宣称完成或发布，是因为以下 5 个 release evidence 必需 gate 仍为 `pending`。
 
 权威校验：
 
@@ -32,16 +32,19 @@ pnpm verify:release-evidence
 node scripts/verify-release-evidence.mjs --require-complete
 ```
 
-截至 2026-06-10，第一条命令只能证明 ledger 结构、脱敏和 checklist 对齐规则有效；第二条命令必须失败，直到下表 6 个 gate 全部拿到真实外部证据并标记 `passed`。
+截至 2026-06-10，第一条命令证明 ledger 结构、脱敏和 checklist 对齐规则有效，并应报告 `1/6` 个 required gate 已通过；第二条命令必须失败，直到剩余 5 个 gate 全部拿到真实外部证据并标记 `passed`。
 
 | Gate | 卡点是什么 | 当前缺失证据 | 解锁动作 / 验收命令 | 追踪 |
 | --- | --- | --- | --- | --- |
 | `real-openai-api` | 需要真实 OpenAI Key、`gpt-image-2` 模型权限和显式成本确认；本地/CI mock 不能替代真实 API 验收。 | 模型发现包含 `gpt-image-2`；真实文生图、参考图编辑、mask 局部重绘成功；真实任务的历史、下载行为已检查。 | 设置真实 Key 后运行 `IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 pnpm verify:real-api`；按需追加 `IMAGE2TOOLS_REAL_API_ACCEPT_STREAM_COST=1` 跑 streaming；把脱敏后的命令、artifact 路径、OS/commit、app 手工检查结果写入 `docs/release/evidence.json`。 | [#1](https://github.com/Bliveren/image2tools/issues/1) |
 | `real-gemini-api` | 需要真实 Gemini Key、`gemini-3.1-flash-image` 权限和显式成本确认；mock Gemini verifier 只能证明协议适配，不证明真实模型可用。 | 模型发现包含 `gemini-3.1-flash-image`；Nano Banana 3 文生图、参考图编辑、局部引导编辑成功；历史 provider/model、参数复用和下载行为已检查。 | 设置真实 Key 后运行 `IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 pnpm verify:real-gemini-api`；再做 app 级历史/下载/参数恢复验收；更新 evidence ledger 和 checklist。 | [#102](https://github.com/Bliveren/image2tools/issues/102) |
 | `macos-signed-notarized` | 需要 Developer ID Application 证书和 Apple notarization 凭据；当前默认 `pnpm package:mac` 只是本地预览路径，不能作为正式发布证据。 | `pnpm verify:signing-ready` 通过；`pnpm package:mac:signed` 产出签名/公证 artifact；`pnpm verify:release:mac` 对同一 artifact 通过；记录 notarization / artifact 证据。 | 在具备证书和 Apple env 的签名机上运行 `pnpm verify:signing-ready`、`pnpm package:mac:signed`、`pnpm verify:release:mac`；把签名身份摘要、公证结果、artifact URL/hash/size 写入 evidence。 | [#3](https://github.com/Bliveren/image2tools/issues/3) |
-| `windows-native-release` | Hosted CI 只跑 `package-smoke`，不能替代原生 Windows full-install 验收；2026-06-10 已取得一次原生 full-install verifier 通过证据。 | 仍缺 native download / open-folder 行为通过证据；full-install 已覆盖 PE 检查、未安装 app 启动、NSIS 静默安装、已安装 app 启动、主窗口检测和静默卸载。 | 在 Windows 机器补充 download/open-folder 验收并记录 OS/version/artifact 证据；必要时对最终分发 artifact 重跑 `IMAGE2TOOLS_WINDOWS_VERIFY_MODE=full-install pnpm verify:release:windows`。 | [#4](https://github.com/Bliveren/image2tools/issues/4) |
 | `linux-native-release` | CI/Docker 环境可能缺 FUSE，不能替代原生 Linux desktop 直接 AppImage 验收。 | 原生 Linux 桌面上 direct AppImage 启动强制通过；mock OpenAI/Gemini 配置、下载、打开文件夹行为已检查。 | 在带 FUSE 的 Linux 桌面运行 `IMAGE2TOOLS_LINUX_REQUIRE_DIRECT_APPIMAGE=1 pnpm verify:release:linux`；补充 app 手工检查和 OS/version/artifact 证据。 | [#4](https://github.com/Bliveren/image2tools/issues/4) |
 | `update-manifest-assets` | 正式 update manifest 必须基于已经签名/公证或原生平台验收通过的最终分发 artifacts；不能用 preview、unsigned、unnotarized 或未验收 artifact。 | 公开 HTTPS release asset URL；`docs/updates/latest.json` 中每个 asset 的 `url`、`fileName`、`sha256`、`sizeBytes` 与真实 artifact 匹配。 | 上传正式 artifacts 后运行 `pnpm update:manifest-asset -- --file <artifact> --platform <darwin|win32|linux|all> --url <https-url> [--arch <arch>]`；更新 evidence 后跑 `pnpm verify:release-evidence -- --require-complete`。 | [#103](https://github.com/Bliveren/image2tools/issues/103) |
+
+已解除：
+
+- `windows-native-release`：Windows 11 Pro `10.0.26100` 上 full-install verifier 通过，packaged app mock OpenAI/Gemini 配置和生成通过，native download 保存文件且 size/hash 匹配，native open-folder 打开 Explorer 到预期目录；证据见 `docs/release/windows-full-install-2026-06-10.md` 和 `docs/release/windows-native-download-open-folder-2026-06-10.md`。
 
 执行边界：
 
@@ -88,7 +91,7 @@ node scripts/verify-release-evidence.mjs --require-complete
 
 - 真实 OpenAI / Gemini API 验收仍需要外部 Key、模型权限和显式成本确认。
 - 签名/公证和正式更新 manifest 资产 URL/hash/size 仍需要真实分发 artifacts。
-- Windows 原生安装验证和 Linux 原生桌面直接 AppImage 验证仍需要对应平台环境。
+- Linux 原生桌面直接 AppImage 验证仍需要对应平台环境；Windows 原生发布验证已通过。
 - Nano Banana 局部编辑仍是“局部引导编辑”，不能描述为 OpenAI 等价 exact mask inpaint。
 
 ## 3. 官方能力判断

--- a/TODO.md
+++ b/TODO.md
@@ -129,8 +129,8 @@
 - [x] 将 Linux release verifier 扩展到可选直接 AppImage 启动，原生验收可通过环境变量强制要求 FUSE
 - [x] 取得绿色 CI
 - [ ] 完成签名、公证并补充正式分发资产 URL / hash / size 证据
-- [ ] 非 macOS 平台安装验证；Windows 与原生 Linux 桌面 shell 行为仍待验证
-  - 2026-06-10: Windows full-install verifier 通过证据已记录到 `docs/release/windows-full-install-2026-06-10.md`；该项仍保持未完成，直到 Windows download/open-folder 和原生 Linux 桌面验证都有证据。
+- [ ] 非 macOS 平台安装验证；Windows 已完成，原生 Linux 桌面 shell 行为仍待验证
+  - 2026-06-10: Windows full-install verifier、packaged-app mock provider、native download 和 open-folder 证据已记录；该组合项仍保持未完成，直到原生 Linux 桌面验证也有证据。
 - [x] 增加中英文界面切换
 
 ## 建议优先级

--- a/docs/release/evidence.json
+++ b/docs/release/evidence.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "releaseVersion": "0.2.0",
-  "lastUpdated": "2026-06-10T02:16:23.000Z",
+  "lastUpdated": "2026-06-10T04:11:24.000Z",
   "gates": [
     {
       "id": "real-openai-api",
@@ -87,7 +87,7 @@
       "id": "windows-native-release",
       "title": "Native Windows release package validation",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Windows package verifier runs in full native install mode.",
         "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass.",
@@ -95,9 +95,9 @@
         "Download and open-folder behavior are checked on native Windows."
       ],
       "evidence": {
-        "verifiedAt": "2026-06-10T02:16:23.000Z",
-        "commit": "e6587d2e3e2bff7d586164b4dd4294aed026c953",
-        "environment": "Native Windows shell; package version 0.2.0; artifact release\\Image2Tools-Setup.exe.",
+        "verifiedAt": "2026-06-10T04:11:24.000Z",
+        "commit": "4b4dd18ff4255fcb4bfb2a25fadde7bbf788eafd",
+        "environment": "Microsoft Windows 11 Pro 10.0.26100 build 26100 x64; package version 0.2.0; artifacts release\\Image2Tools-Setup.exe and release\\win-unpacked\\Image2Tools.exe.",
         "commands": [
           "$env:IMAGE2TOOLS_WINDOWS_VERIFY_MODE='full-install'; corepack pnpm@10.25.0 verify:release:windows"
         ],
@@ -112,10 +112,16 @@
             "kind": "evidence-note",
             "path": "docs/release/windows-full-install-2026-06-10.md",
             "public": true,
-            "description": "Redacted Windows full-install verifier result and remaining download/open-folder gap."
+            "description": "Redacted Windows full-install verifier result."
+          },
+          {
+            "kind": "evidence-note",
+            "path": "docs/release/windows-native-download-open-folder-2026-06-10.md",
+            "public": true,
+            "description": "Redacted Windows packaged-app mock provider, native download, and native open-folder acceptance result."
           }
         ],
-        "summary": "Partial Windows native evidence recorded: full-install verifier passed, including PE checks, unpacked and installed app launch, main-window detection, NSIS silent install, and silent uninstall. Gate remains pending because native download/open-folder acceptance was not counted as passed."
+        "summary": "Windows native release evidence passed: full-install verifier passed, packaged app configured mock OpenAI and Gemini endpoints, mock generation produced outputs, native download saved the selected file with matching size/hash, and native open-folder opened Explorer at the expected output directory."
       }
     },
     {

--- a/docs/release/windows-full-install-2026-06-10.md
+++ b/docs/release/windows-full-install-2026-06-10.md
@@ -1,8 +1,9 @@
 # Windows Full-Install Verification - 2026-06-10
 
-This note records partial external evidence for the `windows-native-release`
-gate. It does not mark the gate complete because native download and open-folder
-acceptance was not counted as passed.
+This note records the first external full-install verifier evidence for the
+`windows-native-release` gate. It is complemented by
+`docs/release/windows-native-download-open-folder-2026-06-10.md`, which records
+the follow-up native download/open-folder acceptance that completed the gate.
 
 ## Source
 
@@ -46,9 +47,10 @@ Supplemental packaged-app bridge checks reached OpenAI / Gemini mock provider
 configuration, discovery, connection, and generation through the packaged app
 bridge.
 
-## Remaining Windows Evidence
+## Follow-Up Windows Evidence
 
-Native download / open-folder automation was not counted as passed because
-native Save dialog automation remained unstable. The `windows-native-release`
-gate remains pending until that behavior is checked on native Windows and
-recorded in the release evidence ledger.
+Native download/open-folder acceptance was completed in a follow-up Windows
+test run against commit `4b4dd18ff4255fcb4bfb2a25fadde7bbf788eafd`; see
+`docs/release/windows-native-download-open-folder-2026-06-10.md`. The
+`windows-native-release` gate is now marked passed in the release evidence
+ledger.

--- a/docs/release/windows-native-download-open-folder-2026-06-10.md
+++ b/docs/release/windows-native-download-open-folder-2026-06-10.md
@@ -1,0 +1,92 @@
+# Windows Native Download/Open-Folder Verification - 2026-06-10
+
+This note records follow-up external evidence completing the
+`windows-native-release` gate.
+
+## Source
+
+- Repository: `https://github.com/Bliveren/image2tools`
+- Branch / commit tested: `main` /
+  `4b4dd18ff4255fcb4bfb2a25fadde7bbf788eafd`
+- Package version: `0.2.0`
+- Windows environment: Microsoft Windows 11 Pro `10.0.26100`, build `26100`,
+  x64.
+- Artifacts checked:
+  - `release\Image2Tools-Setup.exe`
+  - `release\win-unpacked\Image2Tools.exe`
+- Source note: user-provided Windows test history, redacted into this tracked
+  evidence note.
+
+## Full-Install Verifier
+
+```powershell
+$env:IMAGE2TOOLS_WINDOWS_VERIFY_MODE='full-install'; corepack pnpm@10.25.0 verify:release:windows
+```
+
+Result: passed.
+
+Fresh verifier coverage included PE checks, unpacked app launch, main-window
+detection, stability smoke, NSIS silent install, installed app launch,
+installed main-window detection, installed stability smoke, and silent
+uninstall.
+
+The final verifier output included:
+
+- `Silent Windows install/uninstall cycle passed.`
+- `Windows release verification passed.`
+
+## Packaged App Mock Provider Checks
+
+OpenAI-compatible mock endpoint configuration, connection, discovery, and
+generation were exercised through the packaged app bridge.
+
+- Discovered model: `gpt-image-2`
+- Job: `job_96250abe-a346-46f8-9d64-fdaf1132567e`
+- Output path:
+  `C:\work\image2tools-acceptance\windows-native-2026-06-10T03-58-13-085Z\userdata\images\job_96250abe-a346-46f8-9d64-fdaf1132567e-result-0.png`
+- Output size: `70` bytes
+- Output SHA-256:
+  `E83C539E44EBC56B3D93C09B6CD2F4A3CF84B0832A3BEDD949478691D8EC606C`
+
+Gemini mock endpoint configuration, connection, discovery, and generation were
+also exercised through the packaged app bridge.
+
+- Discovered models: `gemini-3.1-flash-image` and
+  `gemini-2.0-flash-preview-image-generation`
+- Job: `job_490a1ba9-4087-4bb3-8d25-a0c17003b2a7`
+- Output path:
+  `C:\work\image2tools-acceptance\windows-native-gemini-2026-06-10T04-09-47-546Z\userdata\images\job_490a1ba9-4087-4bb3-8d25-a0c17003b2a7-result-0.png`
+- Output size: `70` bytes
+- Output SHA-256:
+  `E83C539E44EBC56B3D93C09B6CD2F4A3CF84B0832A3BEDD949478691D8EC606C`
+
+## Native Download Result
+
+The packaged app `downloadAsset` action opened the native Windows
+`Save image` dialog and saved the generated image to the selected native path.
+
+- Saved path:
+  `C:\work\image2tools-acceptance\windows-native-2026-06-10T03-58-13-085Z\downloads\native-download-acceptance.png`
+- File existence: confirmed.
+- Saved file size: `70` bytes.
+- Saved file SHA-256:
+  `E83C539E44EBC56B3D93C09B6CD2F4A3CF84B0832A3BEDD949478691D8EC606C`
+- The saved file size and hash matched the source output.
+
+## Native Open-Folder Result
+
+The packaged app `openAssetFolder` action opened Windows Explorer at the
+expected output directory.
+
+- Explorer directory:
+  `C:\work\image2tools-acceptance\windows-native-2026-06-10T03-58-13-085Z\userdata\images`
+- Explorer window name: `images`
+- Explorer location URL:
+  `file:///C:/work/image2tools-acceptance/windows-native-2026-06-10T03-58-13-085Z/userdata/images`
+- Expected output file was present:
+  `job_96250abe-a346-46f8-9d64-fdaf1132567e-result-0.png`
+
+## Cleanup
+
+The Windows test note reported no residual Image2Tools / Electron process and
+no residual Image2Tools install registry entry after verification.

--- a/scripts/verify-release-evidence.mjs
+++ b/scripts/verify-release-evidence.mjs
@@ -30,7 +30,7 @@ const checklistGuards = [
   },
   {
     file: "TODO.md",
-    text: "非 macOS 平台安装验证；Windows 与原生 Linux 桌面 shell 行为仍待验证",
+    text: "非 macOS 平台安装验证；Windows 已完成，原生 Linux 桌面 shell 行为仍待验证",
     gateIds: ["windows-native-release", "linux-native-release"]
   },
   {

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -67,7 +67,7 @@ describe("release evidence verifier", () => {
     const result = await run([]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 0/6 required gate(s) passed.");
+    expect(result.stdout).toContain("Release evidence validated: 1/6 required gate(s) passed.");
     expect(result.stdout).toContain("real-openai-api");
   });
 


### PR DESCRIPTION
## Summary
- record Windows native download/open-folder follow-up evidence
- mark the windows-native-release gate as passed in docs/release/evidence.json
- update v0.2 plan/checklist/audit docs and release evidence guard expectations

## Validation
- pnpm verify:release-evidence
- node scripts/verify-release-evidence.mjs --require-complete (expected failure: real-openai-api, real-gemini-api, macos-signed-notarized, linux-native-release, update-manifest-assets)
- pnpm test -- scripts/verify-release-evidence.test.mjs
- git diff --check