### PR TITLE
fix: preserve gallery references safely

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -57,7 +57,7 @@ import { fetchWithTimeout } from "./services/openaiImage.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
 import { buildProviderConfigForSave, providerDisplayName } from "./services/providerConfigSave.js";
-import { assertKnownOutputPath, assertManagedRegularFile, assertManagedRegularFileInRoots, collectOwnedJobFilePaths, normalizeManagedAssetPath, resolveManagedFileName } from "./services/assetOwnership.js";
+import { assertKnownOutputPath, assertKnownRegularOutputPath, assertManagedRegularFile, assertManagedRegularFileInRoots, collectOwnedJobFilePaths, normalizeManagedAssetPath, resolveManagedFileName } from "./services/assetOwnership.js";
 import { recoverInterruptedJobs } from "./services/stateRecovery.js";
 import { type AppStateFile, type StoredProviderConfig, STATE_VERSION, getDefaultState, normalizeImageParams, normalizeState } from "./services/stateMigration.js";
 import { verifyUpdateAssetBytes } from "./services/updateInstallerVerification.js";
@@ -877,7 +877,7 @@ async function handleImportToGallery(_event: IpcMainInvokeEvent, paths?: string[
 
 async function handleAddHistoryAssetToGallery(_event: IpcMainInvokeEvent, assetPath: string): Promise<GalleryAsset> {
   const state = await readState();
-  const sourcePath = assertKnownOutputPath(getImagesDir(), state.history, assetPath);
+  const sourcePath = await assertKnownRegularOutputPath(getImagesDir(), state.history, assetPath);
   const asset = await createGalleryAssetFromFile(sourcePath, "result", new Date().toISOString());
   await writeState({ ...state, galleryAssets: [asset, ...state.galleryAssets] });
   return asset;
@@ -919,6 +919,7 @@ async function handlePickGalleryAsset(_event: IpcMainInvokeEvent, id: string): P
     path: filePath,
     mimeType: asset.mimeType,
     sizeBytes: asset.sizeBytes,
+    previewUrl: `${ASSET_PROTOCOL}://image?gallery=${encodeURIComponent(asset.fileName)}`,
     width: asset.width,
     height: asset.height
   };

--- a/src/main/services/assetOwnership.test.ts
+++ b/src/main/services/assetOwnership.test.ts
@@ -6,6 +6,7 @@ import type { GenerationJob } from "../../shared/types";
 import { DEFAULT_IMAGE_PARAMS } from "../../shared/validation";
 import {
   assertKnownOutputPath,
+  assertKnownRegularOutputPath,
   assertManagedRegularFile,
   assertManagedRegularFileInRoots,
   collectOwnedJobFilePaths,
@@ -82,6 +83,20 @@ describe("asset ownership checks", () => {
     await import("node:fs/promises").then((fs) => fs.symlink(outsidePath, linkPath));
 
     await expect(assertManagedRegularFile(imagesDir, linkPath)).rejects.toThrow("管理目录");
+  });
+
+  it.skipIf(process.platform === "win32")("rejects known history outputs that are symlinks outside the managed images directory", async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "image2tools-assets-"));
+    const imagesDir = path.join(tmpDir, "images");
+    await mkdir(imagesDir);
+    const outsidePath = path.join(tmpDir, "outside.png");
+    const linkPath = path.join(imagesDir, "history-linked.png");
+    await writeFile(outsidePath, "secret");
+    await import("node:fs/promises").then((fs) => fs.symlink(outsidePath, linkPath));
+    const job = makeJob(imagesDir, linkPath);
+
+    expect(assertKnownOutputPath(imagesDir, [job], linkPath)).toBe(path.resolve(linkPath));
+    await expect(assertKnownRegularOutputPath(imagesDir, [job], linkPath)).rejects.toThrow("管理目录");
   });
 
   it("collects only generated files and locally persisted masks owned by a job", () => {

--- a/src/main/services/assetOwnership.ts
+++ b/src/main/services/assetOwnership.ts
@@ -43,6 +43,10 @@ export function assertKnownOutputPath(imagesDir: string, history: GenerationJob[
   return normalized;
 }
 
+export async function assertKnownRegularOutputPath(imagesDir: string, history: GenerationJob[], assetPath: string): Promise<string> {
+  return assertManagedRegularFile(imagesDir, assertKnownOutputPath(imagesDir, history, assetPath));
+}
+
 export async function assertManagedRegularFile(imagesDir: string, assetPath: string): Promise<string> {
   const normalized = normalizeManagedAssetPath(imagesDir, assetPath);
   if (!normalized) {

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -368,6 +368,7 @@ describe("renderer multi-model smoke", () => {
     expect(bridge.pickGalleryAsset).toHaveBeenCalledWith(asset.id);
     expect(document.body.textContent).toContain("gallery-product.png added as a reference.");
     expect(document.querySelector(".asset-tile")?.textContent).toContain("gallery-product.png");
+    expect(document.querySelector<HTMLImageElement>(".asset-tile img")?.src).toBe(`image2tools-asset://image?gallery=${asset.fileName}`);
 
     await click(document.querySelector<HTMLButtonElement>(".primary-run")!);
 
@@ -605,7 +606,7 @@ describe("renderer multi-model smoke", () => {
     expect(document.body.textContent).toContain("Show fewer");
   });
 
-  it("keeps prompt text while switching models and resets incompatible General inputs", async () => {
+  it("keeps prompt text and reference inputs while switching to incompatible General mode", async () => {
     const defaultConfig = providerConfig({
       apiKeySaved: true,
       discoveredModels: [
@@ -614,22 +615,36 @@ describe("renderer multi-model smoke", () => {
       ],
       lastModelDiscoveryAt: now
     });
+    const referenceAsset = galleryAsset("general-reference.png");
     const bridge = await renderApp(
       snapshot({
         providers: [defaultConfig],
-        activeProviderId: defaultConfig.id
+        activeProviderId: defaultConfig.id,
+        galleryAssets: [referenceAsset]
       })
     );
     const promptInput = document.querySelector<HTMLTextAreaElement>("textarea")!;
     const originalPrompt = promptInput.value;
+    vi.mocked(bridge.pickGalleryAsset).mockResolvedValueOnce({
+      id: referenceAsset.id,
+      name: referenceAsset.originalName,
+      path: `/tmp/gallery/${referenceAsset.fileName}`,
+      mimeType: referenceAsset.mimeType,
+      sizeBytes: referenceAsset.sizeBytes,
+      previewUrl: `image2tools-asset://image?gallery=${referenceAsset.fileName}`
+    });
 
     await click(buttonByText("Image to image", ".mode-tab"));
+    await click(buttonByText("Reference Gallery", ".section-toggle"));
+    await click(document.querySelector<HTMLButtonElement>(".gallery-thumb")!);
+    await flushAsync();
     await click(launchButton("General"));
 
     expect(document.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(originalPrompt);
-    expect(buttonByText("Generate", ".primary-run").disabled).toBe(false);
+    expect(document.body.textContent).toContain("general-reference.png");
+    expect(document.querySelector<HTMLImageElement>(".asset-tile img")?.src).toBe(`image2tools-asset://image?gallery=${referenceAsset.fileName}`);
+    expect(buttonByText("Generate", ".primary-run").disabled).toBe(true);
     expect(document.body.textContent).toContain("prompt-only generation");
-    expect(document.body.textContent).not.toContain("Add references");
     expect(bridge.saveConfig).toHaveBeenLastCalledWith(
       expect.objectContaining({
         activeLaunchId: "general",
@@ -890,7 +905,8 @@ function createBridge(initialSnapshot: AppSnapshot): AppBridge {
         name: asset.originalName,
         path: `/tmp/gallery/${asset.fileName}`,
         mimeType: asset.mimeType,
-        sizeBytes: asset.sizeBytes
+        sizeBytes: asset.sizeBytes,
+        previewUrl: `image2tools-asset://image?gallery=${asset.fileName}`
       };
     }),
     selectImages: vi.fn(async () => []),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -192,6 +192,7 @@ function getBridge() {
 
 function assetSource(asset?: ImageAsset | InputAsset | null): string | undefined {
   if (!asset) return undefined;
+  if ("previewUrl" in asset && asset.previewUrl) return asset.previewUrl;
   if ("dataUrl" in asset && asset.dataUrl) return asset.dataUrl;
   if ("fileName" in asset && asset.path) return `image2tools-asset://image?path=${encodeURIComponent(asset.path)}`;
   if (asset.path) return `file://${encodeURI(asset.path)}`;
@@ -743,7 +744,7 @@ export function App() {
       : hasMask
         ? "inpaint"
         : "edit";
-  const showReferenceTools = generalParams ? generalAllowsReferences : tabMode === "img2img";
+  const showReferenceTools = generalParams ? generalAllowsReferences || effectiveInputAssets.length > 0 : tabMode === "img2img";
   const generalModeNotice = generalParams ? generalRuntimeNotice(generalParams.providerKind, copy) : copy.generalRuntimeUnsupported;
   const activeInpaintCapability = inpaintCapabilityForParams(params);
   const usesExactMask = activeInpaintCapability === "exact-mask";
@@ -897,25 +898,11 @@ export function App() {
 
   useEffect(() => {
     if (!generalParams) return;
-    if (!generalFallbackSupportsReferenceImages(generalParams.providerKind)) {
-      if (inputAssets.length > 0) {
-        setInputAssets([]);
-      }
-      if (promptTokens.some((token) => token.type === "asset")) {
-        setPromptTokens((current) => current.filter((token) => token.type !== "asset"));
-        setPromptTokenAssets({});
-      }
-      if (maskAsset || maskDataUrl) {
-        setMaskAsset(null);
-        setMaskDataUrl(null);
-      }
-      return;
-    }
     if (maskAsset || maskDataUrl) {
       setMaskAsset(null);
       setMaskDataUrl(null);
     }
-  }, [generalParams, inputAssets.length, maskAsset, maskDataUrl, promptTokens]);
+  }, [generalParams, maskAsset, maskDataUrl]);
 
   useEffect(() => {
     void refreshSnapshot();
@@ -1472,11 +1459,6 @@ export function App() {
     const nextParams = createLaunchParams(button.launchId, button.modelId, params, launchProvider, launchConfig);
     setParams(nextParams);
     if (isGeneralImageParams(nextParams)) {
-      if (!generalFallbackSupportsReferenceImages(nextParams.providerKind)) {
-        setTabMode("text2img");
-        setInputAssets([]);
-        clearPromptChips();
-      }
       setMaskAsset(null);
       setMaskDataUrl(null);
     }
@@ -1510,11 +1492,6 @@ export function App() {
     const nextParams = createLaunchParams(launchId, selectedModel.id, params, selectedModel.providerKind, activeConfig);
     setParams(nextParams);
     if (isGeneralImageParams(nextParams)) {
-      if (!generalFallbackSupportsReferenceImages(nextParams.providerKind)) {
-        setTabMode("text2img");
-        setInputAssets([]);
-        clearPromptChips();
-      }
       setMaskAsset(null);
       setMaskDataUrl(null);
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -127,6 +127,7 @@ export interface InputAsset {
   mimeType: string;
   sizeBytes: number;
   dataUrl?: string;
+  previewUrl?: string;
   width?: number;
   height?: number;
 }

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -397,6 +397,9 @@ export function validateInputAssetShape(asset: unknown): ValidationResult {
   if (asset.dataUrl !== undefined && typeof asset.dataUrl !== "string") {
     return { ok: false, message: "输入资源数据无效。" };
   }
+  if (asset.previewUrl !== undefined && typeof asset.previewUrl !== "string") {
+    return { ok: false, message: "输入资源预览地址无效。" };
+  }
   if (asset.width !== undefined && (!isInteger(asset.width) || asset.width < 1)) {
     return { ok: false, message: "输入资源宽度无效。" };
   }


### PR DESCRIPTION
## Summary
- preserve user reference images and Gallery asset chips when switching to prompt-only General models
- keep incompatible references visible so validation can explain the issue instead of silently deleting input
- use managed image2tools-asset preview URLs for Gallery-picked reference assets
- reject history outputs that are known paths but resolve to symlinks outside the managed images directory

## Validation
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- git diff --check

## Release boundary
- does not change package.json version
- does not change docs/updates/latest.json
- does not change docs/release/evidence.json
- does not touch v0.2.3 release notes/evidence