### PR TITLE
Fix v0.2.2 Windows installer SHA256 in update manifest

### DIFF
--- a/docs/updates/latest.json
+++ b/docs/updates/latest.json
@@ -15,8 +15,8 @@
       "platform": "win32",
       "url": "https://github.com/Bliveren/image2tools/releases/download/v0.2.2/Image2Tools-Setup.exe",
       "fileName": "Image2Tools-Setup.exe",
-      "sha256": "59b0eeda4924fc17fb71d792eda2b556a28039cb17fb512febb04e2db9cd315b",
-      "sizeBytes": 98328196,
+      "sha256": "e25e92b6c7dbd4da2621fffd1c8db9664232b054cbd79b6ca0b06d381043db61",
+      "sizeBytes": 98328195,
       "arch": "x64"
     }
   ]


### PR DESCRIPTION
## Problem

The Windows installer for v0.2.2 was re-uploaded, resulting in a different SHA256 hash. The update manifest (`docs/updates/latest.json`) contained the old hash, causing installer verification to fail.

## Changes

### Update Manifest
- Updated Windows installer SHA256: `59b0ee...` → `e25e92...`
- Corrected file size: `98328196` → `98328195` bytes
- Verified by downloading from GitHub release and hashing

### Release Notes
- Added Windows updater fixes to changelog (timeout + process exit handling)
- Updated Windows SHA256 in verification table
- Added notice for v0.2.0 users about manual install requirement

## Verification

```bash
curl -sL "https://github.com/Bliveren/image2tools/releases/download/v0.2.2/Image2Tools-Setup.exe" | sha256sum
# e25e92b6c7dbd4da2621fffd1c8db9664232b054cbd79b6ca0b06d381043db61
```

## Impact

✅ v0.2.1+ users can now auto-update to v0.2.2 via in-app updater
✅ Installer verification will succeed with correct SHA256