### PR TITLE
feat: add prompt chip trigger input

### DIFF
--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -427,6 +427,46 @@ describe("renderer multi-model smoke", () => {
     );
   });
 
+  it("creates prompt chips from @, ~, and # triggers in the prompt input", async () => {
+    const gallery = galleryAsset("trigger-gallery.png");
+    const template = {
+      id: "template-trigger",
+      title: "Trigger template",
+      body: "cinematic backlight",
+      tags: ["cinematic"],
+      createdAt: now,
+      updatedAt: now
+    };
+    const bridge = await renderApp(snapshot({ galleryAssets: [gallery], promptTemplates: [template] }));
+    const promptInput = textAreaByLabel("Prompt");
+
+    await changeTextArea(promptInput, "Product hero @trigger");
+    expect(document.body.textContent).toContain("trigger-gallery.png");
+    await keyDown(promptInput, "Enter");
+
+    await changeTextArea(promptInput, `${promptInput.value} ~trigger`);
+    expect(document.body.textContent).toContain("Trigger template");
+    await keyDown(promptInput, "Enter");
+
+    await changeTextArea(promptInput, `${promptInput.value} #abc`);
+    await keyDown(promptInput, "Enter");
+
+    expect(bridge.pickGalleryAsset).toHaveBeenCalledWith(gallery.id);
+    expect(document.body.textContent).toContain("@ trigger-gallery.png");
+    expect(document.body.textContent).toContain("~ Trigger template");
+    expect(document.body.textContent).toContain("#ABC");
+
+    await click(document.querySelector<HTMLButtonElement>(".primary-run")!);
+
+    expect(bridge.runJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "edit",
+        prompt: "Product hero\n\ncinematic backlight\n\n#ABC",
+        inputPaths: [`/tmp/gallery/${gallery.fileName}`]
+      })
+    );
+  });
+
   it("adds a history result to Gallery", async () => {
     const result = imageAsset("history-result.png");
     const job = geminiJob(0, { outputs: [result] });

--- a/src/renderer/PromptComposer.tsx
+++ b/src/renderer/PromptComposer.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { ImagePlus, Palette, ScrollText, X } from "lucide-react";
 import type { GalleryAsset, PromptTemplate } from "../shared/types";
 import { normalizeHexColor, type PromptToken } from "./promptTokens";
@@ -25,6 +26,11 @@ export function PromptComposer({
   onGalleryAssetToken,
   onDirty
 }: PromptComposerProps) {
+  const promptTrigger = useMemo(
+    () => getTrailingPromptTrigger(value, galleryAssets, templates),
+    [galleryAssets, templates, value]
+  );
+
   function addToken(token: PromptToken) {
     onDirty();
     onTokensChange([...tokens, token]);
@@ -33,6 +39,57 @@ export function PromptComposer({
   function removeToken(index: number) {
     onDirty();
     onTokensChange(tokens.filter((_, tokenIndex) => tokenIndex !== index));
+  }
+
+  function replaceTrailingPromptTrigger(nextValue: string) {
+    onDirty();
+    onChange(nextValue);
+  }
+
+  function stripTrailingPromptTrigger(startIndex: number): string {
+    return value.slice(0, startIndex).replace(/[ \t]+$/, "");
+  }
+
+  function chooseGalleryAsset(asset: GalleryAsset, triggerStartIndex?: number) {
+    if (triggerStartIndex !== undefined) {
+      replaceTrailingPromptTrigger(stripTrailingPromptTrigger(triggerStartIndex));
+    }
+    onGalleryAssetToken(asset);
+  }
+
+  function chooseTemplate(template: PromptTemplate, triggerStartIndex?: number) {
+    if (triggerStartIndex !== undefined) {
+      replaceTrailingPromptTrigger(stripTrailingPromptTrigger(triggerStartIndex));
+    }
+    addToken({ type: "template", templateId: template.id, title: template.title, body: template.body });
+  }
+
+  function addColorChip(color: string, startIndex?: number) {
+    if (startIndex !== undefined) {
+      replaceTrailingPromptTrigger(stripTrailingPromptTrigger(startIndex));
+    }
+    addToken({ type: "color", value: color });
+  }
+
+  function handlePromptKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key === "Enter") {
+      const colorTrigger = getTrailingColorTrigger(value);
+      if (colorTrigger) {
+        event.preventDefault();
+        addColorChip(colorTrigger.color, colorTrigger.startIndex);
+        return;
+      }
+
+      const firstPromptOption = promptTrigger?.options[0];
+      if (promptTrigger && firstPromptOption) {
+        event.preventDefault();
+        if (promptTrigger.kind === "gallery") {
+          chooseGalleryAsset(firstPromptOption as GalleryAsset, promptTrigger.startIndex);
+        } else {
+          chooseTemplate(firstPromptOption as PromptTemplate, promptTrigger.startIndex);
+        }
+      }
+    }
   }
 
   return (
@@ -45,14 +102,36 @@ export function PromptComposer({
             onDirty();
             onChange(event.target.value);
           }}
+          onKeyDown={handlePromptKeyDown}
         />
       </label>
+      {promptTrigger && promptTrigger.options.length > 0 && (
+        <div className="prompt-trigger-menu" role="listbox" aria-label={promptTrigger.kind === "gallery" ? "@ Gallery" : "~ Template"}>
+          {promptTrigger.options.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className="prompt-trigger-option"
+              onClick={() => {
+                if (promptTrigger.kind === "gallery") {
+                  chooseGalleryAsset(option as GalleryAsset, promptTrigger.startIndex);
+                } else {
+                  chooseTemplate(option as PromptTemplate, promptTrigger.startIndex);
+                }
+              }}
+            >
+              {promptTrigger.kind === "gallery" ? <ImagePlus size={14} /> : <ScrollText size={14} />}
+              <span>{promptTrigger.kind === "gallery" ? (option as GalleryAsset).originalName : (option as PromptTemplate).title}</span>
+            </button>
+          ))}
+        </div>
+      )}
       <div className="prompt-token-toolbar" aria-label="Prompt chips">
         <select
           value=""
           onChange={(event) => {
             const asset = galleryAssets.find((item) => item.id === event.target.value);
-            if (asset) onGalleryAssetToken(asset);
+            if (asset) chooseGalleryAsset(asset);
             event.currentTarget.value = "";
           }}
           title="@ Gallery"
@@ -66,7 +145,7 @@ export function PromptComposer({
           value=""
           onChange={(event) => {
             const template = templates.find((item) => item.id === event.target.value);
-            if (template) addToken({ type: "template", templateId: template.id, title: template.title, body: template.body });
+            if (template) chooseTemplate(template);
             event.currentTarget.value = "";
           }}
           title="~ Template"
@@ -84,7 +163,7 @@ export function PromptComposer({
             event.preventDefault();
             const color = normalizeHexColor(event.currentTarget.value);
             if (!color) return;
-            addToken({ type: "color", value: color });
+            addColorChip(color);
             event.currentTarget.value = "";
           }}
         />
@@ -116,4 +195,60 @@ function labelForToken(token: PromptToken): string {
   if (token.type === "template") return `~ ${token.title}`;
   if (token.type === "color") return token.value;
   return token.text;
+}
+
+type PromptTrigger =
+  | { kind: "gallery"; startIndex: number; query: string; options: GalleryAsset[] }
+  | { kind: "template"; startIndex: number; query: string; options: PromptTemplate[] };
+
+function getTrailingPromptTrigger(value: string, galleryAssets: GalleryAsset[], templates: PromptTemplate[]): PromptTrigger | null {
+  const match = /(^|[\s])([@~])([^\s@~#]{0,48})$/.exec(value);
+  if (!match) return null;
+
+  const marker = match[2];
+  const query = match[3].trim().toLowerCase();
+  const startIndex = match.index + match[1].length;
+
+  if (marker === "@") {
+    return {
+      kind: "gallery",
+      startIndex,
+      query,
+      options: galleryAssets
+        .filter((asset) => matchesGalleryQuery(asset, query))
+        .slice(0, 6)
+    };
+  }
+
+  return {
+    kind: "template",
+    startIndex,
+    query,
+    options: templates
+      .filter((template) => matchesTemplateQuery(template, query))
+      .slice(0, 6)
+  };
+}
+
+function getTrailingColorTrigger(value: string): { startIndex: number; color: string } | null {
+  const match = /(^|[\s])(#[0-9a-fA-F]{6}|#[0-9a-fA-F]{3})$/.exec(value);
+  if (!match) return null;
+  const color = normalizeHexColor(match[2]);
+  if (!color) return null;
+  return {
+    startIndex: match.index + match[1].length,
+    color
+  };
+}
+
+function matchesGalleryQuery(asset: GalleryAsset, query: string): boolean {
+  if (!query) return true;
+  const haystack = `${asset.originalName} ${asset.fileName} ${asset.tags.join(" ")}`.toLowerCase();
+  return haystack.includes(query);
+}
+
+function matchesTemplateQuery(template: PromptTemplate, query: string): boolean {
+  if (!query) return true;
+  const haystack = `${template.title} ${template.body} ${template.tags.join(" ")} ${template.category ?? ""}`.toLowerCase();
+  return haystack.includes(query);
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1361,6 +1361,39 @@ label {
   height: 34px;
 }
 
+.prompt-trigger-menu {
+  display: grid;
+  gap: 4px;
+  max-height: 154px;
+  overflow: auto;
+  border: 1px solid #d6d0c3;
+  border-radius: 8px;
+  background: #fffdf8;
+  padding: 4px;
+}
+
+.prompt-trigger-option {
+  justify-content: flex-start;
+  min-width: 0;
+  width: 100%;
+  min-height: 30px;
+  border-color: transparent;
+  background: transparent;
+  color: #2d2a24;
+  font-size: 12px;
+}
+
+.prompt-trigger-option:hover {
+  background: #f2ece0;
+}
+
+.prompt-trigger-option span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .prompt-chip-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary\n- add @ and ~ trigger suggestions directly from the prompt textarea\n- add #RGB/#RRGGBB Enter handling for color chips\n- cover trigger-based chip creation in renderer smoke tests\n\n## Validation\n- pnpm build\n- pnpm verify:mock-api\n- pnpm verify:mock-gemini-api\n- pnpm verify:mock-model-discovery\n- git diff --check\n\n## Release boundary\n- does not change package.json version\n- does not change docs/updates/latest.json\n- does not change docs/release/evidence.json\n- does not touch v0.2.3 release notes/evidence