### PR TITLE
Fix Windows in-app updater timeout and process blocking

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,7 +8,6 @@ import {
   shell,
   type IpcMainInvokeEvent
 } from "electron";
-import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { promises as fs } from "node:fs";
@@ -58,13 +57,15 @@ import { assertKnownOutputPath, assertManagedRegularFile, collectOwnedJobFilePat
 import { recoverInterruptedJobs } from "./services/stateRecovery.js";
 import { type AppStateFile, type StoredProviderConfig, STATE_VERSION, getDefaultState, normalizeImageParams, normalizeState } from "./services/stateMigration.js";
 import { verifyUpdateAssetBytes } from "./services/updateInstallerVerification.js";
+import { launchWindowsInstallerAndRestart } from "./services/windowsUpdateLauncher.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MAX_HISTORY = 100;
 const FALLBACK_KEY_PREFIX = "plain:";
 const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
 const ASSET_PROTOCOL = "image2tools-asset";
-const UPDATE_TIMEOUT_MS = 30000;
+const UPDATE_CHECK_TIMEOUT_MS = 30000;
+const UPDATE_DOWNLOAD_TIMEOUT_MS = 600000; // 10 minutes for large installer downloads
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -338,25 +339,6 @@ function redactLikelySecrets(value: string): string {
 
 function getUpdatesDir(): string {
   return path.join(app.getPath("userData"), "updates");
-}
-
-function quoteCmdArg(value: string): string {
-  return `"${value.replace(/%/g, "%%").replace(/"/g, '""')}"`;
-}
-
-function launchWindowsInstallerAndRestart(installerPath: string): void {
-  const command = [
-    "timeout /t 1 /nobreak > nul",
-    `start /wait "" ${quoteCmdArg(installerPath)} /S`,
-    `start "" ${quoteCmdArg(process.execPath)}`
-  ].join(" & ");
-  const child = spawn(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", command], {
-    detached: true,
-    stdio: "ignore",
-    windowsHide: true
-  });
-  child.unref();
-  setTimeout(() => app.quit(), 50);
 }
 
 function getUpdateManifestUrl(): string {
@@ -849,7 +831,7 @@ async function handleCheckForUpdates(): Promise<UpdateCheckResult> {
           Accept: "application/json"
         }
       },
-      UPDATE_TIMEOUT_MS
+      UPDATE_CHECK_TIMEOUT_MS
     );
 
     if (!response.ok) {
@@ -893,7 +875,7 @@ async function handleDownloadAndInstallUpdate(): Promise<UpdateInstallResult> {
   await ensureDir(getUpdatesDir());
   const fileName = safeUpdateFileName(update.asset);
   const filePath = path.join(getUpdatesDir(), fileName);
-  const response = await fetchWithTimeout(fetch, update.asset.url, { method: "GET" }, UPDATE_TIMEOUT_MS);
+  const response = await fetchWithTimeout(fetch, update.asset.url, { method: "GET" }, UPDATE_DOWNLOAD_TIMEOUT_MS);
 
   if (!response.ok) {
     throw new Error(`更新包下载失败：HTTP ${response.status}`);
@@ -908,7 +890,7 @@ async function handleDownloadAndInstallUpdate(): Promise<UpdateInstallResult> {
   }
 
   if (process.platform === "win32") {
-    launchWindowsInstallerAndRestart(filePath);
+    launchWindowsInstallerAndRestart(filePath, { appQuit: () => app.quit() });
     return {
       version: update.latestVersion,
       filePath,

--- a/src/main/services/windowsUpdateLauncher.test.ts
+++ b/src/main/services/windowsUpdateLauncher.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildWindowsUpdatePowerShellCommand, launchWindowsInstallerAndRestart } from "./windowsUpdateLauncher";
+
+describe("Windows update launcher", () => {
+  it("waits for the current app process before running the NSIS installer", () => {
+    const command = buildWindowsUpdatePowerShellCommand({
+      currentPid: 1234,
+      executablePath: "C:\\Program Files\\Image2Tools\\Image2Tools.exe",
+      installerPath: "C:\\Users\\Ada\\AppData\\Roaming\\image2tools\\updates\\Image2Tools-Setup.exe",
+      waitSeconds: 45
+    });
+
+    expect(command).toContain("Wait-Process -Id 1234 -Timeout 45");
+    expect(command).toContain("$installer = 'C:\\Users\\Ada\\AppData\\Roaming\\image2tools\\updates\\Image2Tools-Setup.exe'");
+    expect(command).toContain("Get-CimInstance Win32_Process");
+    expect(command).toContain("$_.ExecutablePath -and $_.ExecutablePath -ieq $app");
+    expect(command).toContain("Start-Process -FilePath $installer -ArgumentList @('/S', '--updated')");
+    expect(command).toContain("Start-Process -FilePath $app");
+  });
+
+  it("quotes single quotes in paths for PowerShell", () => {
+    const command = buildWindowsUpdatePowerShellCommand({
+      currentPid: 1234,
+      executablePath: "C:\\Apps\\Image2Tools\\Image2Tools.exe",
+      installerPath: "C:\\Users\\O'Brien\\updates\\Image2Tools-Setup.exe"
+    });
+
+    expect(command).toContain("$installer = 'C:\\Users\\O''Brien\\updates\\Image2Tools-Setup.exe'");
+  });
+
+  it("spawns a detached hidden PowerShell helper and then quits the app", () => {
+    const unref = vi.fn();
+    const spawnImpl = vi.fn(() => ({ unref })) as unknown as typeof import("node:child_process").spawn;
+    const appQuit = vi.fn();
+    const setTimeoutImpl = vi.fn((callback: () => void) => {
+      callback();
+      return 1;
+    });
+
+    launchWindowsInstallerAndRestart("C:\\updates\\Image2Tools-Setup.exe", {
+      appQuit,
+      currentPid: 5678,
+      executablePath: "C:\\Apps\\Image2Tools\\Image2Tools.exe",
+      helperCwd: "C:\\Temp",
+      spawnImpl,
+      setTimeoutImpl
+    });
+
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "powershell.exe",
+      expect.arrayContaining(["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-WindowStyle", "Hidden", "-Command"]),
+      { cwd: "C:\\Temp", detached: true, stdio: "ignore", windowsHide: true }
+    );
+    const args = spawnImpl.mock.calls[0][1] as string[];
+    expect(args.at(-1)).toContain("Wait-Process -Id 5678");
+    expect(unref).toHaveBeenCalled();
+    expect(setTimeoutImpl).toHaveBeenCalledWith(expect.any(Function), 50);
+    expect(appQuit).toHaveBeenCalled();
+  });
+});

--- a/src/main/services/windowsUpdateLauncher.ts
+++ b/src/main/services/windowsUpdateLauncher.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+interface LaunchWindowsInstallerOptions {
+  appQuit?: () => void;
+  currentPid?: number;
+  executablePath?: string;
+  helperCwd?: string;
+  powerShellPath?: string;
+  spawnImpl?: typeof spawn;
+  setTimeoutImpl?: (callback: () => void, ms: number) => unknown;
+  waitSeconds?: number;
+}
+
+interface WindowsUpdateCommandOptions {
+  currentPid: number;
+  executablePath: string;
+  installerPath: string;
+  waitSeconds?: number;
+}
+
+const DEFAULT_PROCESS_EXIT_WAIT_SECONDS = 120;
+
+export function buildWindowsUpdatePowerShellCommand({
+  currentPid,
+  executablePath,
+  installerPath,
+  waitSeconds = DEFAULT_PROCESS_EXIT_WAIT_SECONDS
+}: WindowsUpdateCommandOptions): string {
+  return [
+    "$ErrorActionPreference = 'SilentlyContinue'",
+    `Wait-Process -Id ${currentPid} -Timeout ${waitSeconds}`,
+    `$installer = ${quotePowerShellString(installerPath)}`,
+    `$app = ${quotePowerShellString(executablePath)}`,
+    `$deadline = (Get-Date).AddSeconds(${waitSeconds})`,
+    "do {",
+    "  $running = @(Get-CimInstance Win32_Process | Where-Object { $_.ExecutablePath -and $_.ExecutablePath -ieq $app })",
+    "  if ($running.Count -eq 0) { break }",
+    "  Start-Sleep -Milliseconds 500",
+    "} while ((Get-Date) -lt $deadline)",
+    "$process = Start-Process -FilePath $installer -ArgumentList @('/S', '--updated') -WindowStyle Hidden -Wait -PassThru",
+    "Start-Process -FilePath $app"
+  ].join("; ");
+}
+
+export function launchWindowsInstallerAndRestart(installerPath: string, options: LaunchWindowsInstallerOptions = {}): void {
+  const spawnImpl = options.spawnImpl ?? spawn;
+  const setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
+  const appQuit = options.appQuit;
+  const command = buildWindowsUpdatePowerShellCommand({
+    installerPath,
+    executablePath: options.executablePath ?? process.execPath,
+    currentPid: options.currentPid ?? process.pid,
+    waitSeconds: options.waitSeconds
+  });
+
+  const child = spawnImpl(
+    options.powerShellPath ?? "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-WindowStyle", "Hidden", "-Command", command],
+    {
+      cwd: options.helperCwd ?? process.env.TEMP ?? process.env.SystemRoot,
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true
+    }
+  );
+  child.unref();
+
+  setTimeoutImpl(() => {
+    appQuit?.();
+  }, 50);
+}
+
+function quotePowerShellString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}


### PR DESCRIPTION
## Problem

Users reported v0.2.0 → v0.2.1 in-app update failure. Investigation revealed two root causes:

1. **Download timeout**: 30-second timeout for 98MB installer (requires sustained 26 Mbps)
2. **Process blocking**: NSIS installer launched before Electron process exits, causing silent install to hang

## Solution

### Timeout Fix
- Split timeout constants:
  - `UPDATE_CHECK_TIMEOUT_MS` (30s) for manifest fetch
  - `UPDATE_DOWNLOAD_TIMEOUT_MS` (600s / 10 minutes) for installer download
- 10 minutes allows download at ~1.6 Mbps (typical broadband)

### Process Exit Fix
- Replace `cmd.exe timeout/start` helper with PowerShell-based `windowsUpdateLauncher`
- New launcher:
  1. Waits for `process.pid` to exit (up to 120s)
  2. Polls until no `Image2Tools.exe` remains at `process.execPath`
  3. Runs NSIS installer with `(/S, --updated)` flags
  4. Restarts app after install completes
- All operations detached, hidden PowerShell process

## Impact

- ✅ This fix applies to **v0.2.2+** in-app updates
- ⚠️ **v0.2.0 users cannot auto-update** (their client has old timeout/launcher code)
- 📦 v0.2.0 users must **manually download and install** v0.2.1 or v0.2.2 once
- ✅ After manual install to v0.2.1+, future in-app updates will work

## Testing

- ✅ All tests pass (21 files, 130 passed, 1 skipped)
- ✅ New `windowsUpdateLauncher.test.ts` covers PowerShell command generation and spawn
- ✅ `pnpm build` passes
- 🔬 Needs v0.2.2 release + Windows runtime verification

## Related

- History.md: 2026-06-15 11:49:46 +08:00 investigation notes
- Local reproduction confirmed: cached installer valid, but cmd.exe helper hung during silent install