### PR TITLE
Fix mac release verifier DMG selection

### DIFF
--- a/scripts/release-artifact-selection.mjs
+++ b/scripts/release-artifact-selection.mjs
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+const macDmgPattern = /^Image2Tools-.*-mac-.*\.dmg$/;
+
+export function selectDmgFile(entries, packageVersion, releaseDir = path.resolve("release")) {
+  const candidates = entries.filter((entry) => entry.isFile && macDmgPattern.test(entry.name));
+  const versionedCandidates = packageVersion
+    ? candidates.filter((entry) => entry.name.includes(`-${packageVersion}-`))
+    : candidates;
+  const selectedCandidates = versionedCandidates.length > 0 ? versionedCandidates : candidates;
+  if (selectedCandidates.length !== 1) {
+    throw new Error(
+      `Expected one Image2Tools macOS dmg${packageVersion ? ` for version ${packageVersion}` : ""}, found ${selectedCandidates.length}: ${
+        selectedCandidates.map((entry) => path.join(releaseDir, entry.name)).join(", ") || "none"
+      }`
+    );
+  }
+  return path.join(releaseDir, selectedCandidates[0].name);
+}

--- a/scripts/verify-mac-release.mjs
+++ b/scripts/verify-mac-release.mjs
@@ -2,11 +2,12 @@
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { selectDmgFile } from "./release-artifact-selection.mjs";
 
 const execFileAsync = promisify(execFile);
 const releaseDir = path.resolve("release");
-const dmgPattern = /^Image2Tools-.*-mac-.*\.dmg$/;
 const appName = "Image2Tools.app";
 const processName = "Image2Tools";
 const appExecutable = "Contents/MacOS/Image2Tools";
@@ -24,15 +25,19 @@ async function run(command, args, options = {}) {
   });
 }
 
+async function readPackageVersion() {
+  const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+  return typeof packageJson.version === "string" ? packageJson.version : "";
+}
+
 async function findDmg() {
   const entries = await readdir(releaseDir, { withFileTypes: true });
-  const candidates = entries
-    .filter((entry) => entry.isFile() && dmgPattern.test(entry.name))
-    .map((entry) => path.join(releaseDir, entry.name));
-  if (candidates.length !== 1) {
-    throw new Error(`Expected one Image2Tools macOS dmg, found ${candidates.length}: ${candidates.join(", ") || "none"}`);
-  }
-  return candidates[0];
+  const packageVersion = await readPackageVersion();
+  return selectDmgFile(
+    entries.map((entry) => ({ name: entry.name, isFile: entry.isFile() })),
+    packageVersion,
+    releaseDir
+  );
 }
 
 function parseMountPoint(output) {
@@ -223,7 +228,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/verify-mac-release.test.mjs
+++ b/scripts/verify-mac-release.test.mjs
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { selectDmgFile } from "./release-artifact-selection.mjs";
+
+function file(name) {
+  return { name, isFile: true };
+}
+
+function directory(name) {
+  return { name, isFile: false };
+}
+
+describe("macOS release verifier dmg selection", () => {
+  it("selects the package-version dmg when older release artifacts remain", () => {
+    expect(selectDmgFile([
+      file("Image2Tools-0.2.2-mac-arm64.dmg"),
+      file("Image2Tools-0.2.3-mac-arm64.dmg"),
+      file("Image2Tools-0.2.3-mac-arm64.zip"),
+      directory("mac-arm64")
+    ], "0.2.3")).toBe(path.resolve("release/Image2Tools-0.2.3-mac-arm64.dmg"));
+  });
+
+  it("still fails when multiple dmgs exist for the current package version", () => {
+    expect(() => selectDmgFile([
+      file("Image2Tools-0.3.0-mac-arm64.dmg"),
+      file("Image2Tools-0.3.0-mac-x64.dmg")
+    ], "0.3.0")).toThrow("Expected one Image2Tools macOS dmg for version 0.3.0");
+  });
+
+  it("falls back to the old single-candidate behavior when no versioned dmg exists", () => {
+    expect(selectDmgFile([
+      file("Image2Tools-preview-mac-arm64.dmg")
+    ], "0.3.0")).toBe(path.resolve("release/Image2Tools-preview-mac-arm64.dmg"));
+  });
+});


### PR DESCRIPTION
## Summary
- select the macOS DMG matching package.json version when older release artifacts remain in release/
- keep the previous single-candidate fallback for legacy artifact names
- avoid running the verifier CLI when importing the module in tests

## Validation
- pnpm test -- scripts/verify-mac-release.test.mjs
- pnpm build
