### PR TITLE
Release prep: v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,33 +52,10 @@ Download the latest installer from the [Releases page](https://github.com/Bliver
 
 | Platform | File | Notes |
 | --- | --- | --- |
-| macOS (Apple Silicon) | `Image2Tools-<version>-mac-arm64.dmg` | ad-hoc signed, not Apple-notarized |
-| Windows (x64) | `Image2Tools-Setup.exe` | NSIS installer |
+| macOS (Apple Silicon) | `Image2Tools-<version>-mac-arm64.dmg` | Developer ID signed and Apple-notarized when published from the signed release pipeline |
+| Windows (x64) | `Image2Tools-Setup.exe` | NSIS installer; SmartScreen reputation may still appear on early open-source builds |
 
-> ### ⚠️ Why your OS shows an "unverified developer" warning
->
-> Image2Tools preview builds are **not yet signed with an Apple Developer ID or a
-> Windows code-signing certificate** (commercial paid certificates we haven't
-> purchased for this preview). Because of that, on first launch macOS Gatekeeper
-> says something like *"Apple could not verify Image2Tools is free of malware"*
-> and Windows SmartScreen shows a blue *"Windows protected your PC"* prompt.
->
-> **This is expected for an unsigned open-source preview — it is not a virus
-> warning and does not mean the download is corrupted.** The entire source is
-> public and auditable, and every release artifact's SHA256 is published so you
-> can verify the file you downloaded is exactly the one we built (see below).
-> Signing & notarization are tracked in [issue #116](https://github.com/Bliveren/image2tools/issues/116);
-> once done, these warnings will disappear.
-
-Follow the one-time steps below to open the app.
-
-**macOS** — if Gatekeeper blocks the app, either right-click the app and choose **Open** twice, or clear the quarantine attribute:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/Image2Tools.app
-```
-
-**Windows** — if SmartScreen shows a blue prompt, click **More info** → **Run anyway**.
+If macOS or Windows shows a first-run security prompt, verify the SHA256 below and open the app through the system's normal confirmation flow. The source is public and each release artifact's SHA256 is published so the downloaded file can be checked against the built artifact.
 
 **Verify the download (optional).** Compare the SHA256 of your downloaded file against the value published in [`docs/updates/latest.json`](./docs/updates/latest.json):
 
@@ -93,18 +70,22 @@ Get-FileHash .\Image2Tools-Setup.exe -Algorithm SHA256
 
 Image2Tools is an easy-to-use, all-in-one desktop tool for AI image generation management. The current main branch supports GPT Image 2 through the OpenAI Image API, the app's Nano Banana 3 launch target through Gemini image models such as `gemini-3.1-flash-image` and `gemini-3-pro-image`, and a minimal General launch mode for discovered non-focused image models.
 
-The app is built for non-developers, individual creators, product teams, and internal AI workflow builders who need a simple desktop tool instead of a cloud workspace or account system. The latest UI separates model configuration, launch-model selection, model-specific parameters, local history, draft recovery, and update management so API setup, model discovery, generation, reuse, and desktop updates stay in one local workflow.
+The app is built for non-developers, individual creators, product teams, and internal AI workflow builders who need a simple desktop tool instead of a cloud workspace or account system. The latest UI separates API access management, launch-model selection, model-specific parameters, prompt templates, a managed reference Gallery, local history, draft recovery, and update management so setup, model discovery, generation, reuse, and desktop updates stay in one local workflow.
 
 ## Features
 
 | Area | Capability |
 | --- | --- |
-| Model configuration | OpenAI, Gemini, and OpenAI-compatible Custom setup with Base URL/API Key storage, saved key preview, automatic connection checks, and friendly failure hints. |
+| Multi-API management | Save, switch, and delete multiple OpenAI, Gemini, and OpenAI-compatible Custom API access profiles without re-entering keys or model discovery results. |
+| Model configuration | Per-API Base URL/API Key storage, saved key preview, automatic connection checks, and friendly failure hints. |
 | Model discovery | Detects models exposed by the configured API and uses discovered provider/model metadata instead of relying only on the selected provider label. |
 | Launch models | GPT Image 2, Nano Banana 3, and General launch buttons with availability reasons plus concrete discovered-model choices inside each launch button. |
 | GPT Image 2 | Text-to-image, single/multi-image editing, exact-mask inpainting, streaming partial previews, and validated OpenAI Image API parameters. |
 | Nano Banana 3 | Gemini `generateContent` image generation, reference-image editing, guided-region editing, aspect ratio, resolution, Thinking, and Search grounding controls. |
 | General | Minimal fallback for discovered non-focused image models: Gemini supports prompt and reference images, while OpenAI and Custom use a prompt-only OpenAI-compatible generation contract. |
+| Prompt templates | Local template library with search, tags, categories, edit/delete, and JSON import/export. |
+| Reference Gallery | Managed local reference-image library with import, tagging, search, history-to-Gallery reuse, and filename-only safe previews. |
+| Prompt chips | `@` inserts a Gallery reference, `~` expands a template, and `#` adds a color value while the backend still receives plain text plus input assets. |
 | Local history | Generated assets are saved in Electron user data with provider/model chips and can be reused, opened, downloaded, or cleared after explicit confirmation. |
 | Workspace recovery | Draft prompt, parameters, references, masks, and brush size are autosaved. |
 | Bilingual UI | In-app language switch supports English and Simplified Chinese through localStorage. |
@@ -113,12 +94,24 @@ The app is built for non-developers, individual creators, product teams, and int
 
 ## Product Flow
 
-1. Configure the API provider, Base URL, and API Key. The app automatically tests the saved connection on startup and after config changes.
-2. Run model discovery and pick GPT Image 2, Nano Banana 3, or General from the launch-model area.
-3. If multiple compatible concrete models are discovered under a launch family, open the launch button menu and choose the exact model to run.
-4. Choose Generate, Edit, or Inpaint/Guided Region where the selected model supports it.
-5. Tune model-specific parameters. GPT Image 2 exposes OpenAI Image API controls and streaming; Nano Banana 3 exposes Gemini image controls; General stays minimal.
-6. Download results, open the local output folder, or reuse history prompts with their provider/model context.
+1. Add one or more API access profiles with provider type, Base URL, and API Key. The app automatically tests the active profile on startup and after config changes.
+2. Run model discovery for each profile and switch between profiles when you need a different key, endpoint, or model inventory.
+3. Pick GPT Image 2, Nano Banana 3, or General from the launch-model area. If multiple compatible concrete models are discovered under a launch family, open the launch button menu and choose the exact model to run.
+4. Compose the prompt with plain text, saved templates, managed Gallery references, and color chips.
+5. Choose Generate, Edit, or Inpaint/Guided Region where the selected model supports it, then tune model-specific parameters.
+6. Download results, open the local output folder, save outputs back into the Gallery, or reuse history prompts with their provider/model context.
+
+## Multi-API Management
+
+Image2Tools can keep several API access profiles side by side. Each profile has its own provider type, Base URL, saved-key state, discovered model list, connection status, and selected concrete model. Switching profiles updates the model configuration, launch model, and parameter areas without requiring the user to paste keys again.
+
+Model availability is based on what the active API actually exposes. For example, an OpenAI-compatible aggregator key can enable both GPT Image 2 and Nano Banana 3 if discovery returns compatible models for both launch families.
+
+## Prompt Workflow
+
+The prompt workflow is local-first. Templates store reusable prompt text with tags and optional categories. The Gallery copies imported references into the app-managed user data directory and only exposes filename-based preview URLs, so the renderer never needs arbitrary local file paths.
+
+Prompt chips keep composition fast without changing provider contracts. `@` adds a Gallery reference to `inputAssets`, `~` expands a saved template into the final prompt, and `#` inserts a color value. Before a job starts, the composer serializes everything to the existing backend shape: plain text `prompt`, `inputAssets`, and model params.
 
 ## Open Source Status
 
@@ -333,31 +326,10 @@ Image2Tools is released under the [MIT License](./LICENSE).
 
 | 平台 | 文件 | 说明 |
 | --- | --- | --- |
-| macOS（Apple 芯片） | `Image2Tools-<版本>-mac-arm64.dmg` | 临时签名，未经 Apple 公证 |
-| Windows（x64） | `Image2Tools-Setup.exe` | NSIS 安装程序 |
+| macOS（Apple 芯片） | `Image2Tools-<版本>-mac-arm64.dmg` | 通过签名发布流水线产出时为 Developer ID 签名并完成 Apple 公证 |
+| Windows（x64） | `Image2Tools-Setup.exe` | NSIS 安装程序；早期开源版本仍可能出现 SmartScreen 声誉提示 |
 
-> ### ⚠️ 为什么系统会提示"无法验证开发者"
->
-> Image2Tools 预览版**尚未取得 Apple Developer ID 签名和 Windows 代码签名证书**
-> （这些是需要付费购买的商业证书，预览阶段暂未采购）。因此首次打开时，macOS
-> Gatekeeper 会提示类似*"无法验证 Image2Tools 是否包含恶意软件"*，Windows
-> SmartScreen 会弹出蓝色的*"Windows 已保护你的电脑"*窗口。
->
-> **这是未签名开源预览版的正常现象，既不是病毒警告，也不代表安装包损坏。**
-> 本项目源码完全公开可审计，每个发布安装包都附带 SHA256，你可以校验下载到的
-> 文件与我们构建的完全一致（见下方）。签名与公证进度见
-> [issue #116](https://github.com/Bliveren/image2tools/issues/116)，完成后这些
-> 提示将不再出现。
-
-按下面的一次性步骤即可正常打开应用。
-
-**macOS** — 若 Gatekeeper 拦截，可右键应用选择 **打开** 两次，或清除隔离属性：
-
-```bash
-xattr -dr com.apple.quarantine /Applications/Image2Tools.app
-```
-
-**Windows** — 若出现 SmartScreen 蓝色提示，点击 **更多信息** → **仍要运行**。
+如果 macOS 或 Windows 首次运行时出现系统安全确认，请先按下方 SHA256 校验下载文件，再通过系统提供的正常确认流程打开。项目源码公开可审计，每个发布安装包都会附带 SHA256，便于确认下载文件与构建产物一致。
 
 **校验下载（可选）。** 将下载文件的 SHA256 与 [`docs/updates/latest.json`](./docs/updates/latest.json) 中发布的值比对：
 
@@ -372,18 +344,22 @@ Get-FileHash .\Image2Tools-Setup.exe -Algorithm SHA256
 
 Image2Tools 是一个方便易用的一站式AI生图管理工具。当前 main 分支支持通过 OpenAI Image API 使用 GPT Image 2，通过 Gemini 图片模型（如 `gemini-3.1-flash-image` 和 `gemini-3-pro-image`）使用应用内的 Nano Banana 3 启动入口，并为应用探测到的非重点图片模型提供最小 General 兜底模式。
 
-适合非开发人员、个人创作者、产品团队、AI 应用工程团队和需要轻量图像工作台的内部工具场景。最新版界面把模型配置、启动模型选择、模型专属参数、本地历史、草稿恢复和升级管理拆开，让 API 配置、模型探测、生成、复用和桌面更新集中在一个本地工作流里完成。
+适合非开发人员、个人创作者、产品团队、AI 应用工程团队和需要轻量图像工作台的内部工具场景。最新版界面把 API 接入管理、启动模型选择、模型专属参数、提示词模板、受管参考图 Gallery、本地历史、草稿恢复和升级管理拆开，让配置、模型探测、生成、复用和桌面更新集中在一个本地工作流里完成。
 
 ## 功能亮点
 
 | 模块 | 能力 |
 | --- | --- |
-| 模型配置 | OpenAI、Gemini 与 OpenAI 兼容 Custom 配置，支持 Base URL/API Key 本地保存、Key 脱敏预览、自动联通测试和友好的失败原因提示。 |
+| 多 API 管理 | 保存、切换和删除多个 OpenAI、Gemini 与 OpenAI 兼容 Custom API 接入，不需要反复输入 Key 或重新探测模型。 |
+| 模型配置 | 每个 API 接入独立保存 Base URL/API Key、Key 脱敏预览、自动联通测试和友好的失败原因提示。 |
 | 模型探测 | 基于用户配置的 API 探测可用模型，并使用探测到的 provider/model 信息匹配功能，而不是只依赖用户选择的服务商标签。 |
 | 启动模型 | GPT Image 2、Nano Banana 3、General 启动按钮，根据探测结果显示可用性原因，并把具体可运行模型折叠到对应启动按钮内选择。 |
 | GPT Image 2 | 文生图、单图/多图编辑、精确 mask 局部重绘、流式局部预览和 OpenAI Image API 参数校验。 |
 | Nano Banana 3 | Gemini `generateContent` 图片生成、参考图编辑、引导式区域编辑、画面比例、分辨率、Thinking 和 Search grounding 控件。 |
 | General | 针对探测到的非重点图片模型提供最小兜底；Gemini 支持 prompt 与参考图，OpenAI 和 Custom 使用 OpenAI 兼容的纯提示词生成契约。 |
+| 提示词模板 | 本地模板库支持搜索、标签、分类、编辑删除和 JSON 导入导出。 |
+| 参考图 Gallery | 受管本地参考图库，支持导入、打标签、搜索、历史结果加入 Gallery，并用文件名级安全预览。 |
+| Prompt chips | `@` 插入 Gallery 参考图，`~` 展开模板，`#` 加入色值，同时后端仍接收纯文本 prompt 和 input assets。 |
 | 本地历史 | 输出资产保存在 Electron user data，历史条目显示 provider/model，可下载、打开目录、复用 prompt；清空全部历史前需要二次确认。 |
 | 草稿恢复 | 自动保存 prompt、参数、参考图、mask 和画笔大小。 |
 | 双语界面 | 应用内支持 English / 简体中文切换，语言选择保存在 localStorage。 |
@@ -392,12 +368,24 @@ Image2Tools 是一个方便易用的一站式AI生图管理工具。当前 main 
 
 ## 产品流程
 
-1. 配置 API 服务商、Base URL 与 API Key。应用会在保存后和下次启动时自动测试联通状态。
-2. 执行模型探测，并在启动模型区选择 GPT Image 2、Nano Banana 3 或 General。
-3. 如果某个启动模型下探测到多个具体模型，打开启动按钮内的下拉菜单，选择实际要运行的模型。
-4. 根据模型能力选择生成、编辑或局部重绘 / 引导式区域编辑。
-5. 调整模型专属参数：GPT Image 2 显示 OpenAI Image API 与 streaming 控件，Nano Banana 3 显示 Gemini 图片参数，General 保持最小能力。
-6. 下载结果、打开本地输出目录，或从历史记录复用带有 provider/model 上下文的 prompt。
+1. 添加一个或多个 API 接入，配置服务商类型、Base URL 与 API Key。应用会在保存后和下次启动时自动测试当前接入的联通状态。
+2. 对每个 API 接入执行模型探测，需要不同 Key、端点或模型库存时直接切换接入。
+3. 在启动模型区选择 GPT Image 2、Nano Banana 3 或 General。如果某个启动模型下探测到多个具体模型，打开启动按钮内的下拉菜单，选择实际要运行的模型。
+4. 使用纯文本、已保存模板、Gallery 参考图和色值 chip 组合 prompt。
+5. 根据模型能力选择生成、编辑或局部重绘 / 引导式区域编辑，并调整模型专属参数。
+6. 下载结果、打开本地输出目录、把结果加入 Gallery，或从历史记录复用带有 provider/model 上下文的 prompt。
+
+## 多 API 管理
+
+Image2Tools 可以同时保存多个 API 接入。每个接入都有独立的服务商类型、Base URL、Key 保存状态、模型探测结果、连接状态和具体模型选择。切换接入后，模型配置、启动模型和参数区会随之更新，不需要用户重新粘贴 Key。
+
+模型功能是否可启动基于当前 API 实际探测到的模型决定。例如，同一个 OpenAI 兼容聚合站 Key 如果同时暴露 GPT Image 2 与 Gemini 图片模型，就可以同时启用 GPT Image 2 与 Nano Banana 3 启动入口。
+
+## 提示词工作流
+
+提示词工作流坚持本地优先。模板库保存可复用的 prompt 文本、标签和分类。Gallery 会把导入参考图复制到应用受管目录，并只通过文件名级预览 URL 暴露给 renderer，避免任意本地路径读取。
+
+Prompt chips 用来提升组合效率，但不改变 provider 契约。`@` 会把 Gallery 参考图加入 `inputAssets`，`~` 会把模板展开进最终 prompt，`#` 会插入色值。任务启动前，composer 会统一序列化为现有后端结构：纯文本 `prompt`、`inputAssets` 和模型参数。
 
 ## MIT 开源状态
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,41 @@
 # Image2Tools Release Notes
 
+## v0.3.0 (release candidate)
+
+Productivity release focused on multi-API management and reusable prompt workflows.
+
+### Multi-API management
+
+- Save multiple API access profiles for OpenAI, Gemini, and OpenAI-compatible Custom endpoints.
+- Switch API profiles without re-entering keys, Base URLs, model discovery results, or model-specific launch settings.
+- Keep API connectivity and model discovery scoped to the active API profile so GPT Image 2, Nano Banana 3, and General launch availability follows the models exposed by the selected key.
+- Preserve the current prompt and references while switching profiles; incompatible model states show validation guidance instead of silently clearing user work.
+
+### Prompt workflow
+
+- Add a local prompt template library with search, tags, categories, edit/delete, and JSON import/export.
+- Add a managed reference Gallery. Imported images are copied into the app's user data directory, can be tagged/searched, and can be reused as references without exposing arbitrary local file paths to the renderer.
+- Add prompt chips: `@` inserts a Gallery reference, `~` expands a saved template, and `#` adds a color value. Jobs still submit the same stable backend contract: plain text `prompt` plus `inputAssets` and params.
+- History reuse intentionally degrades back to plain text prompt content, keeping older jobs compatible without storing renderer-specific chip schema.
+
+### Safety and compatibility
+
+- State v3 is extended with optional `promptTemplates` and `galleryAssets` arrays without a destructive state-version bump.
+- Gallery previews use the managed `image2tools-asset://` protocol and filename-only Gallery reads; symlink escape and malformed migration cases are covered by tests.
+- Prompt-template and Gallery IPC are kept behind the existing main/preload boundary, with renderer smoke coverage for creation, import/export, Gallery selection, deletion confirmation, and chip serialization.
+
+### Release gates
+
+- Automatic validation required before final release:
+  - `pnpm build`
+  - `pnpm verify:mock-api`
+  - `pnpm verify:mock-gemini-api`
+  - `pnpm verify:mock-model-discovery`
+  - `pnpm verify:release-evidence`
+- Final publication is still gated by v0.3.0 macOS signed/notarized artifacts, Windows installer validation, v0.3.0 update manifest assets, and refreshed real API acceptance evidence.
+
+---
+
 ## v0.2.3 (unsigned preview)
 
 Compatibility and UX patch release. Fixes aggregator streaming compatibility issues and adds image preview context menu.

--- a/docs/release/evidence.json
+++ b/docs/release/evidence.json
@@ -1,98 +1,80 @@
 {
   "schemaVersion": 1,
-  "releaseVersion": "0.2.3",
-  "lastUpdated": "2026-06-28T16:00:00.000Z",
+  "releaseVersion": "0.3.0",
+  "lastUpdated": "2026-06-29T12:24:17.000Z",
   "gates": [
     {
       "id": "real-openai-api",
       "title": "Real OpenAI GPT Image 2 API acceptance",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
-        "Model discovery confirms gpt-image-2 is available to the tested key.",
+        "Model discovery confirms gpt-image-2 is available to the tested key on the v0.3.0 build.",
         "Text-to-image generation succeeds with real OpenAI Image API output.",
         "Reference-image editing succeeds with real OpenAI Image API output.",
         "Mask-based inpaint succeeds with real OpenAI Image API output.",
-        "App history and download behavior are checked with the real task outputs."
+        "Prompt templates, Gallery reference selection, prompt chips, app history, and download behavior are checked with the real task outputs."
       ],
       "evidence": {
-        "verifiedAt": "2026-06-16T08:34:43.000Z",
-        "commit": "220707ec7f24e9564a903c154dc6cbd95eee35da",
-        "environment": "macOS 26.5.1 arm64; package version 0.2.2; OpenAI-compatible image aggregator endpoint (not the official OpenAI API); model gpt-image-2.",
-        "commands": [
-          "IMAGE2TOOLS_API_KEY=[REDACTED] IMAGE2TOOLS_BASE_URL=[REDACTED_AGGREGATOR] IMAGE2TOOLS_REAL_API_ACCEPT_COST=1 pnpm verify:real-api"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Real OpenAI GPT Image 2 external acceptance tracker",
             "url": "https://github.com/Bliveren/image2tools/issues/1"
           }
         ],
-        "artifacts": [
-          {
-            "kind": "verifier-output",
-            "path": "real-api-artifacts/2026-06-16T08-34-43-365Z",
-            "public": false,
-            "description": "Redacted-local generation, single-edit, multi-edit, and mask inpaint outputs from the real-api verifier (gpt-image-2). Git-ignored; not distributed."
-          }
-        ],
-        "summary": "Re-verified for 0.2.2 against a cost-approved OpenAI-compatible image aggregator endpoint: gpt-image-2 model discovery, text-to-image generation, single and multi reference editing, and mask-based inpaint all succeeded. Edit and inpaint requests run non-streaming (the 0.2.1 fix) and no longer hit the non-SSE streaming error. The verifier accepts both b64_json and image-url responses."
+        "artifacts": [],
+        "summary": "Pending v0.3.0 real OpenAI acceptance. Earlier 0.2.x GPT Image 2 acceptance evidence is not carried forward as a completed 0.3.0 gate because this release adds multi-API switching, templates, Gallery, and prompt chips that must be checked in the packaged 0.3.0 flow."
       }
     },
     {
       "id": "real-gemini-api",
       "title": "Real Gemini / Nano Banana 3 API acceptance",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
-        "Model discovery confirms gemini-3.1-flash-image is available to the tested key.",
+        "Model discovery confirms a supported Gemini image model is available to the tested key on the v0.3.0 build.",
         "Nano Banana 3 text-to-image generation succeeds with real Gemini output.",
         "Reference-image editing succeeds with real Gemini output.",
         "Guided-region editing succeeds and is not described as exact-mask inpainting.",
-        "App history, provider/model display, parameter restore, and download behavior are checked with the real task outputs."
+        "Prompt templates, Gallery reference selection, prompt chips, app history, provider/model display, parameter restore, and download behavior are checked with the real task outputs."
       ],
       "evidence": {
-        "verifiedAt": "2026-06-16T08:50:29.000Z",
-        "commit": "220707ec7f24e9564a903c154dc6cbd95eee35da",
-        "environment": "macOS 26.5.1 arm64; package version 0.2.2; OpenAI-compatible image aggregator endpoint (not the official Google Generative Language API); model gemini-3.1-flash-image; bearer auth mode.",
-        "commands": [
-          "IMAGE2TOOLS_GEMINI_API_KEY=[REDACTED] IMAGE2TOOLS_GEMINI_BASE_URL=[REDACTED_AGGREGATOR] IMAGE2TOOLS_REAL_GEMINI_API_ACCEPT_COST=1 IMAGE2TOOLS_GEMINI_MODEL=gemini-3.1-flash-image IMAGE2TOOLS_GEMINI_AUTH_MODE=bearer pnpm verify:real-gemini-api"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Real Gemini / Nano Banana 3 external acceptance tracker",
             "url": "https://github.com/Bliveren/image2tools/issues/102"
           }
         ],
-        "artifacts": [
-          {
-            "kind": "verifier-output",
-            "path": "real-api-artifacts/gemini/2026-06-16T08-50-29-112Z",
-            "public": false,
-            "description": "Redacted-local Nano Banana 3 generation, reference-edit, and guided-region-edit outputs from the real-gemini-api verifier (gemini-3.1-flash-image). Git-ignored; not distributed."
-          }
-        ],
-        "summary": "Re-verified for 0.2.2 against the same cost-approved OpenAI-compatible image aggregator endpoint (bearer auth): gemini-3.1-flash-image model discovery, Nano Banana 3 text-to-image generation, reference-image editing, and guided-region editing all succeeded. Guided-region editing is recorded as guided-region, not exact-mask inpainting. The aggregator exposes the Gemini image model over an OpenAI-compatible base URL rather than the native Google Generative Language API."
+        "artifacts": [],
+        "summary": "Pending v0.3.0 real Gemini / Nano Banana 3 acceptance. Earlier 0.2.x Gemini acceptance evidence is retained in release history but must be rerun or manually confirmed against the v0.3.0 packaged flow before this gate is marked passed."
       }
     },
     {
       "id": "macos-signed-notarized",
       "title": "Signed and notarized macOS release package",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
         "Developer ID signing readiness passes without exposing secret values.",
-        "package:mac:signed produces signed and notarized macOS artifacts.",
-        "macOS release verification passes against the signed artifact.",
+        "package:mac:signed produces signed and notarized v0.3.0 macOS artifacts.",
+        "macOS release verification passes against the signed v0.3.0 artifact.",
         "The artifact intended for distribution is the same artifact used for update manifest metadata."
       ],
       "evidence": {
-        "verifiedAt": "2026-06-29T10:01:00.000Z",
-        "commit": "a7bc7678972a885b5866ddb16d8fcde6b5ea49b9",
-        "environment": "macOS arm64; package version 0.2.3; Developer ID Application: Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7); Apple notarytool.",
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
         "commands": [
-          "pnpm package:mac:signed",
-          "spctl -a -vv release/mac-arm64/Image2Tools.app"
+          "pnpm package:mac",
+          "pnpm verify:release:mac"
         ],
         "references": [
           {
@@ -102,112 +84,89 @@
         ],
         "artifacts": [
           {
-            "kind": "release-artifact",
-            "path": "release/Image2Tools-0.2.3-mac-arm64.dmg",
+            "kind": "local-release-artifact",
+            "path": "release/Image2Tools-0.3.0-mac-arm64.dmg",
             "public": false,
-            "description": "Developer ID signed and Apple-notarized DMG. spctl verdict: accepted, source=Notarized Developer ID."
+            "description": "Local ad-hoc macOS DMG built during v0.3.0 release preparation. SHA256 c7a5d3efc9a42a73d2ccc4b1401c12f94949ec2f83c779e90105e294bf880313. It passed pnpm verify:release:mac but is not Developer ID signed/notarized."
+          },
+          {
+            "kind": "local-release-artifact",
+            "path": "release/Image2Tools-0.3.0-mac-arm64.zip",
+            "public": false,
+            "description": "Local ad-hoc macOS zip built during v0.3.0 release preparation. SHA256 494e960a35a7e66421612e6e8521fcfc2ff8b87b1c0b84ddfc238ed58d8dd816."
           }
         ],
-        "summary": "v0.2.3 macOS DMG signed with Developer ID Application: Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7) and Apple-notarized via notarytool. spctl -a -vv reports 'accepted, source=Notarized Developer ID'. Timestamp: Jun 29, 2026 at 17:01:24."
+        "summary": "Pending v0.3.0 signed and notarized macOS package. Local ad-hoc macOS packaging and DMG install smoke passed on 2026-06-29, but the formal gate remains pending until pnpm package:mac:signed produces Developer ID signed and Apple-notarized v0.3.0 artifacts. The 0.2.3 signed/notarized DMG remains valid only for the 0.2.3 release and must not be reused as 0.3.0 evidence."
       }
     },
     {
       "id": "windows-native-release",
       "title": "Native Windows release package validation",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
-        "Windows package verifier runs in full native install mode.",
-        "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass.",
+        "Windows package verifier runs in full native install mode or the release workflow gate passes with documented package-smoke coverage.",
+        "NSIS install, installed app launch, main-window detection, and uninstall pass for the v0.3.0 installer.",
         "Packaged app can configure mock OpenAI and Gemini endpoints.",
-        "Download and open-folder behavior are checked on native Windows."
+        "Multi-API switching, templates, Gallery, prompt chips, download, and open-folder behavior are checked on native Windows."
       ],
       "evidence": {
-        "verifiedAt": "2026-06-10T04:10:02.193Z",
-        "commit": "4b4dd18ff4255fcb4bfb2a25fadde7bbf788eafd",
-        "environment": "Native Windows 11 Pro 10.0.26100 x64 shell; package version 0.2.0; artifacts release\\Image2Tools-Setup.exe and release\\win-unpacked\\Image2Tools.exe.",
-        "commands": [
-          "$env:IMAGE2TOOLS_WINDOWS_VERIFY_MODE='full-install'; corepack pnpm@10.25.0 verify:release:windows",
-          "Packaged app bridge acceptance: configure loopback mock OpenAI and Gemini endpoints, generate managed outputs, invoke downloadAsset through the native Save dialog, and invoke openAssetFolder with Explorer directory verification."
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Native Windows release validation tracker",
             "url": "https://github.com/Bliveren/image2tools/issues/4"
           }
         ],
-        "artifacts": [
-          {
-            "kind": "evidence-note",
-            "path": "docs/release/windows-full-install-2026-06-10.md",
-            "public": true,
-            "description": "Redacted Windows full-install verifier result."
-          },
-          {
-            "kind": "evidence-note",
-            "path": "docs/release/windows-native-download-open-folder-2026-06-10.md",
-            "public": true,
-            "description": "Native Windows packaged-app download and open-folder acceptance evidence."
-          }
-        ],
-        "summary": "Windows native release evidence passed: full-install verifier passed, mock OpenAI and Gemini packaged-app provider configuration and generation were verified, native Save dialog download saved the generated output to the selected Windows path, and open-folder opened the expected Explorer directory containing the output."
+        "artifacts": [],
+        "summary": "Pending v0.3.0 Windows installer validation. Earlier Windows native release evidence belongs to prior releases and must be refreshed against the v0.3.0 installer or release workflow output."
       }
     },
     {
       "id": "linux-native-release",
       "title": "Native Linux desktop AppImage validation",
-      "required": true,
-      "status": "passed",
+      "required": false,
+      "status": "pending",
       "acceptanceCriteria": [
-        "Linux release verifier runs on a native desktop shell.",
-        "Direct AppImage execution is mandatory with IMAGE2TOOLS_LINUX_REQUIRE_DIRECT_APPIMAGE=1.",
+        "Linux release verifier runs on a native desktop shell if Linux artifacts are published for v0.3.0.",
+        "Direct AppImage execution is mandatory with IMAGE2TOOLS_LINUX_REQUIRE_DIRECT_APPIMAGE=1 when Linux distribution is included.",
         "Packaged app can configure mock OpenAI and Gemini endpoints.",
         "Download and open-folder behavior are checked on native Linux."
       ],
       "evidence": {
-        "verifiedAt": "2026-06-11T03:12:00.000Z",
-        "commit": "c4eed447fcbfd14a19c4f58ff9eab5dbd125d33c",
-        "environment": "Ubuntu 24.04.4 LTS (Noble Numbat) on WSL2, kernel 6.6.87.2-microsoft-standard-WSL2, x86_64; package version 0.2.0; artifact release/Image2Tools-0.2.0-linux-x86_64.AppImage.",
-        "commands": [
-          "IMAGE2TOOLS_LINUX_REQUIRE_DIRECT_APPIMAGE=1 IMAGE2TOOLS_LINUX_SMOKE_TIMEOUT_MS=15000 node scripts/verify-linux-release.mjs"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Native Linux desktop AppImage validation tracker",
             "url": "https://github.com/Bliveren/image2tools/issues/4"
           }
         ],
-        "artifacts": [
-          {
-            "kind": "evidence-note",
-            "path": "docs/release/linux-native-release-2026-06-11.md",
-            "public": true,
-            "description": "Linux native release verification evidence including verifier result and download/open-folder platform rationale."
-          }
-        ],
-        "summary": "Linux native release verification passed: ELF assertions, unpacked app Xvfb launch, direct AppImage execution (FUSE mandatory), and extracted AppImage launch all stable for 15s. Download/open-folder relies on shared Electron IPC verified on Windows; native dialog cannot be exercised headlessly."
+        "artifacts": [],
+        "summary": "Not required for the v0.3.0 macOS and Windows distribution target. Keep this gate pending unless Linux AppImage assets are produced and published for v0.3.0."
       }
     },
     {
       "id": "update-manifest-assets",
       "title": "Formal update manifest distribution assets",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
-        "Distribution artifacts are uploaded to a public HTTPS release URL.",
+        "Distribution artifacts are uploaded to a public HTTPS v0.3.0 release URL.",
         "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata.",
         "Manifest asset metadata is generated from the exact signed or platform-validated artifact.",
         "The app update downloader verifies downloaded asset size and SHA-256 before opening it."
       ],
       "evidence": {
-        "verifiedAt": "2026-06-16T02:52:06.000Z",
-        "commit": "0b4d78f5d90aff285b7cb4801c66e01f912173a8",
-        "environment": "macOS 26.5.1 arm64 local release build plus GitHub Actions Windows release workflow 27734145491; package version 0.2.2; unsigned/ad-hoc preview artifacts published to the v0.2.2 GitHub prerelease: Image2Tools-0.2.2-mac-arm64.dmg (darwin/arm64) and Image2Tools-Setup.exe (win32/x64).",
-        "commands": [
-          "node scripts/update-manifest-asset.mjs --file release/Image2Tools-0.2.2-mac-arm64.dmg --platform darwin --arch arm64 --url https://github.com/Bliveren/image2tools/releases/download/v0.2.2/Image2Tools-0.2.2-mac-arm64.dmg",
-          "gh release download v0.2.2 --pattern Image2Tools-Setup.exe --dir /tmp/v022dl --clobber",
-          "node scripts/update-manifest-asset.mjs --file /tmp/v022dl/Image2Tools-Setup.exe --platform win32 --arch x64 --url https://github.com/Bliveren/image2tools/releases/download/v0.2.2/Image2Tools-Setup.exe"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Formal update manifest distribution asset tracker",
@@ -219,10 +178,10 @@
             "kind": "update-manifest",
             "path": "docs/updates/latest.json",
             "public": true,
-            "description": "Update manifest with darwin/arm64 dmg and win32/x64 installer asset URLs, sha256, and sizeBytes for the unsigned v0.2.2 preview."
+            "description": "During v0.3.0 release preparation this manifest still points at the latest published v0.2.3 assets. Regenerate it from the exact uploaded v0.3.0 macOS and Windows artifacts before publishing."
           }
         ],
-        "summary": "Update manifest assets populated for the unsigned v0.2.2 preview. The darwin dmg entry was generated from the locally built and mac-release-verified artifact (sha256 d4f8974..., 114859171 bytes). The win32 installer entry was generated from the exact v0.2.2 GitHub release asset re-published by the tag-triggered Windows release workflow run 27734145491 (sha256 59b0eed..., 98328196 bytes). Both release asset URLs return HTTP 200. The app updater verifies downloaded size and SHA-256 before opening. Note: these are unsigned/ad-hoc preview artifacts, not Developer ID signed/notarized builds."
+        "summary": "Pending v0.3.0 release assets. Do not update docs/updates/latest.json to version 0.3.0 until the final uploaded macOS and Windows artifacts are available and their sha256 and sizeBytes have been generated from those exact files."
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image2tools",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "A multi-model desktop image workspace for GPT Image 2, Nano Banana 3, and compatible image providers.",
   "author": "Nowo, Corgnitor, and Image2Tools contributors",
   "license": "MIT",

--- a/scripts/verify-release-evidence.mjs
+++ b/scripts/verify-release-evidence.mjs
@@ -6,9 +6,6 @@ const defaultEvidenceFile = "docs/release/evidence.json";
 const allowedStatuses = new Set(["pending", "passed", "failed", "blocked"]);
 // Gates that must exist in the ledger. Whether each blocks release readiness is
 // driven by its own `required` flag in the evidence file, not by this list.
-// macos-signed-notarized is intentionally a non-blocking enhancement gate:
-// the app ships as an unsigned/ad-hoc preview, so signing/notarization absence
-// must not block a release.
 const knownGateIds = [
   "real-openai-api",
   "real-gemini-api",
@@ -19,145 +16,29 @@ const knownGateIds = [
 ];
 const checklistGuards = [
   {
-    file: "TODO.md",
-    text: "用真实 API Key 做一次实际生成、编辑、局部重绘手工验收",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "TODO.md",
-    text: "用真实 Gemini Key 完成 Nano Banana 3 生成、参考图编辑、局部引导编辑和下载/历史验收",
-    gateIds: ["real-gemini-api"]
-  },
-  {
-    file: "TODO.md",
-    text: "完成签名、公证并补充正式分发资产 URL / hash / size 证据",
+    file: "docs/plans/v0.3.0-plan.md",
+    text: "macOS：`pnpm package:mac:signed` 产出 signed/notarized dmg/zip",
     gateIds: ["macos-signed-notarized", "update-manifest-assets"]
   },
   {
-    file: "TODO.md",
-    text: "非 macOS 平台安装验证；Windows 已完成，原生 Linux 桌面 shell 行为仍待验证",
-
-    gateIds: ["windows-native-release", "linux-native-release"]
+    file: "docs/plans/v0.3.0-plan.md",
+    text: "macOS：`pnpm verify:release:mac` 通过",
+    gateIds: ["macos-signed-notarized"]
   },
   {
-    file: "CHECKLIST.md",
-    text: "文本提示可成功出图（需真实 API Key 手工验收）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "单图编辑可用（需真实 API Key 手工验收）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "多图参考编辑可用（需真实 API Key 手工验收）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "局部重绘可用（需真实 API Key 手工验收）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "Windows 原生安装与启动验证完成",
+    file: "docs/plans/v0.3.0-plan.md",
+    text: "Windows：`pnpm verify:release:windows` 或 GitHub workflow gate 通过",
     gateIds: ["windows-native-release"]
   },
   {
-    file: "CHECKLIST.md",
-    text: "Linux 原生桌面 AppImage 直接运行、下载、打开文件夹行为验证完成",
-    gateIds: ["linux-native-release"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "Gemini / Nano Banana 3 真实 API 验收完成（已有受成本保护 verifier，仍需真实 Key 跑通并记录证据）",
-    gateIds: ["real-gemini-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "仅输入 prompt 生成一张图（需真实 API Key）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "输入长 prompt 生成一张图（需真实 API Key）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "上传一张参考图后编辑（需真实 API Key）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "上传多张参考图后编辑（需真实 API Key）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "用 mask 对图局部重绘（需真实 API Key）",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "真实 OpenAI / Gemini 外部验收完成",
-    gateIds: ["real-openai-api", "real-gemini-api"]
-  },
-  {
-    file: "CHECKLIST.md",
-    text: "正式更新 manifest 已补充分发资产 URL、hash 和 size",
+    file: "docs/plans/v0.3.0-plan.md",
+    text: "用实际上传资产更新 `docs/updates/latest.json`",
     gateIds: ["update-manifest-assets"]
   },
   {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "`v0.2.0` 发布前完成至少一轮真实 OpenAI / Gemini API 外部验收",
-    gateIds: ["real-openai-api", "real-gemini-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "OpenAI Key 可发现 `gpt-image-2`",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "OpenAI Key 可完成一次文生图",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "OpenAI Key 可完成一次参考图编辑",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "OpenAI Key 可完成一次 mask 局部重绘",
-    gateIds: ["real-openai-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "Gemini Key 可发现 `gemini-3.1-flash-image`",
-    gateIds: ["real-gemini-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "Gemini Key 可完成一次 Nano Banana 3 文生图",
-    gateIds: ["real-gemini-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "Gemini Key 可完成一次 Nano Banana 3 参考图编辑",
-    gateIds: ["real-gemini-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "Gemini Key 可完成一次 Nano Banana 3 局部引导编辑",
-    gateIds: ["real-gemini-api"]
-  },
-  {
-    file: "MULTI_MODEL_CHECKLIST.md",
-    text: "历史中能区分 OpenAI 与 Gemini 任务",
-    gateIds: ["real-openai-api", "real-gemini-api"]
+    file: "docs/plans/v0.3.0-plan.md",
+    text: "更新 `docs/release/evidence.json` 的 update manifest gate",
+    gateIds: ["update-manifest-assets"]
   }
 ];
 

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 const scriptPath = path.resolve("scripts/verify-release-evidence.mjs");
 const execFileAsync = promisify(execFile);
-const checklistFiles = ["TODO.md", "CHECKLIST.md", "MULTI_MODEL_CHECKLIST.md"];
+const checklistFiles = ["TODO.md", "CHECKLIST.md", "MULTI_MODEL_CHECKLIST.md", "docs/plans/v0.3.0-plan.md"];
 
 async function run(args, options = {}) {
   try {
@@ -49,7 +49,7 @@ function completeLedger() {
   ];
   return {
     schemaVersion: 1,
-    releaseVersion: "0.2.3",
+    releaseVersion: "0.3.0",
     lastUpdated: "2026-06-09T12:00:00.000Z",
     gates: gateIds.map((id) => ({
       id,
@@ -63,18 +63,19 @@ function completeLedger() {
 }
 
 describe("release evidence verifier", () => {
-  it("validates the staged release evidence ledger", async () => {
+  it("validates the staged v0.3.0 release-prep evidence ledger", async () => {
     const result = await run([]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 6/6 required gate(s) passed.");
+    expect(result.stdout).toContain("Release evidence validated:");
+    expect(result.stdout).toContain("Pending required gate(s):");
   });
 
-  it("passes --require-complete because all gates are passed", async () => {
+  it("fails --require-complete while staged v0.3.0 release gates are pending", async () => {
     const result = await run(["--require-complete"]);
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 6/6 required gate(s) passed.");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Required release evidence gates are not passed");
   });
 
   it("fails --require-complete when a required gate is still pending", async () => {
@@ -164,20 +165,21 @@ describe("release evidence verifier", () => {
       };
       await writeFile(path.join(docsReleaseDir, "evidence.json"), JSON.stringify(ledger, null, 2));
 
-      const checklistPath = path.join(tempRoot, "TODO.md");
+      const guardedItem = "macOS：`pnpm package:mac:signed` 产出 signed/notarized dmg/zip";
+      const checklistPath = path.join(tempRoot, "docs/plans/v0.3.0-plan.md");
       const checklist = await readFile(checklistPath, "utf8");
       await writeFile(
         checklistPath,
         checklist.replace(
-          "- [ ] 完成签名、公证并补充正式分发资产 URL / hash / size 证据",
-          "- [x] 完成签名、公证并补充正式分发资产 URL / hash / size 证据"
+          `- [ ] ${guardedItem}`,
+          `- [x] ${guardedItem}`
         )
       );
 
       const result = await run([], { cwd: tempRoot });
 
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain("完成签名、公证并补充正式分发资产 URL / hash / size 证据");
+      expect(result.stderr).toContain(guardedItem);
       expect(result.stderr).toContain("macos-signed-notarized");
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
@@ -187,6 +189,8 @@ describe("release evidence verifier", () => {
 
 async function copyChecklistFixture(tempRoot) {
   for (const file of checklistFiles) {
-    await copyFile(path.resolve(file), path.join(tempRoot, file));
+    const destination = path.join(tempRoot, file);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await copyFile(path.resolve(file), destination);
   }
 }

--- a/src/shared/package-config.test.ts
+++ b/src/shared/package-config.test.ts
@@ -3,8 +3,8 @@ import packageJson from "../../package.json";
 import updateManifest from "../../docs/updates/latest.json";
 
 describe("package release configuration", () => {
-  it("stages the v0.2.3 multi-model release metadata", () => {
-    expect(packageJson.version).toBe("0.2.3");
+  it("stages the v0.3.0 multi-API productivity release metadata", () => {
+    expect(packageJson.version).toBe("0.3.0");
     expect(packageJson.description).toContain("multi-model desktop image workspace");
     expect(packageJson.description).toContain("GPT Image 2");
     expect(packageJson.description).toContain("Nano Banana 3");
@@ -13,8 +13,8 @@ describe("package release configuration", () => {
   });
 
   it("keeps a published update manifest with verifiable size and sha256", () => {
-    // During 0.2.2 development the manifest still describes the last published
-    // release (0.2.0 preview); it is regenerated from signed/validated release
+    // During release preparation the manifest may still describe the last
+    // published release. It is regenerated from signed/validated v0.3.0
     // artifacts at release time. Validate shape, not version equality.
     expect(typeof updateManifest.version).toBe("string");
     expect(updateManifest.version.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- prepares v0.3.0 package metadata, README, release notes, and release evidence ledger
- keeps docs/updates/latest.json on the last published v0.2.3 assets until final v0.3.0 artifacts exist
- records pending v0.3.0 gates explicitly instead of carrying forward prior-release evidence

## Validation
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm verify:release-evidence
- pnpm package:mac
- pnpm verify:release:mac

## Not ready to merge/release yet
- v0.2.3 remote release is not fully published: no v0.2.3 tag/release exists, and the current 0.2.3 DMG copy is app-notarized but not DMG-notarized/stapled
- v0.3.0 release evidence still has required pending gates: real-openai-api, real-gemini-api, macos-signed-notarized, windows-native-release, update-manifest-assets
