### PR TITLE
release: prepare v0.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Verify Windows package
         env:
-          IMAGE2TOOLS_WINDOWS_VERIFY_MODE: package-smoke
+          IMAGE2TOOLS_WINDOWS_VERIFY_MODE: full-install
         run: pnpm verify:release:windows
 
   linux-package:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Verify Windows package
         env:
-          IMAGE2TOOLS_WINDOWS_VERIFY_MODE: package-smoke
+          IMAGE2TOOLS_WINDOWS_VERIFY_MODE: full-install
         run: pnpm verify:release:windows
 
       - name: Publish GitHub Release asset

--- a/docs/release/evidence.json
+++ b/docs/release/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "releaseVersion": "0.2.3",
+  "releaseVersion": "0.2.4",
   "lastUpdated": "2026-06-30T16:17:47.000Z",
   "gates": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image2tools",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A multi-model desktop image workspace for GPT Image 2, Nano Banana 3, and compatible image providers.",
   "author": "Nowo, Corgnitor, and Image2Tools contributors",
   "license": "MIT",

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -49,7 +49,7 @@ function completeLedger() {
   ];
   return {
     schemaVersion: 1,
-    releaseVersion: "0.2.3",
+    releaseVersion: "0.2.4",
     lastUpdated: "2026-06-09T12:00:00.000Z",
     gates: gateIds.map((id) => ({
       id,

--- a/src/shared/package-config.test.ts
+++ b/src/shared/package-config.test.ts
@@ -3,8 +3,8 @@ import packageJson from "../../package.json";
 import updateManifest from "../../docs/updates/latest.json";
 
 describe("package release configuration", () => {
-  it("stages the v0.2.3 multi-model release metadata", () => {
-    expect(packageJson.version).toBe("0.2.3");
+  it("stages the v0.2.4 bugfix release metadata", () => {
+    expect(packageJson.version).toBe("0.2.4");
     expect(packageJson.description).toContain("multi-model desktop image workspace");
     expect(packageJson.description).toContain("GPT Image 2");
     expect(packageJson.description).toContain("Nano Banana 3");


### PR DESCRIPTION
## Summary
- Bump package metadata to 0.2.4 for the configuration/Gemini sizing bugfix release.
- Align release evidence and package-config tests with the 0.2.4 version.
- Raise Windows CI/release verification from package-smoke to full-install so v0.2.4 can collect native installer evidence before final publication.

## Current local validation
- pnpm build
- pnpm verify:release-evidence

## Follow-up before final release
- Wait for CI, especially Windows full-install.
- Upload 0.2.4 release assets and update docs/updates/latest.json + docs/release/evidence.json with final asset hashes/sizes.