### PR TITLE
Parse Gemini text data URL images

### DIFF
--- a/src/main/services/geminiImageAdapter.test.ts
+++ b/src/main/services/geminiImageAdapter.test.ts
@@ -219,6 +219,34 @@ describe("Gemini image adapter", () => {
     await expect(readFile(result.outputs[0].path)).resolves.toEqual(Buffer.from(tinyPngBase64, "base64"));
   });
 
+  it("extracts Markdown data URL images from Gemini text parts", async () => {
+    const fetchImpl = (async () =>
+      Response.json({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: `![image](data:image/jpeg;base64,${tinyPngBase64})` }]
+            },
+            finishReason: "STOP"
+          }
+        ]
+      })) as typeof fetch;
+    const { runtime } = await createRuntime(fetchImpl);
+
+    const result = await runGeminiImageJob(job(), "mock-gemini-key", "https://api.test/v1beta", runtime);
+
+    expect(result.status).toBe("succeeded");
+    expect(result.outputs[0]).toMatchObject({
+      fileName: "job_gemini_test-result-0.jpg",
+      mimeType: "image/jpeg"
+    });
+    expect(result.providerMetadata).toMatchObject({
+      geminiTextParts: ["![image](data:image/jpeg;base64,[image data omitted])"],
+      geminiFinishReasons: ["STOP"]
+    });
+    await expect(readFile(result.outputs[0].path)).resolves.toEqual(Buffer.from(tinyPngBase64, "base64"));
+  });
+
   it("downloads Gemini fileData image URLs before saving results", async () => {
     const fetchImpl = (async (url: string | URL | Request) => {
       if (String(url) === "https://files.example.com/generated.png") {

--- a/src/main/services/geminiImageAdapter.ts
+++ b/src/main/services/geminiImageAdapter.ts
@@ -333,7 +333,8 @@ function collectGeminiResponseParts(payload: GeminiGenerateContentResponse): {
     for (const part of parts) {
       if (!isRecord(part)) continue;
       if (typeof part.text === "string" && part.text.trim()) {
-        textParts.push(part.text);
+        textParts.push(textPartForMetadata(part.text));
+        images.push(...imageSourcesFromText(part.text));
       }
       const imageSource = imageSourceFromResponsePart(part);
       if (imageSource) {
@@ -384,6 +385,24 @@ function imageSourceFromResponsePart(part: Record<string, unknown>): GeminiImage
     data: "",
     url
   };
+}
+
+function imageSourcesFromText(text: string): GeminiImageSource[] {
+  return [...text.matchAll(dataImageUrlPattern())].map((match) => {
+    const mimeType = normalizeGeminiResponseMimeType(match[1], "image/png");
+    return {
+      mimeType,
+      data: `data:${mimeType};base64,${match[2] ?? ""}`
+    };
+  });
+}
+
+function textPartForMetadata(text: string): string {
+  return text.trim().replace(dataImageUrlPattern(), (_match, mimeType: string) => `data:${mimeType};base64,[image data omitted]`);
+}
+
+function dataImageUrlPattern(): RegExp {
+  return /data:(image\/(?:png|jpe?g|webp));base64,([A-Za-z0-9+/_=-]+)/gi;
 }
 
 async function saveGeminiImages(jobId: string, images: GeminiImageSource[], runtime: GeminiImageRuntime): Promise<ImageAsset[]> {


### PR DESCRIPTION
## Summary
- extract data:image base64 URLs embedded in Gemini text parts, including Markdown image syntax returned by compatible gateways
- save those extracted images as normal outputs using their MIME type
- omit embedded base64 image bytes from stored Gemini text metadata to avoid bloating history/state

## Validation
- pnpm test -- src/main/services/geminiImageAdapter.test.ts
- pnpm typecheck
- pnpm verify:mock-gemini-api
- pnpm build
- git diff --check