### PR TITLE
Refine sidebar settings workflow

### DIFF
--- a/docs/updates/README.md
+++ b/docs/updates/README.md
@@ -1,13 +1,16 @@
 # Image2Tools Update Feed
 
-This directory is intended to be served by GitHub Pages from the repository
-`docs/` folder.
+This directory contains the update manifest consumed by the desktop app.
 
-Stable manifest URL:
+Default manifest URL used by packaged apps:
 
 ```text
-https://bliveren.github.io/image2tools/updates/latest.json
+https://raw.githubusercontent.com/Bliveren/image2tools/main/docs/updates/latest.json
 ```
+
+GitHub Pages can also serve this directory from `docs/` once Pages is enabled
+for the repository. Until then, the raw GitHub URL is the stable default to
+avoid a 404 update check.
 
 For each release:
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Nowo, Corgnitor, and Image2Tools contributors",
   "license": "MIT",
   "image2tools": {
-    "updateManifestUrl": "https://bliveren.github.io/image2tools/updates/latest.json"
+    "updateManifestUrl": "https://raw.githubusercontent.com/Bliveren/image2tools/main/docs/updates/latest.json"
   },
   "type": "module",
   "packageManager": "pnpm@10.25.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,6 +8,7 @@ import {
   shell,
   type IpcMainInvokeEvent
 } from "electron";
+import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { promises as fs } from "node:fs";
@@ -337,6 +338,25 @@ function redactLikelySecrets(value: string): string {
 
 function getUpdatesDir(): string {
   return path.join(app.getPath("userData"), "updates");
+}
+
+function quoteCmdArg(value: string): string {
+  return `"${value.replace(/%/g, "%%").replace(/"/g, '""')}"`;
+}
+
+function launchWindowsInstallerAndRestart(installerPath: string): void {
+  const command = [
+    "timeout /t 1 /nobreak > nul",
+    `start /wait "" ${quoteCmdArg(installerPath)} /S`,
+    `start "" ${quoteCmdArg(process.execPath)}`
+  ].join(" & ");
+  const child = spawn(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", command], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true
+  });
+  child.unref();
+  setTimeout(() => app.quit(), 50);
 }
 
 function getUpdateManifestUrl(): string {
@@ -823,7 +843,8 @@ async function handleCheckForUpdates(): Promise<UpdateCheckResult> {
     );
 
     if (!response.ok) {
-      throw new Error(`更新检查失败：HTTP ${response.status}`);
+      const notFoundHint = response.status === 404 ? "manifest 地址不存在，请检查更新地址或发布配置。" : "";
+      throw new Error(`更新检查失败：HTTP ${response.status}${notFoundHint ? `，${notFoundHint}` : ""}`);
     }
 
     const manifest = parseUpdateManifest(await response.json());
@@ -875,6 +896,16 @@ async function handleDownloadAndInstallUpdate(): Promise<UpdateInstallResult> {
   if (process.platform !== "win32") {
     await fs.chmod(filePath, 0o755).catch(() => undefined);
   }
+
+  if (process.platform === "win32") {
+    launchWindowsInstallerAndRestart(filePath);
+    return {
+      version: update.latestVersion,
+      filePath,
+      message: "更新包已下载并启动静默安装，应用将关闭并在安装完成后重新打开。"
+    };
+  }
+
   const openError = await shell.openPath(filePath);
   if (openError) {
     throw new Error(`更新包已下载，但无法打开安装程序：${openError}`);

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -64,6 +64,22 @@ describe("renderer multi-model smoke", () => {
     expect(document.body.textContent).toContain("Save an API key first.");
   });
 
+  it("auto-tests saved API config on startup and after config save", async () => {
+    const bridge = await renderApp(snapshot());
+
+    await flushAsync();
+
+    expect(bridge.testConnection).toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Connected");
+
+    vi.mocked(bridge.testConnection).mockClear();
+    await click(buttonByText("Save"));
+    await flushAsync();
+
+    expect(bridge.saveConfig).toHaveBeenCalled();
+    expect(bridge.testConnection).toHaveBeenCalledTimes(1);
+  });
+
   it("enables only GPT Image 2 for OpenAI discovery without enabling General", async () => {
     await renderApp(
       snapshot({
@@ -142,9 +158,9 @@ describe("renderer multi-model smoke", () => {
 
     await click(launchButton("Nano Banana 3"));
     expect(document.body.textContent).toContain("Guided region");
-    const modelSelect = document.querySelector<HTMLSelectElement>(".launch-model-select select")!;
-    expect(modelSelect).toBeTruthy();
-    await selectOption(modelSelect, GEMINI_3_PRO_IMAGE_MODEL_ID);
+    const modelOption = launchModelOption("Gemini 3 Pro Image");
+    expect(modelOption).toBeTruthy();
+    await click(modelOption);
     await click(buttonByText("Generate", ".primary-run"));
 
     expect(bridge.saveConfig).toHaveBeenCalledWith(
@@ -282,18 +298,21 @@ describe("renderer multi-model smoke", () => {
     );
   });
 
-  it("keeps service config, launch buttons, and parameters in a clear left-rail order", async () => {
+  it("keeps model config, launch buttons, parameters, and updates in a clear left-rail order", async () => {
     await renderApp(snapshot());
     const sidebar = document.querySelector<HTMLElement>(".sidebar")!;
     const configSection = sidebar.querySelector<HTMLElement>("form.tool-section")!;
-    const launchStrip = sidebar.querySelector<HTMLElement>(".launch-strip")!;
+    const launchSection = sidebar.querySelector<HTMLElement>(".launch-section")!;
     const parameterSection = buttonByText("Parameters", ".section-toggle").closest<HTMLElement>(".tool-section")!;
+    const updatePanel = sidebar.querySelector<HTMLElement>(".update-panel")!;
 
-    expect(configSection.textContent).toContain("Provider");
-    expect(launchStrip.textContent).toContain("Launch");
+    expect(configSection.textContent).toContain("Model config");
+    expect(launchSection.textContent).toContain("Launch");
     expect(parameterSection.textContent).toContain("Parameters");
-    expect(configSection.compareDocumentPosition(launchStrip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(launchStrip.compareDocumentPosition(parameterSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(updatePanel.textContent).toContain("Updates");
+    expect(configSection.compareDocumentPosition(launchSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(launchSection.compareDocumentPosition(parameterSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(parameterSection.compareDocumentPosition(updatePanel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("supports keyboard resizing without losing fixed history layout", async () => {
@@ -343,7 +362,24 @@ describe("renderer multi-model smoke", () => {
     expect(document.querySelector(".launch-button small")).toBeTruthy();
     expect(document.querySelectorAll(".history-item")).toHaveLength(6);
     expect(buttonByText("Show all 10")).toBeTruthy();
-    expect(launchButton("General").textContent).toContain("gemini-2.0-flash-preview-image-generation-with-a-very-long-display-name");
+    expect(launchButton("General").textContent).toContain("Gemini image fallback with a very long display name");
+  });
+
+  it("requires confirmation before clearing all history", async () => {
+    const bridge = await renderApp(snapshot({ history: [geminiJob(0), geminiJob(1)] }));
+    const clearAllButton = document.querySelector<HTMLButtonElement>('button[title="Clear all history records"]')!;
+
+    expect(clearAllButton).toBeTruthy();
+    await click(clearAllButton);
+
+    expect(bridge.clearHistory).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Clear all history?");
+    expect(document.body.textContent).toContain("This will delete all 2 history records");
+
+    await click(buttonByText("Clear all", ".danger-button"));
+
+    expect(bridge.clearHistory).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).not.toContain("Clear all history?");
   });
 
   it("renders Gemini results on the canvas and routes downloads through the bridge", async () => {
@@ -539,22 +575,26 @@ function launchButton(name: string): HTMLButtonElement {
   return buttonByText(name, ".launch-button");
 }
 
+function launchModelOption(name: string): HTMLButtonElement {
+  return buttonByText(name, ".launch-model-option");
+}
+
 function buttonByText(text: string, selector = "button"): HTMLButtonElement {
   const button = [...document.querySelectorAll<HTMLButtonElement>(selector)].find((item) => item.textContent?.includes(text));
   if (!button) throw new Error(`Button containing "${text}" was not found.`);
   return button;
 }
 
-async function click(button: HTMLButtonElement) {
+async function flushAsync() {
   await act(async () => {
-    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
   });
 }
 
-async function selectOption(select: HTMLSelectElement, value: string) {
+async function click(button: HTMLButtonElement) {
   await act(async () => {
-    select.value = value;
-    select.dispatchEvent(new Event("change", { bubbles: true }));
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,7 +14,6 @@ import {
   Languages,
   Loader2,
   Paintbrush,
-  PlugZap,
   RefreshCw,
   Save,
   Search,
@@ -94,6 +93,11 @@ interface MaskCheck {
   message: string;
 }
 
+interface ConnectionCheck {
+  status: "idle" | "checking" | "ok" | "error";
+  message?: string;
+}
+
 const sizePresets = ["auto", "1024x1024", "1536x1024", "1024x1536", "2048x1152", "2048x2048", "3840x2160", "2160x3840"];
 const qualityOptions: ImageQuality[] = ["auto", "low", "medium", "high"];
 const formatOptions: ImageFormat[] = ["png", "jpeg", "webp"];
@@ -108,7 +112,7 @@ const MIN_SIDEBAR_WIDTH = 260;
 const MAX_SIDEBAR_WIDTH = 430;
 const MIN_HISTORY_WIDTH = 280;
 const MAX_HISTORY_WIDTH = 460;
-const MIN_WORKSPACE_WIDTH = 620;
+const MIN_WORKSPACE_WIDTH = 680;
 const RESIZER_WIDTH = 12;
 const HISTORY_COLLAPSED_LIMIT = 6;
 const DEFAULT_HISTORY_MODEL_DISPLAY = "GPT Image 2";
@@ -456,6 +460,17 @@ function inpaintCapabilityForParams(params: ImageParams) {
   return getFocusedModelDefinition(params.launchId)?.capabilities.inpaint ?? false;
 }
 
+function connectionStatusLabel(check: ConnectionCheck, copy: UiCopy): string {
+  if (check.status === "checking") return copy.connectionChecking;
+  if (check.status === "ok") return copy.connectionOk;
+  if (check.status === "error") return copy.connectionError;
+  return copy.connectionIdle;
+}
+
+function discoverySummary(config: ProviderConfig, copy: UiCopy): string {
+  return config.lastModelDiscoveryError ?? copy.discoveredModelsCount(config.discoveredModels.length);
+}
+
 function getHistoryModelDetails(job: GenerationJob): HistoryModelDetails {
   const jobRecord = runtimeRecord(job);
   const paramsRecord = runtimeRecord(job.params);
@@ -592,10 +607,13 @@ export function App() {
   const [isDiscoveringModels, setIsDiscoveringModels] = useState(false);
   const [isClearingApiKey, setIsClearingApiKey] = useState(false);
   const [isTestingConnection, setIsTestingConnection] = useState(false);
+  const [connectionCheck, setConnectionCheck] = useState<ConnectionCheck>({ status: "idle" });
   const [isRunning, setIsRunning] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [openLaunchMenuId, setOpenLaunchMenuId] = useState<FocusedLaunchId | null>(null);
   const [historySearch, setHistorySearch] = useState("");
   const [isHistoryExpanded, setIsHistoryExpanded] = useState(false);
+  const [isClearHistoryConfirmOpen, setIsClearHistoryConfirmOpen] = useState(false);
   const [brushSize, setBrushSize] = useState(72);
   const [isPainting, setIsPainting] = useState(false);
   const [draftUpdatedAt, setDraftUpdatedAt] = useState<string | null>(null);
@@ -613,6 +631,7 @@ export function App() {
   const maskCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const sourceImageRef = useRef<HTMLImageElement | null>(null);
   const paintedDuringStrokeRef = useRef(false);
+  const hasAutoTestedConnectionRef = useRef(false);
 
   const sourceAsset = inputAssets[0];
   const sourcePreview = assetSource(sourceAsset);
@@ -633,10 +652,11 @@ export function App() {
   const previewZoomPercent = Math.round(previewZoom * 100);
   const apiKeyPlaceholder = snapshot.config.apiKeyPreview ?? (snapshot.config.apiKeySaved ? copy.savedLocally : copy.pasteApiKey);
   const launchButtons = useMemo(() => getLaunchButtonStates(snapshot.config, copy), [copy, snapshot.config]);
-  const activeModelOptions = useMemo(() => getLaunchModelOptions(snapshot.config, snapshot.config.activeLaunchId), [snapshot.config]);
-  const activeModelValue =
-    activeModelOptions.find((model) => normalizeModelId(model.id) === normalizeModelId(snapshot.config.activeModelId))?.id ?? activeModelOptions[0]?.id ?? "";
   const activeLaunchDisplay = launchButtons.find((button) => button.launchId === snapshot.config.activeLaunchId)?.displayName ?? modelLabelFromId(snapshot.config.activeModelId);
+  const connectionLabel = connectionStatusLabel(connectionCheck, copy);
+  const connectionTitle = connectionCheck.status === "error" && connectionCheck.message ? copy.connectionErrorDetail(connectionCheck.message) : connectionLabel;
+  const connectionErrorText = connectionCheck.status === "error" && connectionCheck.message ? copy.connectionErrorDetail(connectionCheck.message) : null;
+  const discoveryText = discoverySummary(snapshot.config, copy);
   const maxSidebarWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, window.innerWidth - historyWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
   const maxHistoryWidth = Math.min(MAX_HISTORY_WIDTH, Math.max(MIN_HISTORY_WIDTH, window.innerWidth - sidebarWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
 
@@ -763,6 +783,18 @@ export function App() {
   useEffect(() => {
     void refreshSnapshot();
   }, []);
+
+  useEffect(() => {
+    if (!bridge) return;
+    if (!snapshot.config.apiKeySaved) {
+      hasAutoTestedConnectionRef.current = false;
+      setConnectionCheck({ status: "idle" });
+      return;
+    }
+    if (hasAutoTestedConnectionRef.current) return;
+    hasAutoTestedConnectionRef.current = true;
+    void runConnectionTest({ silent: true });
+  }, [bridge, snapshot.config.apiKeySaved, snapshot.config.updatedAt]);
 
   useEffect(() => {
     if (!bridge || !hasRestoredDraft || !hasUserChangedDraft) return;
@@ -920,6 +952,11 @@ export function App() {
     });
   }
 
+  function resetConnectionCheckForConfigEdit() {
+    hasAutoTestedConnectionRef.current = false;
+    setConnectionCheck({ status: "idle" });
+  }
+
   async function saveConfig() {
     if (!bridge) {
       setNotice({ kind: "error", text: copy.notices.bridgeSaveConfig });
@@ -946,6 +983,12 @@ export function App() {
         kind: config.lastModelDiscoveryError ? "error" : "success",
         text: config.lastModelDiscoveryError ? config.lastModelDiscoveryError : copy.notices.configSaved
       });
+      if (config.apiKeySaved) {
+        hasAutoTestedConnectionRef.current = true;
+        await runConnectionTest({ silent: false, apiKeySaved: config.apiKeySaved });
+      } else {
+        setConnectionCheck({ status: "idle" });
+      }
     } catch (error) {
       setNotice({ kind: "error", text: normalizeNotice(error) });
     } finally {
@@ -972,6 +1015,7 @@ export function App() {
 
   function changeProvider(kind: ProviderKind) {
     markDraftChanged();
+    resetConnectionCheckForConfigEdit();
     setProviderKind(kind);
     setBaseURL(defaultBaseURLForProvider(kind, baseURL));
   }
@@ -1015,11 +1059,12 @@ export function App() {
     }
   }
 
-  async function selectLaunchModel(modelId: string) {
-    if (!bridge || !modelId) return;
-    const selectedModel = activeModelOptions.find((model) => model.id === modelId);
-    if (!selectedModel) return;
-    const nextParams = createLaunchParams(snapshot.config.activeLaunchId, selectedModel.id, params, selectedModel.providerKind, snapshot.config);
+  async function selectLaunchModel(launchId: FocusedLaunchId, selectedModel: LaunchModelOption) {
+    if (!bridge || !selectedModel.id) return;
+    const modelOptions = getLaunchModelOptions(snapshot.config, launchId);
+    const isAvailable = modelOptions.some((model) => model.id === selectedModel.id && model.providerKind === selectedModel.providerKind);
+    if (!isAvailable) return;
+    const nextParams = createLaunchParams(launchId, selectedModel.id, params, selectedModel.providerKind, snapshot.config);
     setParams(nextParams);
     if (isGeneralImageParams(nextParams)) {
       if (!generalFallbackSupportsReferenceImages(nextParams.providerKind)) {
@@ -1040,10 +1085,11 @@ export function App() {
         defaultSize: defaultSizeForConfigSave(nextParams, snapshot.config),
         defaultQuality: defaultQualityForConfigSave(nextParams, snapshot.config),
         timeoutMs: nextParams.timeoutMs,
-        activeLaunchId: snapshot.config.activeLaunchId,
+        activeLaunchId: launchId,
         activeModelId: selectedModel.id
       });
       applyConfig(config);
+      setOpenLaunchMenuId(null);
       setNotice({ kind: "info", text: copy.notices.launchSelected(selectedModel.displayName) });
     } catch (error) {
       setNotice({ kind: "error", text: normalizeNotice(error) });
@@ -1052,21 +1098,30 @@ export function App() {
     }
   }
 
-  async function testConnection() {
+  async function runConnectionTest({ silent = false, apiKeySaved = snapshot.config.apiKeySaved }: { silent?: boolean; apiKeySaved?: boolean } = {}) {
     if (!bridge) {
-      setNotice({ kind: "error", text: copy.notices.bridgeTestConnection });
+      if (!silent) setNotice({ kind: "error", text: copy.notices.bridgeTestConnection });
+      return;
+    }
+    if (!apiKeySaved) {
+      setConnectionCheck({ status: "idle" });
       return;
     }
     setIsTestingConnection(true);
+    setConnectionCheck({ status: "checking" });
     try {
-      if (apiKey.trim() || baseURL !== snapshot.config.baseURL || providerKind !== snapshot.config.kind) {
-        await saveConfig();
-      }
       const result = await bridge.testConnection();
-      setNotice({ kind: result.ok ? "success" : "error", text: result.message });
-      await refreshSnapshot();
+      setConnectionCheck({ status: result.ok ? "ok" : "error", message: result.message });
+      if (!silent || !result.ok) {
+        setNotice({
+          kind: result.ok ? "success" : "error",
+          text: result.ok ? result.message : copy.connectionErrorDetail(result.message)
+        });
+      }
     } catch (error) {
-      setNotice({ kind: "error", text: normalizeNotice(error) });
+      const message = normalizeNotice(error);
+      setConnectionCheck({ status: "error", message });
+      setNotice({ kind: "error", text: copy.connectionErrorDetail(message) });
     } finally {
       setIsTestingConnection(false);
     }
@@ -1082,6 +1137,8 @@ export function App() {
       const config = await bridge.clearApiKey();
       applyConfig(config);
       setApiKey("");
+      hasAutoTestedConnectionRef.current = false;
+      setConnectionCheck({ status: "idle" });
       setNotice({ kind: "success", text: copy.notices.keyCleared });
     } catch (error) {
       setNotice({ kind: "error", text: normalizeNotice(error) });
@@ -1108,6 +1165,17 @@ export function App() {
     if (!bridge) return;
     setIsInstallingUpdate(true);
     try {
+      await bridge.saveDraft({
+        activeLaunchId: params.launchId,
+        activeModelId: params.model,
+        mode,
+        prompt,
+        params,
+        inputAssets,
+        maskAsset: maskAsset ?? undefined,
+        maskDataUrl: maskDataUrl ?? undefined,
+        brushSize
+      });
       const result = await bridge.downloadAndInstallUpdate();
       setNotice({ kind: "success", text: copy.updateReady(result.version) });
     } catch (error) {
@@ -1251,12 +1319,13 @@ export function App() {
     }
   }
 
-  async function clearHistory() {
+  async function confirmClearHistory() {
     if (!bridge) return;
     try {
       const history = await bridge.clearHistory();
       setSnapshot((current) => ({ ...current, history }));
       setActiveJob(null);
+      setIsClearHistoryConfirmOpen(false);
       setNotice({ kind: "success", text: copy.notices.historyCleared });
     } catch (error) {
       setNotice({ kind: "error", text: normalizeNotice(error) });
@@ -1654,43 +1723,30 @@ export function App() {
           </div>
         </section>
 
-        <section className="update-panel">
-          <div className="section-title">
-            <RefreshCw size={16} />
-            <h2>{copy.updates}</h2>
-          </div>
-          <div className="update-status">
-            <span>
-              {copy.currentVersion}: {snapshot.appVersion}
-            </span>
-            <strong data-status={updateCheck?.status ?? "idle"}>{isCheckingUpdate ? copy.checkingUpdates : formatUpdateStatus(updateCheck)}</strong>
-          </div>
-          <div className="button-row">
-            <button type="button" className="secondary" onClick={checkForUpdates} disabled={!bridge || isCheckingUpdate || isInstallingUpdate}>
-              {isCheckingUpdate ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-              {isCheckingUpdate ? copy.checkingUpdates : copy.checkUpdates}
-            </button>
-            <button
-              type="button"
-              onClick={downloadAndInstallUpdate}
-              disabled={!bridge || updateCheck?.status !== "available" || isCheckingUpdate || isInstallingUpdate}
-            >
-              {isInstallingUpdate ? <Loader2 className="spin" size={16} /> : <Download size={16} />}
-              {isInstallingUpdate ? copy.downloadingUpdate : copy.installUpdate}
-            </button>
-          </div>
-        </section>
-
         <form
-          className="tool-section"
+          className="tool-section model-config-section"
           onSubmit={(event) => {
             event.preventDefault();
             void saveConfig();
           }}
         >
-          <div className="section-title">
-            <KeyRound size={16} />
-            <h2>{copy.provider}</h2>
+          <div className="section-title config-title">
+            <div className="section-title-label">
+              <KeyRound size={16} />
+              <h2>{copy.provider}</h2>
+            </div>
+            <span className="connection-badge" data-status={connectionCheck.status} title={connectionTitle}>
+              {isTestingConnection || connectionCheck.status === "checking" ? (
+                <Loader2 className="spin" size={13} />
+              ) : connectionCheck.status === "ok" ? (
+                <CheckCircle2 size={13} />
+              ) : connectionCheck.status === "error" ? (
+                <AlertTriangle size={13} />
+              ) : (
+                <span className="connection-dot" />
+              )}
+              {connectionLabel}
+            </span>
           </div>
           <label>
             {copy.providerLabel}
@@ -1706,22 +1762,27 @@ export function App() {
               type="password"
               autoComplete="off"
               value={apiKey}
-              onChange={(event) => setApiKey(event.target.value)}
+              onChange={(event) => {
+                resetConnectionCheckForConfigEdit();
+                setApiKey(event.target.value);
+              }}
               placeholder={apiKeyPlaceholder}
             />
           </label>
           <label>
             {copy.baseURL}
-            <input value={baseURL} onChange={(event) => setBaseURL(event.target.value)} />
+            <input
+              value={baseURL}
+              onChange={(event) => {
+                resetConnectionCheckForConfigEdit();
+                setBaseURL(event.target.value);
+              }}
+            />
           </label>
           <div className="button-row">
             <button type="button" onClick={saveConfig} disabled={isSavingConfig}>
               {isSavingConfig ? <Loader2 className="spin" size={16} /> : <Save size={16} />}
               {copy.save}
-            </button>
-            <button type="button" className="secondary" onClick={testConnection} disabled={isTestingConnection}>
-              {isTestingConnection ? <Loader2 className="spin" size={16} /> : <PlugZap size={16} />}
-              {copy.test}
             </button>
             <button type="button" className="ghost" onClick={clearApiKey} disabled={isClearingApiKey || !snapshot.config.apiKeySaved}>
               {isClearingApiKey ? <Loader2 className="spin" size={16} /> : <Trash2 size={16} />}
@@ -1732,58 +1793,92 @@ export function App() {
             <span className={snapshot.config.apiKeySaved ? "dot ok" : "dot"} />
             {snapshot.config.apiKeySaved ? copy.keySaved : copy.noKeySaved}
           </div>
-          <div className="model-discovery-status" data-kind={snapshot.config.lastModelDiscoveryError ? "error" : "info"}>
-            <span>{copy.discoveryStatus}</span>
-            <strong>
-              {snapshot.config.lastModelDiscoveryError
-                ? snapshot.config.lastModelDiscoveryError
-                : snapshot.config.lastModelDiscoveryAt
-                  ? copy.discoveryLastRun(formatDate(snapshot.config.lastModelDiscoveryAt), snapshot.config.discoveredModels.length)
-                  : copy.discoveryNotRun}
-            </strong>
-          </div>
-          <button type="button" className="secondary discover-button" onClick={discoverModels} disabled={!bridge || isDiscoveringModels || !snapshot.config.apiKeySaved}>
-            {isDiscoveringModels ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-            {isDiscoveringModels ? copy.discoveringModels : copy.discoverModels}
-          </button>
-          <div className="launch-strip" aria-label={copy.launchModels}>
-            <div className="launch-strip-header">
-              <span>{copy.launchModels}</span>
-              <strong>{activeLaunchDisplay}</strong>
-            </div>
-            {launchButtons.map((button) => (
-              <button
-                key={button.launchId}
-                type="button"
-                className={snapshot.config.activeLaunchId === button.launchId ? "launch-button active" : "launch-button"}
-                onClick={() => launchModel(button)}
-                disabled={!button.available || isSavingConfig}
-                title={button.reason}
-              >
-                <span>{button.displayName}</span>
-                <small>{button.available ? button.modelId || copy.generalFallback : button.reason}</small>
-              </button>
-            ))}
-            {activeModelOptions.length > 1 && (
-              <label className="launch-model-select">
-                {copy.model}
-                <select value={activeModelValue} onChange={(event) => void selectLaunchModel(event.target.value)} disabled={isSavingConfig}>
-                  {activeModelOptions.map((model) => (
-                    <option key={`${model.providerKind}:${model.id}`} value={model.id}>
-                      {model.displayName}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
+          {connectionErrorText && <p className="inline-check error config-error-detail">{connectionErrorText}</p>}
+          <div className="discovery-row">
+            <button type="button" className="secondary discover-button" onClick={discoverModels} disabled={!bridge || isDiscoveringModels || !snapshot.config.apiKeySaved}>
+              {isDiscoveringModels ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+              {isDiscoveringModels ? copy.discoveringModels : copy.discoverModels}
+            </button>
+            <span className="model-discovery-summary" data-kind={snapshot.config.lastModelDiscoveryError ? "error" : "info"} title={snapshot.config.lastModelDiscoveryError ?? discoveryText}>
+              {discoveryText}
+            </span>
           </div>
         </form>
 
+        <section className="tool-section launch-section">
+          <div className="section-title launch-title">
+            <div className="section-title-label">
+              <Wand2 size={16} />
+              <h2>{copy.launchModels}</h2>
+            </div>
+            <strong>{activeLaunchDisplay}</strong>
+          </div>
+          <div className="launch-strip" aria-label={copy.launchModels}>
+            {launchButtons.map((button) => {
+              const modelOptions = getLaunchModelOptions(snapshot.config, button.launchId);
+              const hasModelMenu = button.available && modelOptions.length > 1;
+              const activeModelOption =
+                modelOptions.find((model) => model.id === snapshot.config.activeModelId && model.providerKind === button.providerKind) ??
+                modelOptions.find((model) => model.id === button.modelId && model.providerKind === button.providerKind);
+              const isActive = snapshot.config.activeLaunchId === button.launchId;
+              return (
+                <div key={button.launchId} className="launch-item">
+                  <button
+                    type="button"
+                    className={isActive ? "launch-button active" : "launch-button"}
+                    onClick={() => {
+                      if (!button.available) return;
+                      setOpenLaunchMenuId((current) => (hasModelMenu ? (current === button.launchId ? null : button.launchId) : null));
+                      void launchModel(button);
+                    }}
+                    disabled={!button.available || isSavingConfig}
+                    title={button.reason}
+                    aria-expanded={hasModelMenu ? openLaunchMenuId === button.launchId : undefined}
+                  >
+                    <span className="launch-button-main">
+                      <span>{button.displayName}</span>
+                      {hasModelMenu && (openLaunchMenuId === button.launchId ? <ChevronUp size={15} /> : <ChevronDown size={15} />)}
+                    </span>
+                    <small>{button.available ? activeModelOption?.displayName ?? (button.modelId || copy.generalFallback) : button.reason}</small>
+                  </button>
+                  {hasModelMenu && openLaunchMenuId === button.launchId && (
+                    <div className="launch-model-menu" role="listbox" aria-label={`${button.displayName} ${copy.model}`}>
+                      {modelOptions.map((model) => {
+                        const isSelected = snapshot.config.activeLaunchId === button.launchId && snapshot.config.activeModelId === model.id && params.providerKind === model.providerKind;
+                        return (
+                          <button
+                            key={`${model.providerKind}:${model.id}`}
+                            type="button"
+                            className={isSelected ? "launch-model-option active" : "launch-model-option"}
+                            onClick={() => void selectLaunchModel(button.launchId, model)}
+                            disabled={isSavingConfig}
+                            role="option"
+                            aria-selected={isSelected}
+                            title={model.id}
+                          >
+                            <span>{model.displayName}</span>
+                            <small>{providerLabelFromKind(model.providerKind)}</small>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
         <section className="tool-section">
           <button type="button" className="section-toggle" onClick={() => setShowAdvanced((current) => !current)}>
-            <SlidersHorizontal size={16} />
-            {copy.parameters}
-            <span>{showAdvanced ? copy.hide : copy.show}</span>
+            <span className="section-toggle-label">
+              <SlidersHorizontal size={16} />
+              <span>{copy.parameters}</span>
+            </span>
+            <span className="section-toggle-state">
+              {showAdvanced ? copy.hide : copy.show}
+              {showAdvanced ? <ChevronUp size={15} /> : <ChevronDown size={15} />}
+            </span>
           </button>
 
           <div className="compact-grid">
@@ -1808,6 +1903,25 @@ export function App() {
         <section className="notice-area" data-kind={notice.kind}>
           {notice.kind === "error" ? <AlertTriangle size={16} /> : <CheckCircle2 size={16} />}
           <span>{notice.text}</span>
+        </section>
+
+        <section className="update-panel sidebar-bottom">
+          <div className="section-title">
+            <RefreshCw size={16} />
+            <h2>{copy.updates}</h2>
+          </div>
+          <div className="update-status">
+            <span>
+              {copy.currentVersion}: {snapshot.appVersion}
+            </span>
+            <strong data-status={updateCheck?.status ?? "idle"}>{isCheckingUpdate ? copy.checkingUpdates : formatUpdateStatus(updateCheck)}</strong>
+          </div>
+          {updateCheck?.status === "available" && (
+            <button type="button" onClick={downloadAndInstallUpdate} disabled={!bridge || isCheckingUpdate || isInstallingUpdate}>
+              {isInstallingUpdate ? <Loader2 className="spin" size={16} /> : <Download size={16} />}
+              {isInstallingUpdate ? copy.downloadingUpdate : copy.installUpdate}
+            </button>
+          )}
         </section>
       </aside>
 
@@ -1855,10 +1969,6 @@ export function App() {
               ))}
             </div>
           )}
-          <button type="button" className="ghost" onClick={refreshSnapshot} disabled={isLoadingSnapshot}>
-            {isLoadingSnapshot ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-            {copy.sync}
-          </button>
         </div>
 
         <div className="preview-layout">
@@ -2089,7 +2199,13 @@ export function App() {
             <p className="eyebrow">{copy.history}</p>
             <h2>{copy.recentJobs}</h2>
           </div>
-          <button type="button" className="icon-button" onClick={clearHistory} disabled={snapshot.history.length === 0} title={copy.clearHistory}>
+          <button
+            type="button"
+            className="icon-button"
+            onClick={() => setIsClearHistoryConfirmOpen(true)}
+            disabled={snapshot.history.length === 0}
+            title={copy.clearAllHistoryTooltip}
+          >
             <Trash2 size={16} />
           </button>
         </header>
@@ -2182,6 +2298,31 @@ export function App() {
           )}
         </div>
       </aside>
+      {isClearHistoryConfirmOpen && (
+        <div
+          className="modal-backdrop"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) setIsClearHistoryConfirmOpen(false);
+          }}
+        >
+          <section className="confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="clear-history-title">
+            <div>
+              <h2 id="clear-history-title">{copy.confirmClearHistoryTitle}</h2>
+              <p>{copy.confirmClearHistoryBody(snapshot.history.length)}</p>
+            </div>
+            <div className="dialog-actions">
+              <button type="button" className="ghost" onClick={() => setIsClearHistoryConfirmOpen(false)}>
+                {copy.cancel}
+              </button>
+              <button type="button" className="danger-button" onClick={confirmClearHistory}>
+                <Trash2 size={16} />
+                {copy.confirmClearHistory}
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -83,6 +83,12 @@ export interface UiCopy {
   discoveryLastRun: (date: string, count: number) => string;
   discoverModels: string;
   discoveringModels: string;
+  discoveredModelsCount: (count: number) => string;
+  connectionIdle: string;
+  connectionChecking: string;
+  connectionOk: string;
+  connectionError: string;
+  connectionErrorDetail: (message: string) => string;
   launchModels: string;
   launchAvailable: string;
   launchUnavailableNoKey: string;
@@ -159,6 +165,11 @@ export interface UiCopy {
   history: string;
   recentJobs: string;
   clearHistory: string;
+  clearAllHistoryTooltip: string;
+  confirmClearHistoryTitle: string;
+  confirmClearHistoryBody: (count: number) => string;
+  confirmClearHistory: string;
+  cancel: string;
   searchPrompt: string;
   historyMatchCount: (count: number) => string;
   showAllHistory: (count: number) => string;
@@ -197,7 +208,7 @@ export const translations: Record<Language, UiCopy> = {
     english: "English",
     chinese: "中文",
     tagline: "Generate, edit, inpaint, download.",
-    provider: "Provider",
+    provider: "Model config",
     providerLabel: "Provider",
     apiKey: "API Key",
     baseURL: "Base URL",
@@ -206,6 +217,12 @@ export const translations: Record<Language, UiCopy> = {
     discoveryLastRun: (date: string, count: number) => `${date} · ${count} model${count === 1 ? "" : "s"}`,
     discoverModels: "Discover models",
     discoveringModels: "Discovering",
+    discoveredModelsCount: (count: number) => `${count} model${count === 1 ? "" : "s"} discovered`,
+    connectionIdle: "Not tested",
+    connectionChecking: "Checking",
+    connectionOk: "Connected",
+    connectionError: "Connection issue",
+    connectionErrorDetail: (message: string) => `Connection issue: ${message}. Check the API key, base URL, provider protocol, or network.`,
     launchModels: "Launch",
     launchAvailable: "Available",
     launchUnavailableNoKey: "Save an API key first.",
@@ -282,6 +299,11 @@ export const translations: Record<Language, UiCopy> = {
     history: "History",
     recentJobs: "Recent jobs",
     clearHistory: "Clear history",
+    clearAllHistoryTooltip: "Clear all history records",
+    confirmClearHistoryTitle: "Clear all history?",
+    confirmClearHistoryBody: (count: number) => `This will delete all ${count} history record${count === 1 ? "" : "s"} and managed result files.`,
+    confirmClearHistory: "Clear all",
+    cancel: "Cancel",
     searchPrompt: "Search prompt",
     historyMatchCount: (count: number) => `${count} match${count === 1 ? "" : "es"}`,
     showAllHistory: (count: number) => `Show all ${count}`,
@@ -296,12 +318,12 @@ export const translations: Record<Language, UiCopy> = {
     currentVersion: "Current",
     checkUpdates: "Check",
     checkingUpdates: "Checking",
-    installUpdate: "Install",
+    installUpdate: "Update",
     downloadingUpdate: "Downloading",
     updateNotConfigured: "Update feed is not configured.",
-    updateCurrent: "You're on the latest version.",
+    updateCurrent: "Up to date.",
     updateAvailable: (version: string) => `Version ${version} is available.`,
-    updateReady: (version: string) => `Installer for ${version} opened.`,
+    updateReady: (version: string) => `Updater for ${version} opened. Local config and drafts remain in user data.`,
     updateCheckFailed: "Update check failed.",
     zoomIn: "Zoom in",
     zoomOut: "Zoom out",
@@ -380,7 +402,7 @@ export const translations: Record<Language, UiCopy> = {
     english: "English",
     chinese: "中文",
     tagline: "生成、编辑、局部重绘、下载。",
-    provider: "服务配置",
+    provider: "模型配置",
     providerLabel: "服务商",
     apiKey: "API Key",
     baseURL: "Base URL",
@@ -389,6 +411,12 @@ export const translations: Record<Language, UiCopy> = {
     discoveryLastRun: (date: string, count: number) => `${date} · ${count} 个模型`,
     discoverModels: "探测模型",
     discoveringModels: "探测中",
+    discoveredModelsCount: (count: number) => `探测到【${count}】个模型`,
+    connectionIdle: "未测试",
+    connectionChecking: "检测中",
+    connectionOk: "连接成功",
+    connectionError: "连接异常",
+    connectionErrorDetail: (message: string) => `连接异常：${message}。请检查 API Key、Base URL、服务商协议或网络。`,
     launchModels: "启动模型",
     launchAvailable: "可用",
     launchUnavailableNoKey: "请先保存 API Key。",
@@ -410,7 +438,7 @@ export const translations: Record<Language, UiCopy> = {
     clearKey: "清除 Key",
     keySaved: "Key 已保存",
     noKeySaved: "未保存 Key",
-    parameters: "参数",
+    parameters: "参数配置",
     hide: "收起",
     show: "展开",
     size: "尺寸",
@@ -465,6 +493,11 @@ export const translations: Record<Language, UiCopy> = {
     history: "历史",
     recentJobs: "最近任务",
     clearHistory: "清空历史",
+    clearAllHistoryTooltip: "清空全部历史记录",
+    confirmClearHistoryTitle: "确认清空全部历史？",
+    confirmClearHistoryBody: (count: number) => `将删除全部 ${count} 条历史记录及其托管结果文件。`,
+    confirmClearHistory: "确认清空",
+    cancel: "取消",
     searchPrompt: "搜索提示词",
     historyMatchCount: (count: number) => `${count} 条匹配`,
     showAllHistory: (count: number) => `显示全部 ${count} 条`,
@@ -479,12 +512,12 @@ export const translations: Record<Language, UiCopy> = {
     currentVersion: "当前版本",
     checkUpdates: "检查",
     checkingUpdates: "检查中",
-    installUpdate: "安装",
+    installUpdate: "更新",
     downloadingUpdate: "下载中",
     updateNotConfigured: "未配置升级地址。",
-    updateCurrent: "当前已是最新版本。",
+    updateCurrent: "已是最新版本。",
     updateAvailable: (version: string) => `发现新版本 ${version}。`,
-    updateReady: (version: string) => `${version} 安装程序已打开。`,
+    updateReady: (version: string) => `${version} 更新程序已启动。本地配置和草稿会保留。`,
     updateCheckFailed: "检查更新失败。",
     zoomIn: "放大",
     zoomOut: "缩小",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -13,7 +13,7 @@
 
 body {
   margin: 0;
-  min-width: 1120px;
+  min-width: 1344px;
   min-height: 100vh;
   background: #f4f1ea;
 }
@@ -100,7 +100,7 @@ h3 {
 
 .app-shell {
   display: grid;
-  grid-template-columns: var(--sidebar-width, 310px) 12px minmax(560px, 1fr) 12px var(--history-width, 330px);
+  grid-template-columns: var(--sidebar-width, 310px) 12px minmax(680px, 1fr) 12px var(--history-width, 330px);
   height: 100vh;
   min-height: 100vh;
   overflow: hidden;
@@ -168,6 +168,10 @@ h3 {
   gap: 10px;
   border-top: 1px solid #ded7c9;
   padding-top: 16px;
+}
+
+.sidebar-bottom {
+  margin-top: auto;
 }
 
 .update-status {
@@ -249,6 +253,28 @@ h3 {
 
 .section-title {
   justify-content: flex-start;
+}
+
+.section-title-label {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 8px;
+}
+
+.config-title,
+.launch-title {
+  justify-content: space-between;
+}
+
+.launch-title strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #5d554c;
+  font-size: 12px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 label {
@@ -349,8 +375,13 @@ label {
   color: #a33a32;
 }
 
+.danger-button {
+  border: 1px solid #a33a32;
+  background: #a33a32;
+  color: #fff;
+}
+
 .config-status,
-.model-discovery-status,
 .inline-check,
 .mask-status {
   display: flex;
@@ -360,50 +391,92 @@ label {
   font-size: 12px;
 }
 
-.model-discovery-status {
-  align-items: flex-start;
-  justify-content: space-between;
+.connection-badge {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  max-width: 138px;
+  min-height: 24px;
+  gap: 5px;
+  border: 1px solid #d6d0c3;
+  border-radius: 999px;
+  background: #fffdf8;
+  color: #6f655a;
+  padding: 0 8px;
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1;
 }
 
-.model-discovery-status strong {
+.connection-badge svg {
+  flex: 0 0 auto;
+}
+
+.connection-badge[data-status="ok"] {
+  border-color: rgba(31, 122, 85, 0.34);
+  background: #e7f2ee;
+  color: #1f7a55;
+}
+
+.connection-badge[data-status="error"] {
+  border-color: rgba(163, 58, 50, 0.28);
+  background: #fff3ef;
+  color: #a33a32;
+}
+
+.connection-badge[data-status="checking"] {
+  color: #1f6f61;
+}
+
+.connection-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #a89e91;
+}
+
+.config-error-detail {
+  align-items: flex-start;
+  line-height: 1.35;
+}
+
+.discovery-row {
+  display: grid;
+  grid-template-columns: minmax(118px, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+}
+
+.model-discovery-summary {
   min-width: 0;
+  overflow: hidden;
   overflow-wrap: anywhere;
   color: #2d2924;
+  font-size: 12px;
   font-weight: 650;
-  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.model-discovery-status[data-kind="error"] strong {
+.model-discovery-summary[data-kind="error"] {
   color: #a33a32;
 }
 
 .discover-button {
   width: 100%;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .launch-strip {
   display: grid;
   gap: 7px;
-  border-top: 1px solid #ded7c9;
-  padding-top: 10px;
 }
 
-.launch-strip-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  color: #5d554c;
-  font-size: 12px;
-}
-
-.launch-strip-header strong {
-  min-width: 0;
-  overflow: hidden;
-  color: #221f1c;
-  font-weight: 700;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.launch-item {
+  position: relative;
+  display: grid;
+  gap: 5px;
 }
 
 .launch-button {
@@ -419,7 +492,19 @@ label {
   text-align: left;
 }
 
-.launch-button span,
+.launch-button-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+}
+
+.launch-button-main svg {
+  flex: 0 0 auto;
+}
+
+.launch-button-main span,
 .launch-button small {
   max-width: 100%;
   overflow: hidden;
@@ -427,7 +512,7 @@ label {
   white-space: nowrap;
 }
 
-.launch-button span {
+.launch-button-main span {
   font-weight: 700;
 }
 
@@ -446,13 +531,49 @@ label {
   color: #2d6e60;
 }
 
-.launch-model-select {
-  gap: 5px;
-  padding-top: 2px;
+.launch-model-menu {
+  display: grid;
+  gap: 4px;
+  border: 1px solid #d6d0c3;
+  border-radius: 7px;
+  background: #fffdf8;
+  padding: 5px;
+  box-shadow: 0 10px 22px rgba(34, 31, 28, 0.1);
 }
 
-.launch-model-select select {
+.launch-model-option {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  justify-items: start;
+  min-height: 34px;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  color: #2d2924;
+  padding: 0 8px;
+  text-align: left;
+}
+
+.launch-model-option span,
+.launch-model-option small {
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launch-model-option small {
+  color: #786e62;
+  font-size: 11px;
+}
+
+.launch-model-option.active {
+  background: #e7f2ee;
+  color: #1f6f61;
+}
+
+.launch-model-option.active small {
+  color: #2d6e60;
 }
 
 .dot {
@@ -469,6 +590,26 @@ label {
 .section-toggle {
   justify-content: space-between;
   width: 100%;
+}
+
+.section-toggle-label,
+.section-toggle-state {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 8px;
+}
+
+.section-toggle-label span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.section-toggle-state {
+  flex: 0 0 auto;
+  color: #5d554c;
+  font-size: 12px;
 }
 
 .section-title h2,
@@ -764,6 +905,40 @@ label {
   color: #8a7f72;
   line-height: 1.35;
   text-align: center;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  background: rgba(34, 31, 28, 0.28);
+  padding: 22px;
+}
+
+.confirm-dialog {
+  display: grid;
+  gap: 18px;
+  width: min(380px, 100%);
+  border: 1px solid #d6d0c3;
+  border-radius: 8px;
+  background: #fffdf8;
+  box-shadow: 0 20px 50px rgba(34, 31, 28, 0.22);
+  padding: 18px;
+}
+
+.confirm-dialog p {
+  margin-top: 8px;
+  color: #5d554c;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 9px;
 }
 
 .partial-strip {


### PR DESCRIPTION
## Summary
- Reorganize the left sidebar into model config, launch model, parameter config, draft, notice, and bottom update sections.
- Replace the manual connection test button with automatic connection checks on startup and config save/update, plus a compact status badge.
- Integrate concrete launch model choices into launch buttons, add clear-all-history confirmation, and remove the unclear workspace sync button.
- Fix the default update manifest URL 404 and launch Windows updates via silent installer + restart after saving the current draft.

## Validation
- pnpm typecheck
- pnpm test
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm build
- git diff --check
- Playwright screenshot check at http://127.0.0.1:5174/