### PR TITLE
fix: improve gallery accessibility basics

### DIFF
--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -511,11 +511,16 @@ describe("renderer multi-model smoke", () => {
     const bridge = await renderApp(snapshot({ galleryAssets: [asset] }));
 
     await openGalleryRail();
+    const thumbnailImage = document.querySelector<HTMLImageElement>(".gallery-thumb img")!;
+    expect(thumbnailImage.getAttribute("loading")).toBe("lazy");
+    expect(thumbnailImage.getAttribute("decoding")).toBe("async");
     await click(document.querySelector<HTMLButtonElement>(".gallery-thumb")!);
 
     expect(bridge.pickGalleryAsset).not.toHaveBeenCalled();
     expect(document.querySelector<HTMLImageElement>(".preview-image-frame img")?.src).toContain(`image2tools-asset://image?gallery=${asset.fileName}`);
     expect(document.body.textContent).toContain("gallery-preview.png opened in the editor.");
+    expect(document.querySelector(".notice-area")?.getAttribute("aria-live")).toBe("polite");
+    expect(document.querySelector(".notice-area")?.getAttribute("aria-atomic")).toBe("true");
   });
 
   it("picks a Gallery image as a reference asset from the context menu", async () => {
@@ -524,6 +529,8 @@ describe("renderer multi-model smoke", () => {
 
     await openGalleryRail();
     await contextMenu(document.querySelector<HTMLElement>(".gallery-item")!);
+    expect(elementByText("Choose from Gallery", ".context-menu-item").tagName).toBe("BUTTON");
+    expect(elementByText("Choose from Gallery", ".context-menu-item").getAttribute("role")).toBe("menuitem");
     await click(elementByText("Choose from Gallery", ".context-menu-item"));
 
     expect(bridge.pickGalleryAsset).toHaveBeenCalledWith(asset.id);
@@ -1092,6 +1099,8 @@ describe("renderer multi-model smoke", () => {
 
     await openGalleryRail();
     await contextMenu(document.querySelector<HTMLElement>(".gallery-item")!);
+    expect(elementByText("Open folder", ".context-menu-item").tagName).toBe("BUTTON");
+    expect(elementByText("Open folder", ".context-menu-item").getAttribute("role")).toBe("menuitem");
     await click(elementByText("Open folder", ".context-menu-item"));
 
     expect(bridge.openStorageFolder).toHaveBeenCalledWith("gallery", null);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5187,7 +5187,7 @@ export function App() {
           {showAdvanced && advancedControls}
         </section>
 
-        <section className="notice-area" data-kind={notice.kind}>
+        <section className="notice-area" data-kind={notice.kind} aria-live={notice.kind === "error" ? "assertive" : "polite"} aria-atomic="true">
           {notice.kind === "error" ? <AlertTriangle size={16} /> : <CheckCircle2 size={16} />}
           <span>{notice.text}</span>
         </section>
@@ -6392,7 +6392,7 @@ export function App() {
                     onContextMenu={(event) => openGalleryAssetContextMenu(event, entry.asset)}
                     title={copy.galleryOpenItem(entry.asset.originalName)}
                   >
-                    <img src={galleryAssetPath(entry.asset)} alt={entry.asset.originalName} draggable={false} />
+                    <img src={galleryAssetPath(entry.asset)} alt={entry.asset.originalName} draggable={false} loading="lazy" decoding="async" />
                   </button>
                   <div className="gallery-meta">
                     <strong title={entry.asset.originalName}>{entry.asset.originalName}</strong>
@@ -7176,18 +7176,18 @@ export function App() {
           style={{ left: contextMenu.x, top: contextMenu.y }}
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="context-menu-item" onClick={handleContextMenuSaveImage}>
+          <button type="button" className="context-menu-item" onClick={handleContextMenuSaveImage} role="menuitem">
             <Download size={14} />
             {copy.saveImage}
-          </div>
-          <div className="context-menu-item" onClick={handleContextMenuCopyPath}>
+          </button>
+          <button type="button" className="context-menu-item" onClick={handleContextMenuCopyPath} role="menuitem">
             <Copy size={14} />
             {copy.copyImagePath}
-          </div>
-          <div className="context-menu-item" onClick={handleContextMenuCopyPrompt}>
+          </button>
+          <button type="button" className="context-menu-item" onClick={handleContextMenuCopyPrompt} role="menuitem">
             <Copy size={14} />
             {copy.copyPrompt}
-          </div>
+          </button>
         </div>
       )}
       {galleryAssetContextMenu && (() => {
@@ -7199,67 +7199,79 @@ export function App() {
             style={{ left: galleryAssetContextMenu.x, top: galleryAssetContextMenu.y }}
             onClick={(event) => event.stopPropagation()}
           >
-            <div
+            <button
+              type="button"
               className="context-menu-item"
               onClick={() => {
                 setGalleryAssetContextMenu(null);
                 void pickGalleryAsset(asset);
               }}
+              role="menuitem"
             >
               <ImageUp size={14} />
               {copy.galleryChoose}
-            </div>
-            <div
+            </button>
+            <button
+              type="button"
               className="context-menu-item"
               onClick={() => {
                 setGalleryAssetContextMenu(null);
                 openRenameGalleryAssetDialog(asset);
               }}
+              role="menuitem"
             >
               <Pencil size={14} />
               {copy.galleryAssetRename}
-            </div>
-            <div
+            </button>
+            <button
+              type="button"
               className="context-menu-item"
               onClick={() => {
                 setGalleryAssetContextMenu(null);
                 editGalleryTags(asset);
               }}
+              role="menuitem"
             >
               <Tags size={14} />
               {copy.galleryEditTags}
-            </div>
-            <div
+            </button>
+            <button
+              type="button"
               className="context-menu-item"
               onClick={() => {
                 setGalleryAssetContextMenu(null);
                 void openStorageFolder("gallery", asset.folderId ?? null);
               }}
+              role="menuitem"
             >
               <FolderOpen size={14} />
               {copy.openFolder}
-            </div>
-            <div
+            </button>
+            <button
+              type="button"
               className="context-menu-item"
               onClick={() => {
                 setGalleryAssetContextMenu(null);
                 void copyImagePath(galleryAssetAbsolutePath(asset), `copy:path:${asset.id}`);
               }}
+              role="menuitem"
             >
               <Copy size={14} />
               {copy.copyImagePath}
-            </div>
+            </button>
             <div className="context-menu-divider" />
-            <div
+            <button
+              type="button"
               className="context-menu-item danger"
               onClick={() => {
                 setGalleryAssetContextMenu(null);
                 void removeGalleryAsset(asset);
               }}
+              role="menuitem"
             >
               <Trash2 size={14} />
               {copy.delete}
-            </div>
+            </button>
           </div>
         );
       })()}
@@ -7273,51 +7285,59 @@ export function App() {
             style={{ left: galleryFolderContextMenu.x, top: galleryFolderContextMenu.y }}
             onClick={(event) => event.stopPropagation()}
           >
-            <div
+            <button
+              type="button"
               className="context-menu-item"
               onClick={() => {
                 closeGalleryFolderContextMenu();
                 void openStorageFolder("gallery", openFolderId);
               }}
+              role="menuitem"
             >
               <FolderOpen size={14} />
               {copy.openFolder}
-            </div>
+            </button>
             {canManageFolder && (
               <>
-                <div
+                <button
+                  type="button"
                   className="context-menu-item"
                   onClick={() => {
                     closeGalleryFolderContextMenu();
                     openRenameGalleryFolderDialog(folder!);
                   }}
+                  role="menuitem"
                 >
                   <Pencil size={14} />
                   {copy.galleryFolderRename}
-                </div>
-                <div
+                </button>
+                <button
+                  type="button"
                   className="context-menu-item danger"
                   onClick={() => {
                     closeGalleryFolderContextMenu();
                     void deleteGalleryFolder(folder!);
                   }}
+                  role="menuitem"
                 >
                   <Trash2 size={14} />
                   {copy.galleryFolderDelete}
-                </div>
+                </button>
                 <div className="context-menu-divider" />
               </>
             )}
-            <div
+            <button
+              type="button"
               className="context-menu-item"
               onClick={() => {
                 closeGalleryFolderContextMenu();
                 openCreateGalleryFolderDialog(openFolderId);
               }}
+              role="menuitem"
             >
               <FolderPlus size={14} />
               {copy.galleryFolderCreate}
-            </div>
+            </button>
           </div>
         );
       })()}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3094,7 +3094,7 @@
   }
 
   .notice-area[data-kind="success"] {
-    color: var(--accent);
+    color: var(--success-strong);
   }
 
   .notice-area[data-kind="error"] {
@@ -4765,16 +4765,21 @@
   }
 
   .context-menu-item {
-    padding: 8px 16px;
-    cursor: pointer;
     display: flex;
     align-items: center;
+    width: 100%;
     gap: 8px;
+    border: 0;
+    background: transparent;
     color: var(--text-primary);
+    padding: 8px 16px;
     font-size: 13px;
+    text-align: left;
+    cursor: pointer;
   }
 
-  .context-menu-item:hover {
+  .context-menu-item:hover,
+  .context-menu-item:focus-visible {
     background: var(--surface-hover);
   }
 


### PR DESCRIPTION
## Summary\n- convert remaining right-click context menu items from div click targets to button menuitems\n- add notice live-region semantics and use success color tokens\n- lazy/decode Gallery thumbnail images\n- add renderer smoke assertions for menu semantics, notice live region, and Gallery image loading hints\n\n## Validation\n- pnpm typecheck\n- pnpm vitest run src/renderer/App.smoke.test.tsx\n- node scripts/create-large-gallery-fixture.mjs --profile gallery-small --output output/perf-fixtures/gallery-small --force\n- node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-small --output output/perf-baselines/phase1-small --iterations 1\n- pnpm build