### PR TITLE
Add model variants and robust Gemini image parsing

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -42,7 +42,7 @@ import {
   GPT_IMAGE_2_LAUNCH_ID,
   GPT_IMAGE_2_MODEL_ID,
   NANO_BANANA_3_LAUNCH_ID,
-  NANO_BANANA_3_MODEL_ID,
+  getFocusedModelDefinition,
   getModelDisplayName,
   isGeneralFallbackProvider,
   isPotentialGeneralImageModel,
@@ -583,7 +583,9 @@ function selectActiveLaunchForDiscovery(
   inferredProviderKind: StoredProviderConfig["kind"]
 ) {
   if (inferredProviderKind === "gemini") {
-    const nanoModel = models.find((model) => model.providerKind === "gemini" && normalizeModelId(model.id) === normalizeModelId(NANO_BANANA_3_MODEL_ID));
+    const nanoDefinition = getFocusedModelDefinition(NANO_BANANA_3_LAUNCH_ID);
+    const nanoModelIds = new Set((nanoDefinition?.modelIds ?? []).map(normalizeModelId));
+    const nanoModel = models.find((model) => model.providerKind === "gemini" && nanoModelIds.has(normalizeModelId(model.id)));
     if (nanoModel) {
       return {
         activeLaunchId: NANO_BANANA_3_LAUNCH_ID,

--- a/src/main/services/geminiImageAdapter.test.ts
+++ b/src/main/services/geminiImageAdapter.test.ts
@@ -191,6 +191,57 @@ describe("Gemini image adapter", () => {
     await expect(readFile(result.outputs[0].path)).resolves.toEqual(Buffer.from(tinyPngBase64, "base64"));
   });
 
+  it("saves OpenAI-style base64 image payloads from Gemini-compatible gateways", async () => {
+    const fetchImpl = (async () =>
+      Response.json({
+        data: [{ b64_json: tinyPngBase64, mime_type: "image/png" }]
+      })) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    const result = await runGeminiImageJob(job(), "mock-gemini-key", "https://api.test/v1beta", runtime);
+
+    expect(result.status).toBe("succeeded");
+    expect(result.outputs[0].fileName).toBe("job_gemini_test-result-0.png");
+    await expect(readFile(result.outputs[0].path)).resolves.toEqual(Buffer.from(tinyPngBase64, "base64"));
+  });
+
+  it("saves data URL image payloads from Gemini-compatible gateways", async () => {
+    const fetchImpl = (async () =>
+      Response.json({
+        data: [{ url: `data:image/png;base64,${tinyPngBase64}` }]
+      })) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    const result = await runGeminiImageJob(job(), "mock-gemini-key", "https://api.test/v1beta", runtime);
+
+    expect(result.status).toBe("succeeded");
+    expect(result.outputs[0].fileName).toBe("job_gemini_test-result-0.png");
+    await expect(readFile(result.outputs[0].path)).resolves.toEqual(Buffer.from(tinyPngBase64, "base64"));
+  });
+
+  it("downloads Gemini fileData image URLs before saving results", async () => {
+    const fetchImpl = (async (url: string | URL | Request) => {
+      if (String(url) === "https://files.example.com/generated.png") {
+        return new Response(Buffer.from(tinyPngBase64, "base64"), { headers: { "content-type": "image/png" } });
+      }
+      return Response.json({
+        candidates: [
+          {
+            content: {
+              parts: [{ fileData: { mimeType: "image/png", fileUri: "https://files.example.com/generated.png" } }]
+            }
+          }
+        ]
+      });
+    }) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    const result = await runGeminiImageJob(job(), "mock-gemini-key", "https://api.test/v1beta", runtime);
+
+    expect(result.status).toBe("succeeded");
+    await expect(readFile(result.outputs[0].path)).resolves.toEqual(Buffer.from(tinyPngBase64, "base64"));
+  });
+
   it("sends source and mask images as inlineData for guided-region inpaint", async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "image2tools-gemini-inputs-"));
     const sourcePath = path.join(tmpDir, "source.png");

--- a/src/main/services/geminiImageAdapter.ts
+++ b/src/main/services/geminiImageAdapter.ts
@@ -60,6 +60,7 @@ interface GeminiModelsResponse {
 
 interface GeminiGenerateContentResponse {
   candidates?: unknown[];
+  data?: unknown;
   usageMetadata?: {
     promptTokenCount?: number;
     candidatesTokenCount?: number;
@@ -78,6 +79,7 @@ interface GeminiApiErrorPayload {
 
 type GeminiImageJob = GenerationJob & { params: GeminiImageParams };
 type GeminiImageRuntime = ImageJobRuntime;
+type GeminiImageSource = GeminiInlineData & { url?: string };
 
 export const geminiImageAdapter: ImageProviderAdapter = {
   kind: "gemini",
@@ -285,7 +287,7 @@ async function handleGeminiGenerateContentResponse(
   const parsed = collectGeminiResponseParts(payload);
   const outputs = await saveGeminiImages(job.id, parsed.images, runtime);
   if (outputs.length === 0) {
-    throw new Error("Gemini API 没有返回可保存的图片。");
+    throw new Error(geminiNoImageMessage(parsed));
   }
 
   return {
@@ -309,13 +311,15 @@ async function handleGeminiGenerateContentResponse(
 }
 
 function collectGeminiResponseParts(payload: GeminiGenerateContentResponse): {
-  images: GeminiInlineData[];
+  images: GeminiImageSource[];
   textParts: string[];
   finishReasons: string[];
 } {
-  const images: GeminiInlineData[] = [];
+  const images: GeminiImageSource[] = [];
   const textParts: string[] = [];
   const finishReasons: string[] = [];
+
+  images.push(...openAIStyleImagesFromGeminiPayload(payload));
 
   const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
   for (const candidate of candidates) {
@@ -331,9 +335,9 @@ function collectGeminiResponseParts(payload: GeminiGenerateContentResponse): {
       if (typeof part.text === "string" && part.text.trim()) {
         textParts.push(part.text);
       }
-      const inlineData = inlineDataFromResponsePart(part);
-      if (inlineData) {
-        images.push(inlineData);
+      const imageSource = imageSourceFromResponsePart(part);
+      if (imageSource) {
+        images.push(imageSource);
       }
     }
   }
@@ -341,17 +345,48 @@ function collectGeminiResponseParts(payload: GeminiGenerateContentResponse): {
   return { images, textParts, finishReasons };
 }
 
-function inlineDataFromResponsePart(part: Record<string, unknown>): GeminiInlineData | null {
+function openAIStyleImagesFromGeminiPayload(payload: GeminiGenerateContentResponse): GeminiImageSource[] {
+  if (!Array.isArray(payload.data)) return [];
+  return payload.data.flatMap((item): GeminiImageSource[] => {
+    if (!isRecord(item)) return [];
+    const data = firstString(item.b64_json, item.b64Json, item.base64, item.data);
+    const url = firstString(item.url, item.uri);
+    const mimeType = firstString(item.mimeType, item.mime_type, item.mime);
+    const fallbackMimeType = mimeTypeFromUrl(data) ?? mimeTypeFromUrl(url) ?? "image/png";
+    if (data) return [{ mimeType: normalizeGeminiResponseMimeType(mimeType, fallbackMimeType), data }];
+    if (url) return [{ mimeType: normalizeGeminiResponseMimeType(mimeType, fallbackMimeType), data: "", url }];
+    return [];
+  });
+}
+
+function imageSourceFromResponsePart(part: Record<string, unknown>): GeminiImageSource | null {
   const rawInlineData = isRecord(part.inlineData) ? part.inlineData : isRecord(part.inline_data) ? part.inline_data : undefined;
-  if (!rawInlineData || typeof rawInlineData.data !== "string") return null;
-  const mimeType = typeof rawInlineData.mimeType === "string" ? rawInlineData.mimeType : "image/png";
+  if (rawInlineData) {
+    const data = firstString(rawInlineData.data, rawInlineData.b64_json, rawInlineData.b64Json, rawInlineData.base64, rawInlineData.bytesBase64Encoded);
+    const mimeType = firstString(rawInlineData.mimeType, rawInlineData.mime_type, rawInlineData.mime);
+    if (data) {
+      return {
+        mimeType: normalizeGeminiResponseMimeType(mimeType, mimeTypeFromUrl(data) ?? "image/png"),
+        data
+      };
+    }
+  }
+
+  const rawFileData = isRecord(part.fileData) ? part.fileData : isRecord(part.file_data) ? part.file_data : undefined;
+  const url = rawFileData
+    ? firstString(rawFileData.fileUri, rawFileData.file_uri, rawFileData.uri, rawFileData.url)
+    : firstString(part.fileUri, part.file_uri, part.url, part.uri);
+  if (!url) return null;
+  const mimeType = rawFileData ? firstString(rawFileData.mimeType, rawFileData.mime_type, rawFileData.mime) : undefined;
+  const fallbackMimeType = mimeTypeFromUrl(url) ?? "image/png";
   return {
-    mimeType: normalizeSupportedGeminiMimeType(mimeType),
-    data: rawInlineData.data
+    mimeType: normalizeGeminiResponseMimeType(mimeType, fallbackMimeType),
+    data: "",
+    url
   };
 }
 
-async function saveGeminiImages(jobId: string, images: GeminiInlineData[], runtime: GeminiImageRuntime): Promise<ImageAsset[]> {
+async function saveGeminiImages(jobId: string, images: GeminiImageSource[], runtime: GeminiImageRuntime): Promise<ImageAsset[]> {
   const outputs: ImageAsset[] = [];
   for (const [index, image] of images.entries()) {
     outputs.push(await saveBase64Image(jobId, image, index, runtime));
@@ -361,7 +396,7 @@ async function saveGeminiImages(jobId: string, images: GeminiInlineData[], runti
 
 async function saveBase64Image(
   jobId: string,
-  image: GeminiInlineData,
+  image: GeminiImageSource,
   index: number,
   runtime: GeminiImageRuntime
 ): Promise<ImageAsset> {
@@ -369,7 +404,7 @@ async function saveBase64Image(
   const mimeType = normalizeSupportedGeminiMimeType(image.mimeType);
   const fileName = `${jobId}-result-${index}.${extensionForMimeType(mimeType)}`;
   const filePath = path.join(runtime.imagesDir, fileName);
-  await fs.writeFile(filePath, Buffer.from(image.data, "base64"));
+  await fs.writeFile(filePath, Buffer.from(await geminiImageSourceToBase64(image, runtime), "base64"));
 
   return {
     id: `img_${randomUUID()}`,
@@ -380,6 +415,28 @@ async function saveBase64Image(
     sourceType: "result",
     createdAt: new Date().toISOString()
   };
+}
+
+async function geminiImageSourceToBase64(image: GeminiImageSource, runtime: GeminiImageRuntime): Promise<string> {
+  if (image.data) return image.data.startsWith("data:image/") ? dataUrlToBase64(image.data) : image.data;
+  if (!image.url) return "";
+  if (image.url.startsWith("data:image/")) return dataUrlToBase64(image.url);
+  const response = await fetchWithTimeout(
+    runtime.fetch,
+    image.url,
+    {
+      method: "GET",
+      headers: {
+        Accept: image.mimeType
+      }
+    },
+    30000
+  );
+  if (!response.ok) {
+    throw new Error(`Gemini API 返回了图片 URL，但下载失败：HTTP ${response.status}。`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  return buffer.toString("base64");
 }
 
 async function readGeminiModelsResponse(response: Response): Promise<DiscoveredModel[]> {
@@ -463,6 +520,29 @@ function requestIdFromHeaders(headers: Headers): string | undefined {
   return headers.get("x-request-id") ?? headers.get("x-goog-request-id") ?? undefined;
 }
 
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string" && value.trim().length > 0)?.trim();
+}
+
+function mimeTypeFromUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  const dataUrlMatch = /^data:([^;,]+)/i.exec(url);
+  if (dataUrlMatch?.[1]) return dataUrlMatch[1];
+  const normalizedUrl = url.toLowerCase().split(/[?#]/)[0] ?? "";
+  if (normalizedUrl.endsWith(".jpg") || normalizedUrl.endsWith(".jpeg")) return "image/jpeg";
+  if (normalizedUrl.endsWith(".webp")) return "image/webp";
+  if (normalizedUrl.endsWith(".png")) return "image/png";
+  return undefined;
+}
+
+function geminiNoImageMessage(parsed: { textParts: string[]; finishReasons: string[] }): string {
+  const details = [
+    parsed.finishReasons.length > 0 ? `finishReason: ${parsed.finishReasons.join(", ")}` : "",
+    parsed.textParts.length > 0 ? `text: ${parsed.textParts.join(" ").slice(0, 160)}` : ""
+  ].filter(Boolean);
+  return details.length > 0 ? `Gemini API 没有返回可保存的图片。${details.join("；")}` : "Gemini API 没有返回可保存的图片。";
+}
+
 function normalizeGeminiAdapterError(error: unknown): string {
   if (error instanceof Error) return redactLikelySecrets(error.message);
   return redactLikelySecrets(String(error));
@@ -472,6 +552,14 @@ function normalizeSupportedGeminiMimeType(mimeType: string): "image/png" | "imag
   const normalized = normalizeImageMimeType(mimeType);
   if (normalized === "image/png" || normalized === "image/jpeg" || normalized === "image/webp") return normalized;
   throw new Error("Gemini inline images must be PNG, JPEG, or WebP.");
+}
+
+function normalizeGeminiResponseMimeType(mimeType: string | undefined, fallback: string): "image/png" | "image/jpeg" | "image/webp" {
+  try {
+    return normalizeSupportedGeminiMimeType(mimeType ?? fallback);
+  } catch {
+    return normalizeSupportedGeminiMimeType(fallback);
+  }
 }
 
 function extensionForMimeType(mimeType: "image/png" | "image/jpeg" | "image/webp"): "png" | "jpg" | "webp" {

--- a/src/main/services/modelDiscovery.test.ts
+++ b/src/main/services/modelDiscovery.test.ts
@@ -38,7 +38,7 @@ describe("model discovery", () => {
   it("classifies focused model ids discovered from an OpenAI-compatible model list", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({
-        data: [{ id: "gpt-image-2", object: "model" }, { id: "gemini-3.1-flash-image", object: "model" }]
+        data: [{ id: "gpt-image-2", object: "model" }, { id: "gemini-3.1-flash-image", object: "model" }, { id: "gemini-3-pro-image", object: "model" }]
       })
     );
 
@@ -46,7 +46,8 @@ describe("model discovery", () => {
 
     expect(result.models).toEqual([
       expect.objectContaining({ id: "gpt-image-2", providerKind: "openai" }),
-      expect.objectContaining({ id: "gemini-3.1-flash-image", providerKind: "gemini" })
+      expect.objectContaining({ id: "gemini-3.1-flash-image", providerKind: "gemini" }),
+      expect.objectContaining({ id: "gemini-3-pro-image", providerKind: "gemini" })
     ]);
   });
 

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -17,6 +17,7 @@ import {
   DEFAULT_IMAGE_PARAMS
 } from "../shared/validation";
 import {
+  GEMINI_3_PRO_IMAGE_MODEL_ID,
   GPT_IMAGE_2_LAUNCH_ID,
   GPT_IMAGE_2_MODEL_ID,
   NANO_BANANA_3_LAUNCH_ID,
@@ -128,7 +129,8 @@ describe("renderer multi-model smoke", () => {
           apiKeySaved: true,
           discoveredModels: [
             { id: GPT_IMAGE_2_MODEL_ID, providerKind: "openai" },
-            { id: NANO_BANANA_3_MODEL_ID, providerKind: "gemini" }
+            { id: NANO_BANANA_3_MODEL_ID, providerKind: "gemini" },
+            { id: GEMINI_3_PRO_IMAGE_MODEL_ID, providerKind: "gemini", displayName: "Gemini 3 Pro Image" }
           ],
           lastModelDiscoveryAt: now
         })
@@ -139,6 +141,10 @@ describe("renderer multi-model smoke", () => {
     expect(launchButton("Nano Banana 3").disabled).toBe(false);
 
     await click(launchButton("Nano Banana 3"));
+    expect(document.body.textContent).toContain("Guided region");
+    const modelSelect = document.querySelector<HTMLSelectElement>(".launch-model-select select")!;
+    expect(modelSelect).toBeTruthy();
+    await selectOption(modelSelect, GEMINI_3_PRO_IMAGE_MODEL_ID);
     await click(buttonByText("Generate", ".primary-run"));
 
     expect(bridge.saveConfig).toHaveBeenCalledWith(
@@ -146,7 +152,7 @@ describe("renderer multi-model smoke", () => {
         kind: "openai",
         baseURL: "https://gateway.example.com/v1",
         activeLaunchId: NANO_BANANA_3_LAUNCH_ID,
-        activeModelId: NANO_BANANA_3_MODEL_ID
+        activeModelId: GEMINI_3_PRO_IMAGE_MODEL_ID
       })
     );
     expect(bridge.runJob).toHaveBeenCalledWith(
@@ -155,7 +161,7 @@ describe("renderer multi-model smoke", () => {
         params: expect.objectContaining({
           providerKind: "gemini",
           launchId: NANO_BANANA_3_LAUNCH_ID,
-          model: NANO_BANANA_3_MODEL_ID
+          model: GEMINI_3_PRO_IMAGE_MODEL_ID
         })
       })
     );
@@ -542,6 +548,13 @@ function buttonByText(text: string, selector = "button"): HTMLButtonElement {
 async function click(button: HTMLButtonElement) {
   await act(async () => {
     button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function selectOption(select: HTMLSelectElement, value: string) {
+  await act(async () => {
+    select.value = value;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
   });
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -74,6 +74,7 @@ import {
   NANO_BANANA_3_LAUNCH_ID,
   NANO_BANANA_3_MODEL_ID,
   generalFallbackSupportsReferenceImages,
+  getFocusedModelDefinition,
   getGeneralImageModelCandidate,
   isGeneralFallbackProvider,
   isPotentialGeneralImageModel,
@@ -127,6 +128,12 @@ interface LaunchButtonState {
   providerKind: ProviderKind;
   available: boolean;
   reason: string;
+}
+
+interface LaunchModelOption {
+  id: string;
+  providerKind: ProviderKind;
+  displayName: string;
 }
 
 type OpenAIParamPatch = Partial<Omit<OpenAIImageParams, "providerKind" | "launchId">>;
@@ -361,11 +368,11 @@ function updateCustomSizeFromParams(params: ImageParams, setCustomSize: (value: 
 
 function getLaunchButtonStates(config: ProviderConfig, copy: UiCopy): LaunchButtonState[] {
   const hasDiscovery = config.discoveredModels.length > 0;
-  const generalCandidate = getGeneralImageModelCandidate(config.discoveredModels, config.kind) ?? getAnyGeneralImageModelCandidate(config);
   return FOCUSED_MODEL_CATALOG.map((definition) => {
-    const focusedModel = definition.launchId === GENERAL_LAUNCH_ID ? undefined : getFocusedDiscoveredModel(config, definition.modelIds);
-    const modelId = definition.launchId === GENERAL_LAUNCH_ID ? generalCandidate?.id ?? "" : focusedModel?.id ?? definition.defaultModelId;
-    const providerKind = definition.launchId === GENERAL_LAUNCH_ID ? generalCandidate?.providerKind ?? config.kind : definition.providerKind;
+    const modelOptions = getLaunchModelOptions(config, definition.launchId);
+    const preferredModel = getPreferredLaunchModel(config, definition.launchId, modelOptions);
+    const modelId = preferredModel?.id ?? definition.defaultModelId;
+    const providerKind = preferredModel?.providerKind ?? definition.providerKind;
     let available = false;
     let reason = "";
 
@@ -378,13 +385,13 @@ function getLaunchButtonStates(config: ProviderConfig, copy: UiCopy): LaunchButt
     } else if (definition.launchId === GENERAL_LAUNCH_ID) {
       if (!isGeneralFallbackProvider(config.kind)) {
         reason = copy.generalRuntimeUnsupported;
-      } else if (!modelId) {
+      } else if (!preferredModel) {
         reason = copy.launchUnavailableNoImageModels;
       } else {
         available = true;
         reason = copy.launchAvailable;
       }
-    } else if (focusedModel) {
+    } else if (preferredModel) {
       available = true;
       reason = copy.launchAvailable;
     } else {
@@ -402,13 +409,51 @@ function getLaunchButtonStates(config: ProviderConfig, copy: UiCopy): LaunchButt
   });
 }
 
-function getFocusedDiscoveredModel(config: ProviderConfig, modelIds: readonly string[]) {
-  const normalizedModelIds = new Set(modelIds.map(normalizeModelId));
-  return config.discoveredModels.find((model) => normalizedModelIds.has(normalizeModelId(model.id)));
+function getLaunchModelOptions(config: ProviderConfig, launchId: FocusedLaunchId): LaunchModelOption[] {
+  if (launchId === GENERAL_LAUNCH_ID) {
+    return getGeneralLaunchModelOptions(config);
+  }
+  const definition = FOCUSED_MODEL_CATALOG.find((item) => item.launchId === launchId);
+  if (!definition) return [];
+  const normalizedModelIds = new Set(definition.modelIds.map(normalizeModelId));
+  return config.discoveredModels
+    .filter((model) => normalizedModelIds.has(normalizeModelId(model.id)))
+    .map(toLaunchModelOption);
 }
 
-function getAnyGeneralImageModelCandidate(config: ProviderConfig) {
-  return config.discoveredModels.find((model) => isGeneralFallbackProvider(model.providerKind) && isPotentialGeneralImageModel(model));
+function getPreferredLaunchModel(config: ProviderConfig, launchId: FocusedLaunchId, options: LaunchModelOption[]): LaunchModelOption | undefined {
+  if (config.activeLaunchId === launchId) {
+    const activeModel = options.find((model) => normalizeModelId(model.id) === normalizeModelId(config.activeModelId));
+    if (activeModel) return activeModel;
+  }
+  return options[0];
+}
+
+function getGeneralLaunchModelOptions(config: ProviderConfig): LaunchModelOption[] {
+  const preferred = getGeneralImageModelCandidate(config.discoveredModels, config.kind);
+  const candidates = config.discoveredModels.filter((model) => isGeneralFallbackProvider(model.providerKind) && isPotentialGeneralImageModel(model));
+  const ordered = preferred ? [preferred, ...candidates.filter((model) => model !== preferred)] : candidates;
+  return ordered.map(toLaunchModelOption);
+}
+
+function toLaunchModelOption(model: { id: string; providerKind: ProviderKind; displayName?: string }): LaunchModelOption {
+  return {
+    id: model.id,
+    providerKind: model.providerKind,
+    displayName: model.displayName?.trim() || model.id
+  };
+}
+
+function modeLabelsForParams(copy: UiCopy, params: ImageParams): UiCopy["modes"] {
+  if (inpaintCapabilityForParams(params) !== "guided-region") return copy.modes;
+  return {
+    ...copy.modes,
+    inpaint: copy.guidedRegionMode
+  };
+}
+
+function inpaintCapabilityForParams(params: ImageParams) {
+  return getFocusedModelDefinition(params.launchId)?.capabilities.inpaint ?? false;
 }
 
 function getHistoryModelDetails(job: GenerationJob): HistoryModelDetails {
@@ -523,11 +568,11 @@ export function App() {
   const bridge = getBridge();
   const [language, setLanguage] = useState<Language>(() => getInitialLanguage());
   const copy = translations[language];
-  const modeLabels = copy.modes;
   const [snapshot, setSnapshot] = useState<AppSnapshot>(fallbackSnapshot);
   const [mode, setMode] = useState<WorkMode>("generate");
   const [prompt, setPrompt] = useState("A clean product photo of a matte black travel mug on a brushed steel counter");
   const [params, setParams] = useState<ImageParams>(DEFAULT_IMAGE_PARAMS);
+  const modeLabels = useMemo(() => modeLabelsForParams(copy, params), [copy, params]);
   const [apiKey, setApiKey] = useState("");
   const [providerKind, setProviderKind] = useState<ProviderKind>("openai");
   const [baseURL, setBaseURL] = useState(DEFAULT_BASE_URL);
@@ -582,11 +627,15 @@ export function App() {
   const generalAllowsReferences = generalParams ? generalFallbackSupportsReferenceImages(generalParams.providerKind) : false;
   const showReferenceTools = !generalParams || generalAllowsReferences;
   const generalModeNotice = generalParams ? generalRuntimeNotice(generalParams.providerKind, copy) : copy.generalRuntimeUnsupported;
-  const usesExactMask = Boolean(openAIParams);
+  const activeInpaintCapability = inpaintCapabilityForParams(params);
+  const usesExactMask = activeInpaintCapability === "exact-mask";
   const sizeSelectValue = openAIParams && sizePresets.includes(openAIParams.size) ? openAIParams.size : "custom";
   const previewZoomPercent = Math.round(previewZoom * 100);
   const apiKeyPlaceholder = snapshot.config.apiKeyPreview ?? (snapshot.config.apiKeySaved ? copy.savedLocally : copy.pasteApiKey);
   const launchButtons = useMemo(() => getLaunchButtonStates(snapshot.config, copy), [copy, snapshot.config]);
+  const activeModelOptions = useMemo(() => getLaunchModelOptions(snapshot.config, snapshot.config.activeLaunchId), [snapshot.config]);
+  const activeModelValue =
+    activeModelOptions.find((model) => normalizeModelId(model.id) === normalizeModelId(snapshot.config.activeModelId))?.id ?? activeModelOptions[0]?.id ?? "";
   const activeLaunchDisplay = launchButtons.find((button) => button.launchId === snapshot.config.activeLaunchId)?.displayName ?? modelLabelFromId(snapshot.config.activeModelId);
   const maxSidebarWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, window.innerWidth - historyWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
   const maxHistoryWidth = Math.min(MAX_HISTORY_WIDTH, Math.max(MIN_HISTORY_WIDTH, window.innerWidth - sidebarWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
@@ -966,6 +1015,43 @@ export function App() {
     }
   }
 
+  async function selectLaunchModel(modelId: string) {
+    if (!bridge || !modelId) return;
+    const selectedModel = activeModelOptions.find((model) => model.id === modelId);
+    if (!selectedModel) return;
+    const nextParams = createLaunchParams(snapshot.config.activeLaunchId, selectedModel.id, params, selectedModel.providerKind, snapshot.config);
+    setParams(nextParams);
+    if (isGeneralImageParams(nextParams)) {
+      if (!generalFallbackSupportsReferenceImages(nextParams.providerKind)) {
+        setMode("generate");
+        setInputAssets([]);
+      }
+      setMaskAsset(null);
+      setMaskDataUrl(null);
+    }
+    updateCustomSizeFromParams(nextParams, setCustomSize);
+    markDraftChanged();
+    setIsSavingConfig(true);
+    try {
+      const config = await bridge.saveConfig({
+        kind: snapshot.config.kind,
+        baseURL: snapshot.config.baseURL,
+        defaultModel: defaultModelForConfigSave(snapshot.config.kind, nextParams, snapshot.config),
+        defaultSize: defaultSizeForConfigSave(nextParams, snapshot.config),
+        defaultQuality: defaultQualityForConfigSave(nextParams, snapshot.config),
+        timeoutMs: nextParams.timeoutMs,
+        activeLaunchId: snapshot.config.activeLaunchId,
+        activeModelId: selectedModel.id
+      });
+      applyConfig(config);
+      setNotice({ kind: "info", text: copy.notices.launchSelected(selectedModel.displayName) });
+    } catch (error) {
+      setNotice({ kind: "error", text: normalizeNotice(error) });
+    } finally {
+      setIsSavingConfig(false);
+    }
+  }
+
   async function testConnection() {
     if (!bridge) {
       setNotice({ kind: "error", text: copy.notices.bridgeTestConnection });
@@ -1333,7 +1419,7 @@ export function App() {
   }
 
   const sizeValidation = openAIParams ? validateGptImage2Size(openAIParams.size) : null;
-  const maskDescription = geminiParams ? copy.guidedRegionDescription : copy.maskDescription;
+  const maskDescription = activeInpaintCapability === "guided-region" ? copy.guidedRegionDescription : copy.maskDescription;
   const parameterSummary = openAIParams ? (
     <>
       <span>{copy.size}</span>
@@ -1678,6 +1764,18 @@ export function App() {
                 <small>{button.available ? button.modelId || copy.generalFallback : button.reason}</small>
               </button>
             ))}
+            {activeModelOptions.length > 1 && (
+              <label className="launch-model-select">
+                {copy.model}
+                <select value={activeModelValue} onChange={(event) => void selectLaunchModel(event.target.value)} disabled={isSavingConfig}>
+                  {activeModelOptions.map((model) => (
+                    <option key={`${model.providerKind}:${model.id}`} value={model.id}>
+                      {model.displayName}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
           </div>
         </form>
 

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -186,6 +186,7 @@ export interface UiCopy {
   zoomLevel: string;
   clicked: string;
   modes: Record<WorkMode, ModeCopy>;
+  guidedRegionMode: ModeCopy;
   notices: NoticeCopy;
   validation: ValidationCopy;
 }
@@ -312,6 +313,7 @@ export const translations: Record<Language, UiCopy> = {
       edit: { title: "Edit", action: "Edit", hint: "Use references" },
       inpaint: { title: "Inpaint", action: "Inpaint", hint: "Source + mask" }
     },
+    guidedRegionMode: { title: "Guided region", action: "Guide edit", hint: "Source + region" },
     notices: {
       ready: "Ready.",
       browserPreview: "Browser preview: Electron IPC is unavailable.",
@@ -494,6 +496,7 @@ export const translations: Record<Language, UiCopy> = {
       edit: { title: "编辑", action: "编辑", hint: "使用参考图" },
       inpaint: { title: "局部重绘", action: "局部重绘", hint: "源图 + 蒙版" }
     },
+    guidedRegionMode: { title: "区域引导", action: "区域引导", hint: "源图 + 区域" },
     notices: {
       ready: "就绪。",
       browserPreview: "浏览器预览：Electron IPC 不可用。",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -446,6 +446,15 @@ label {
   color: #2d6e60;
 }
 
+.launch-model-select {
+  gap: 5px;
+  padding-top: 2px;
+}
+
+.launch-model-select select {
+  min-width: 0;
+}
+
 .dot {
   width: 8px;
   height: 8px;

--- a/src/shared/modelCatalog.test.ts
+++ b/src/shared/modelCatalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   FOCUSED_MODEL_CATALOG,
+  GEMINI_3_PRO_IMAGE_MODEL_ID,
   GENERAL_LAUNCH_ID,
   GPT_IMAGE_2_LAUNCH_ID,
   NANO_BANANA_3_LAUNCH_ID,
@@ -37,6 +38,7 @@ describe("focused model catalog", () => {
       displayName: "Nano Banana 3",
       providerKind: "gemini",
       defaultModelId: NANO_BANANA_3_MODEL_ID,
+      modelIds: [NANO_BANANA_3_MODEL_ID, GEMINI_3_PRO_IMAGE_MODEL_ID],
       capabilities: {
         inpaint: "guided-region",
         outputText: true,
@@ -74,7 +76,8 @@ describe("focused model catalog", () => {
     ];
     const geminiModels = [
       { id: NANO_BANANA_3_MODEL_ID, providerKind: "gemini" as const },
-      { id: "gemini-3-pro-image", providerKind: "gemini" as const, displayName: "Gemini image model" }
+      { id: GEMINI_3_PRO_IMAGE_MODEL_ID, providerKind: "gemini" as const, displayName: "Gemini 3 Pro Image" },
+      { id: "gemini-2.0-flash-preview-image-generation", providerKind: "gemini" as const, displayName: "Gemini image model" }
     ];
     const customModels = [
       { id: "chat-model", providerKind: "custom" as const },
@@ -82,7 +85,7 @@ describe("focused model catalog", () => {
     ];
 
     expect(getGeneralImageModelCandidate(openAIModels, "openai")?.id).toBe("dall-e-3");
-    expect(getGeneralImageModelCandidate(geminiModels, "gemini")?.id).toBe("gemini-3-pro-image");
+    expect(getGeneralImageModelCandidate(geminiModels, "gemini")?.id).toBe("gemini-2.0-flash-preview-image-generation");
     expect(getGeneralImageModelCandidate(customModels, "custom")?.id).toBe("flux-pro");
     expect(getGeneralImageModelCandidate([{ id: "gpt-4.1", providerKind: "openai" }], "openai")).toBeUndefined();
   });

--- a/src/shared/modelCatalog.ts
+++ b/src/shared/modelCatalog.ts
@@ -4,6 +4,7 @@ export const GPT_IMAGE_2_LAUNCH_ID = "gpt-image-2" as const;
 export const GPT_IMAGE_2_MODEL_ID = "gpt-image-2" as const;
 export const NANO_BANANA_3_LAUNCH_ID = "nano-banana-3" as const;
 export const NANO_BANANA_3_MODEL_ID = "gemini-3.1-flash-image" as const;
+export const GEMINI_3_PRO_IMAGE_MODEL_ID = "gemini-3-pro-image" as const;
 export const GENERAL_LAUNCH_ID = "general" as const;
 export const GENERAL_MODEL_ID = "general" as const;
 
@@ -43,7 +44,7 @@ export const FOCUSED_MODEL_CATALOG = [
     launchId: NANO_BANANA_3_LAUNCH_ID,
     displayName: "Nano Banana 3",
     providerKind: "gemini",
-    modelIds: [NANO_BANANA_3_MODEL_ID],
+    modelIds: [NANO_BANANA_3_MODEL_ID, GEMINI_3_PRO_IMAGE_MODEL_ID],
     defaultModelId: NANO_BANANA_3_MODEL_ID,
     capabilities: {
       generate: true,


### PR DESCRIPTION
## Summary
- classify gemini-3-pro-image under the Nano Banana 3 launch family and add a concrete model selector for discovered variants
- drive the guided-region UI from launch capability metadata so Nano Banana 3 no longer presents exact-mask inpaint wording
- broaden Gemini image response parsing for OpenAI-style data payloads, data URLs, fileData URLs, alternate inline field names, and no-image diagnostics

## Validation
- pnpm typecheck
- pnpm test
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm build
- git diff --check