### PR TITLE
Enable capability-based model launches

### DIFF
--- a/src/main/main.test.ts
+++ b/src/main/main.test.ts
@@ -96,7 +96,7 @@ describe("main config save builder", () => {
     expect(next.lastModelDiscoveryAt).toBeUndefined();
   });
 
-  it("drops incompatible requested launch and model when switching provider", () => {
+  it("preserves an explicitly requested cross-provider focused launch", () => {
     const next = buildProviderConfigForSave(
       savedConfig(),
       input({
@@ -109,7 +109,7 @@ describe("main config save builder", () => {
       "2026-06-09T02:00:00.000Z"
     );
 
-    expect(next.activeLaunchId).toBe("nano-banana-3");
-    expect(next.activeModelId).toBe("gemini-3.1-flash-image");
+    expect(next.activeLaunchId).toBe("gpt-image-2");
+    expect(next.activeModelId).toBe("gpt-image-2");
   });
 });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -38,13 +38,20 @@ import {
   validateWorkspaceDraftInput
 } from "../shared/validation.js";
 import {
+  GENERAL_LAUNCH_ID,
   GPT_IMAGE_2_LAUNCH_ID,
-  getModelDisplayName
+  GPT_IMAGE_2_MODEL_ID,
+  NANO_BANANA_3_LAUNCH_ID,
+  NANO_BANANA_3_MODEL_ID,
+  getModelDisplayName,
+  isGeneralFallbackProvider,
+  isPotentialGeneralImageModel,
+  normalizeModelId
 } from "../shared/modelCatalog.js";
 import { compareVersions, isAllowedUpdateUrl, parseUpdateManifest, safeUpdateFileName, selectUpdateAsset } from "../shared/updateManifest.js";
 import { fetchWithTimeout } from "./services/openaiImage.js";
-import { getImageProviderAdapter, getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
-import { discoverModels, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
+import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
+import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
 import { buildProviderConfigForSave, providerDisplayName } from "./services/providerConfigSave.js";
 import { assertKnownOutputPath, assertManagedRegularFile, collectOwnedJobFilePaths, normalizeManagedAssetPath } from "./services/assetOwnership.js";
 import { recoverInterruptedJobs } from "./services/stateRecovery.js";
@@ -538,13 +545,23 @@ async function handleClearDraft(): Promise<void> {
 async function refreshModelDiscovery(config: StoredProviderConfig): Promise<StoredProviderConfig> {
   const apiKey = getApiKeyForConfigOrThrow(config);
   try {
-    const adapter = getImageProviderAdapter(config.kind);
-    const models = adapter
-      ? await adapter.discoverModels(config, apiKey, { fetch })
-      : (await discoverModels(config.kind, config.baseURL, apiKey, Math.min(config.timeoutMs, 30000), { fetch })).models;
+    const discovery = await discoverModelsAcrossProviders(config.kind, config.baseURL, apiKey, Math.min(config.timeoutMs, 30000), { fetch });
+    const kind = discovery.inferredProviderKind ?? config.kind;
+    const activeSelection = discovery.inferredProviderKind
+      ? selectActiveLaunchForDiscovery(config, discovery.models, discovery.inferredProviderKind)
+      : {
+          activeLaunchId: config.activeLaunchId,
+          activeModelId: config.activeModelId,
+          defaultModel: config.defaultModel
+        };
     return {
       ...config,
-      discoveredModels: models,
+      kind,
+      name: providerDisplayName(kind),
+      defaultModel: activeSelection.defaultModel,
+      activeLaunchId: activeSelection.activeLaunchId,
+      activeModelId: activeSelection.activeModelId,
+      discoveredModels: discovery.models,
       lastModelDiscoveryAt: new Date().toISOString(),
       lastModelDiscoveryError: undefined,
       updatedAt: new Date().toISOString()
@@ -558,6 +575,49 @@ async function refreshModelDiscovery(config: StoredProviderConfig): Promise<Stor
       updatedAt: new Date().toISOString()
     };
   }
+}
+
+function selectActiveLaunchForDiscovery(
+  config: StoredProviderConfig,
+  models: StoredProviderConfig["discoveredModels"],
+  inferredProviderKind: StoredProviderConfig["kind"]
+) {
+  if (inferredProviderKind === "gemini") {
+    const nanoModel = models.find((model) => model.providerKind === "gemini" && normalizeModelId(model.id) === normalizeModelId(NANO_BANANA_3_MODEL_ID));
+    if (nanoModel) {
+      return {
+        activeLaunchId: NANO_BANANA_3_LAUNCH_ID,
+        activeModelId: nanoModel.id,
+        defaultModel: nanoModel.id
+      };
+    }
+  }
+
+  if (inferredProviderKind === "openai") {
+    const gptModel = models.find((model) => model.providerKind === "openai" && normalizeModelId(model.id) === normalizeModelId(GPT_IMAGE_2_MODEL_ID));
+    if (gptModel) {
+      return {
+        activeLaunchId: GPT_IMAGE_2_LAUNCH_ID,
+        activeModelId: gptModel.id,
+        defaultModel: gptModel.id
+      };
+    }
+  }
+
+  const generalModel = models.find((model) => isGeneralFallbackProvider(model.providerKind) && isPotentialGeneralImageModel(model));
+  if (generalModel) {
+    return {
+      activeLaunchId: GENERAL_LAUNCH_ID,
+      activeModelId: generalModel.id,
+      defaultModel: generalModel.id
+    };
+  }
+
+  return {
+    activeLaunchId: config.activeLaunchId,
+    activeModelId: config.activeModelId,
+    defaultModel: config.defaultModel
+  };
 }
 
 async function handleDiscoverModels(): Promise<ProviderConfig> {
@@ -637,7 +697,7 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
   }
 
   const state = await readState();
-  if (normalizedRequest.params.providerKind !== state.config.kind) {
+  if (!canRunRequestWithConfig(normalizedRequest, state.config)) {
     throw new Error("任务 provider 与当前服务配置不一致。请先切换并保存对应服务商。");
   }
   const apiKey = await getApiKeyOrThrow();
@@ -682,6 +742,16 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
     sendJobEvent({ jobId: job.id, type: "failed", error: message });
     return job;
   }
+}
+
+function canRunRequestWithConfig(request: RunJobRequest, config: StoredProviderConfig): boolean {
+  if (request.params.providerKind === config.kind) return true;
+  if (request.params.launchId !== config.activeLaunchId) return false;
+
+  const requestedModelId = normalizeModelId(request.params.model);
+  return config.discoveredModels.some(
+    (model) => model.providerKind === request.params.providerKind && normalizeModelId(model.id) === requestedModelId
+  );
 }
 
 async function handleDownloadAsset(_event: IpcMainInvokeEvent, request: DownloadRequest): Promise<string | null> {

--- a/src/main/services/generalImageAdapter.ts
+++ b/src/main/services/generalImageAdapter.ts
@@ -69,9 +69,6 @@ export async function runGeneralImageJob(
   if (!isGeneralFallbackProvider(job.params.providerKind)) {
     throw new Error(unsupportedGeneralProviderMessage(job.params.providerKind));
   }
-  if (job.params.providerKind !== config.kind) {
-    throw new Error("任务 provider 与当前服务配置不一致。请先切换并保存对应服务商。");
-  }
 
   if (job.params.providerKind === "gemini") {
     const providerJob = {

--- a/src/main/services/modelDiscovery.test.ts
+++ b/src/main/services/modelDiscovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { discoverModels, sanitizeModelDiscoveryError } from "./modelDiscovery";
+import { discoverModels, discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./modelDiscovery";
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -35,6 +35,21 @@ describe("model discovery", () => {
     ]);
   });
 
+  it("classifies focused model ids discovered from an OpenAI-compatible model list", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        data: [{ id: "gpt-image-2", object: "model" }, { id: "gemini-3.1-flash-image", object: "model" }]
+      })
+    );
+
+    const result = await discoverModels("openai", "https://gateway.example.com/v1", "gateway-key", 30000, { fetch: fetchImpl });
+
+    expect(result.models).toEqual([
+      expect.objectContaining({ id: "gpt-image-2", providerKind: "openai" }),
+      expect.objectContaining({ id: "gemini-3.1-flash-image", providerKind: "gemini" })
+    ]);
+  });
+
   it("discovers Gemini models and normalizes resource names", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({
@@ -60,6 +75,25 @@ describe("model discovery", () => {
         displayName: "Gemini 3.1 Flash Image"
       })
     ]);
+  });
+
+  it("merges provider probes and infers a provider when the selected protocol fails", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async (url) => {
+      const target = String(url);
+      if (target.includes("?key=")) {
+        return jsonResponse({
+          models: [{ name: "models/gemini-3.1-flash-image", displayName: "Gemini 3.1 Flash Image" }]
+        });
+      }
+      return jsonResponse({ error: { message: "OpenAI-compatible route unavailable for gateway-key" } }, 404);
+    });
+
+    const result = await discoverModelsAcrossProviders("openai", "https://gateway.example.com/v1beta", "gateway-key", 30000, {
+      fetch: fetchImpl
+    });
+
+    expect(result.inferredProviderKind).toBe("gemini");
+    expect(result.models).toEqual([expect.objectContaining({ id: "gemini-3.1-flash-image", providerKind: "gemini" })]);
   });
 
   it("sanitizes API keys from discovery errors", async () => {

--- a/src/main/services/modelDiscovery.ts
+++ b/src/main/services/modelDiscovery.ts
@@ -1,4 +1,5 @@
 import type { DiscoveredModel, ProviderKind } from "../../shared/types.js";
+import { getProviderKindForFocusedModelId } from "../../shared/modelCatalog.js";
 import { DEFAULT_GEMINI_BASE_URL, normalizeBaseURL } from "../../shared/validation.js";
 import { buildEndpoint, fetchWithTimeout } from "./openaiImage.js";
 
@@ -23,6 +24,7 @@ export interface ModelDiscoveryResult {
   models: DiscoveredModel[];
   status: number;
   requestId?: string;
+  inferredProviderKind?: ProviderKind;
 }
 
 export interface ModelDiscoveryRuntime {
@@ -42,9 +44,58 @@ export async function discoverModels(
   return discoverOpenAICompatibleModels(providerKind, baseURL, apiKey, timeoutMs, runtime);
 }
 
+export async function discoverModelsAcrossProviders(
+  providerKind: ProviderKind,
+  baseURL: string,
+  apiKey: string,
+  timeoutMs: number,
+  runtime: ModelDiscoveryRuntime
+): Promise<ModelDiscoveryResult> {
+  const attempts = discoveryProviderOrder(providerKind);
+  const results: Array<{ providerKind: ProviderKind; result: ModelDiscoveryResult }> = [];
+  const errors: string[] = [];
+
+  for (const attemptProviderKind of attempts) {
+    try {
+      results.push({
+        providerKind: attemptProviderKind,
+        result: await discoverModels(attemptProviderKind, baseURL, apiKey, timeoutMs, runtime)
+      });
+    } catch (error) {
+      errors.push(`${providerLabel(attemptProviderKind)}: ${sanitizeModelDiscoveryError(error, apiKey)}`);
+    }
+  }
+
+  if (results.length === 0) {
+    throw new Error(errors.join(" | ") || "model discovery failed.");
+  }
+
+  const resultsWithModels = results.filter((result) => result.result.models.length > 0);
+  const selectedProviderHasModels = resultsWithModels.some((result) => result.providerKind === providerKind);
+
+  return {
+    models: uniqueModels(results.flatMap((result) => result.result.models)),
+    status: results[0]?.result.status ?? 200,
+    requestId: results.find((result) => result.result.requestId)?.result.requestId,
+    inferredProviderKind: !selectedProviderHasModels && resultsWithModels.length === 1 ? resultsWithModels[0]?.providerKind : undefined
+  };
+}
+
 export function sanitizeModelDiscoveryError(error: unknown, apiKey?: string): string {
   const raw = error instanceof Error ? error.message : String(error);
   return redactLikelySecrets(raw, apiKey).replace(/\s+/g, " ").trim();
+}
+
+function discoveryProviderOrder(providerKind: ProviderKind): ProviderKind[] {
+  if (providerKind === "gemini") return ["gemini", "openai"];
+  if (providerKind === "custom") return ["custom", "gemini"];
+  return ["openai", "gemini"];
+}
+
+function providerLabel(providerKind: ProviderKind): string {
+  if (providerKind === "gemini") return "Gemini";
+  if (providerKind === "custom") return "Custom";
+  return "OpenAI-compatible";
 }
 
 async function discoverOpenAICompatibleModels(
@@ -115,11 +166,12 @@ function parseOpenAIModels(payload: OpenAIModelsResponse, providerKind: Provider
   if (!Array.isArray(payload.data)) return [];
   return payload.data.flatMap((item) => {
     if (!isRecord(item) || typeof item.id !== "string" || !item.id.trim()) return [];
+    const id = item.id.trim();
     return [
       {
-        id: item.id.trim(),
-        providerKind,
-        displayName: typeof item.id === "string" ? item.id.trim() : undefined,
+        id,
+        providerKind: getProviderKindForFocusedModelId(id) ?? providerKind,
+        displayName: id,
         raw: item
       }
     ];

--- a/src/main/services/providerConfigSave.ts
+++ b/src/main/services/providerConfigSave.ts
@@ -9,15 +9,10 @@ import {
   GENERAL_LAUNCH_ID,
   GPT_IMAGE_2_LAUNCH_ID,
   NANO_BANANA_3_LAUNCH_ID,
-  NANO_BANANA_3_MODEL_ID
+  NANO_BANANA_3_MODEL_ID,
+  getFocusedModelDefinition
 } from "../../shared/modelCatalog.js";
 import type { StoredProviderConfig } from "./stateMigration.js";
-
-const LAUNCH_PROVIDER = {
-  [GPT_IMAGE_2_LAUNCH_ID]: "openai",
-  [NANO_BANANA_3_LAUNCH_ID]: "gemini",
-  [GENERAL_LAUNCH_ID]: "custom"
-} as const satisfies Record<FocusedLaunchId, StoredProviderConfig["kind"]>;
 
 export function providerDisplayName(kind: StoredProviderConfig["kind"]): string {
   if (kind === "gemini") return "Gemini";
@@ -32,9 +27,9 @@ export function buildProviderConfigForSave(current: StoredProviderConfig, input:
   const defaultModel = defaultModelForProvider(kind, input.defaultModel);
   const baseURL = normalizeBaseURL(input.baseURL || defaultBaseURLForProvider(kind, current.baseURL));
   const discoveryInvalidated = providerChanged || baseURL !== current.baseURL;
-  const requestedLaunchId = compatibleLaunchForProvider(kind, input.activeLaunchId);
+  const requestedLaunchId = input.activeLaunchId;
   const activeLaunchId = activeLaunchForProvider(kind, requestedLaunchId ?? (providerChanged ? undefined : current.activeLaunchId));
-  const activeModelId = requestedLaunchId ? input.activeModelId?.trim() || defaultModel : defaultModel;
+  const activeModelId = requestedLaunchId ? input.activeModelId?.trim() || defaultModelForLaunch(requestedLaunchId, defaultModel) : defaultModel;
   const nextConfig: StoredProviderConfig = {
     ...current,
     kind,
@@ -87,8 +82,8 @@ function activeLaunchForProvider(kind: StoredProviderConfig["kind"], requestedLa
   return GPT_IMAGE_2_LAUNCH_ID;
 }
 
-function compatibleLaunchForProvider(kind: StoredProviderConfig["kind"], launchId: ProviderConfigInput["activeLaunchId"]): ProviderConfigInput["activeLaunchId"] {
-  if (!launchId) return undefined;
-  if (launchId === GENERAL_LAUNCH_ID) return launchId;
-  return LAUNCH_PROVIDER[launchId] === kind ? launchId : undefined;
+function defaultModelForLaunch(launchId: FocusedLaunchId, fallback: string): string {
+  const definition = getFocusedModelDefinition(launchId);
+  if (!definition || definition.launchId === GENERAL_LAUNCH_ID) return fallback;
+  return definition.defaultModelId;
 }

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -118,6 +118,49 @@ describe("renderer multi-model smoke", () => {
     );
   });
 
+  it("enables focused launches from discovered API models instead of the selected provider", async () => {
+    const bridge = await renderApp(
+      snapshot({
+        config: providerConfig({
+          kind: "openai",
+          name: "OpenAI",
+          baseURL: "https://gateway.example.com/v1",
+          apiKeySaved: true,
+          discoveredModels: [
+            { id: GPT_IMAGE_2_MODEL_ID, providerKind: "openai" },
+            { id: NANO_BANANA_3_MODEL_ID, providerKind: "gemini" }
+          ],
+          lastModelDiscoveryAt: now
+        })
+      })
+    );
+
+    expect(launchButton("GPT Image 2").disabled).toBe(false);
+    expect(launchButton("Nano Banana 3").disabled).toBe(false);
+
+    await click(launchButton("Nano Banana 3"));
+    await click(buttonByText("Generate", ".primary-run"));
+
+    expect(bridge.saveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "openai",
+        baseURL: "https://gateway.example.com/v1",
+        activeLaunchId: NANO_BANANA_3_LAUNCH_ID,
+        activeModelId: NANO_BANANA_3_MODEL_ID
+      })
+    );
+    expect(bridge.runJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "generate",
+        params: expect.objectContaining({
+          providerKind: "gemini",
+          launchId: NANO_BANANA_3_LAUNCH_ID,
+          model: NANO_BANANA_3_MODEL_ID
+        })
+      })
+    );
+  });
+
   it("can discover models, select Nano Banana 3, and run through the Electron bridge", async () => {
     const geminiConfig = providerConfig({
       kind: "gemini",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -75,7 +75,9 @@ import {
   NANO_BANANA_3_MODEL_ID,
   generalFallbackSupportsReferenceImages,
   getGeneralImageModelCandidate,
-  isGeneralFallbackProvider
+  isGeneralFallbackProvider,
+  isPotentialGeneralImageModel,
+  normalizeModelId
 } from "../shared/modelCatalog";
 import { getInitialLanguage, localizeValidationMessage, translations, type Language, type UiCopy } from "./i18n";
 
@@ -122,6 +124,7 @@ interface LaunchButtonState {
   launchId: FocusedLaunchId;
   displayName: string;
   modelId: string;
+  providerKind: ProviderKind;
   available: boolean;
   reason: string;
 }
@@ -238,12 +241,6 @@ function defaultLaunchForProvider(kind: ProviderKind): FocusedLaunchId {
   return GPT_IMAGE_2_LAUNCH_ID;
 }
 
-function providerForLaunch(launchId: FocusedLaunchId, fallback: ProviderKind): ProviderKind {
-  const definition = FOCUSED_MODEL_CATALOG.find((item) => item.launchId === launchId);
-  if (!definition || definition.launchId === GENERAL_LAUNCH_ID) return fallback;
-  return definition.providerKind;
-}
-
 function createOpenAIParams(modelId: string, current: ImageParams, config?: ProviderConfig): OpenAIImageParams {
   const base = isOpenAIImageParams(current) ? current : DEFAULT_IMAGE_PARAMS;
   return {
@@ -324,13 +321,13 @@ function defaultQualityForConfigSave(params: ImageParams, config: ProviderConfig
 
 function runtimeSelectionError(params: ImageParams, config: ProviderConfig, copy: UiCopy): string | null {
   if (isOpenAIImageParams(params)) {
-    return config.kind === "openai" && config.activeLaunchId === GPT_IMAGE_2_LAUNCH_ID ? null : copy.selectLaunchToRun("GPT Image 2");
+    return config.activeLaunchId === GPT_IMAGE_2_LAUNCH_ID ? null : copy.selectLaunchToRun("GPT Image 2");
   }
   if (isGeminiImageParams(params)) {
-    return config.kind === "gemini" && config.activeLaunchId === NANO_BANANA_3_LAUNCH_ID ? null : copy.selectLaunchToRun("Nano Banana 3");
+    return config.activeLaunchId === NANO_BANANA_3_LAUNCH_ID ? null : copy.selectLaunchToRun("Nano Banana 3");
   }
   if (!isGeneralImageParams(params)) return copy.generalRuntimeUnsupported;
-  if (config.kind !== params.providerKind || config.activeLaunchId !== GENERAL_LAUNCH_ID) return copy.selectLaunchToRun("General");
+  if (config.activeLaunchId !== GENERAL_LAUNCH_ID) return copy.selectLaunchToRun("General");
   if (!isGeneralFallbackProvider(params.providerKind)) return copy.generalRuntimeUnsupported;
   if (!params.model.trim()) return copy.launchUnavailableNoImageModels;
   return null;
@@ -363,11 +360,12 @@ function updateCustomSizeFromParams(params: ImageParams, setCustomSize: (value: 
 }
 
 function getLaunchButtonStates(config: ProviderConfig, copy: UiCopy): LaunchButtonState[] {
-  const discoveredIds = new Set(config.discoveredModels.map((model) => model.id));
   const hasDiscovery = config.discoveredModels.length > 0;
-  const generalCandidate = getGeneralImageModelCandidate(config.discoveredModels, config.kind);
+  const generalCandidate = getGeneralImageModelCandidate(config.discoveredModels, config.kind) ?? getAnyGeneralImageModelCandidate(config);
   return FOCUSED_MODEL_CATALOG.map((definition) => {
-    const modelId = definition.launchId === GENERAL_LAUNCH_ID ? generalCandidate?.id ?? "" : definition.defaultModelId;
+    const focusedModel = definition.launchId === GENERAL_LAUNCH_ID ? undefined : getFocusedDiscoveredModel(config, definition.modelIds);
+    const modelId = definition.launchId === GENERAL_LAUNCH_ID ? generalCandidate?.id ?? "" : focusedModel?.id ?? definition.defaultModelId;
+    const providerKind = definition.launchId === GENERAL_LAUNCH_ID ? generalCandidate?.providerKind ?? config.kind : definition.providerKind;
     let available = false;
     let reason = "";
 
@@ -386,9 +384,7 @@ function getLaunchButtonStates(config: ProviderConfig, copy: UiCopy): LaunchButt
         available = true;
         reason = copy.launchAvailable;
       }
-    } else if (config.kind !== definition.providerKind) {
-      reason = copy.launchUnavailableProvider(providerLabelFromKind(definition.providerKind));
-    } else if (definition.modelIds.some((id) => discoveredIds.has(id))) {
+    } else if (focusedModel) {
       available = true;
       reason = copy.launchAvailable;
     } else {
@@ -399,10 +395,20 @@ function getLaunchButtonStates(config: ProviderConfig, copy: UiCopy): LaunchButt
       launchId: definition.launchId,
       displayName: definition.displayName,
       modelId,
+      providerKind,
       available,
       reason
     };
   });
+}
+
+function getFocusedDiscoveredModel(config: ProviderConfig, modelIds: readonly string[]) {
+  const normalizedModelIds = new Set(modelIds.map(normalizeModelId));
+  return config.discoveredModels.find((model) => normalizedModelIds.has(normalizeModelId(model.id)));
+}
+
+function getAnyGeneralImageModelCandidate(config: ProviderConfig) {
+  return config.discoveredModels.find((model) => isGeneralFallbackProvider(model.providerKind) && isPotentialGeneralImageModel(model));
 }
 
 function getHistoryModelDetails(job: GenerationJob): HistoryModelDetails {
@@ -923,8 +929,8 @@ export function App() {
 
   async function launchModel(button: LaunchButtonState) {
     if (!bridge || !button.available) return;
-    const launchProvider = providerForLaunch(button.launchId, snapshot.config.kind);
-    const launchConfig = snapshot.config.kind === launchProvider ? snapshot.config : undefined;
+    const launchProvider = button.providerKind;
+    const launchConfig = snapshot.config;
     const nextParams = createLaunchParams(button.launchId, button.modelId, params, launchProvider, launchConfig);
     setParams(nextParams);
     if (isGeneralImageParams(nextParams)) {
@@ -942,9 +948,9 @@ export function App() {
     setIsSavingConfig(true);
     try {
       const config = await bridge.saveConfig({
-        kind: launchProvider,
-        baseURL: defaultBaseURLForProvider(launchProvider, baseURL),
-        defaultModel: defaultModelForConfigSave(launchProvider, nextParams, snapshot.config),
+        kind: snapshot.config.kind,
+        baseURL: snapshot.config.baseURL,
+        defaultModel: defaultModelForConfigSave(snapshot.config.kind, nextParams, snapshot.config),
         defaultSize: defaultSizeForConfigSave(nextParams, snapshot.config),
         defaultQuality: defaultQualityForConfigSave(nextParams, snapshot.config),
         timeoutMs: nextParams.timeoutMs,

--- a/src/shared/modelCatalog.ts
+++ b/src/shared/modelCatalog.ts
@@ -122,6 +122,15 @@ export function isFocusedImageModelId(providerKind: ProviderKind, modelId: strin
   );
 }
 
+export function getProviderKindForFocusedModelId(modelId: string): ProviderKind | undefined {
+  const normalizedId = normalizeModelId(modelId);
+  return FOCUSED_MODEL_CATALOG.find(
+    (definition) =>
+      definition.launchId !== GENERAL_LAUNCH_ID &&
+      definition.modelIds.some((id) => normalizeModelId(id) === normalizedId)
+  )?.providerKind;
+}
+
 export function isPotentialGeneralImageModel(model: DiscoveredModel): boolean {
   if (isFocusedImageModelId(model.providerKind, model.id)) return false;
   const haystack = normalizeModelId([model.id, model.displayName].filter(Boolean).join(" "));
@@ -133,6 +142,6 @@ export function getGeneralImageModelCandidate(discoveredModels: DiscoveredModel[
   return discoveredModels.find((model) => model.providerKind === providerKind && isPotentialGeneralImageModel(model));
 }
 
-function normalizeModelId(value: string): string {
+export function normalizeModelId(value: string): string {
   return value.trim().toLowerCase().replace(/^models\//, "");
 }


### PR DESCRIPTION
## Summary
- probe both OpenAI-compatible and Gemini model discovery for a saved URL/API key and infer the provider when only one protocol returns usable models
- classify focused model IDs from discovery results so launch buttons are based on detected model capability instead of the selected provider dropdown
- allow active launches to run against the current URL/key when the requested cross-provider model was discovered

## Validation
- pnpm build
- pnpm typecheck
- pnpm test
- pnpm verify:mock-model-discovery
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- git diff --check