### PR TITLE
perf: avoid repeated gallery read scans

### DIFF
--- a/docs/perf/gallery-phase2.md
+++ b/docs/perf/gallery-phase2.md
@@ -1,0 +1,65 @@
+# Gallery Phase 2 Performance Results
+
+Captured: 2026-07-08
+
+Phase 2 targets the main-process Gallery read paths. It keeps full disk scan recovery available, but avoids forcing a scan when the Gallery watcher state is fresh.
+
+## Commands
+
+```bash
+node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force
+node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase2-gallery-large --iterations 3 --no-renderer
+```
+
+The measurement used `gallery-large` with 96 folders and 2400 assets. Renderer capture was intentionally skipped with `--no-renderer` because this phase changes backend read/sync behavior, not Gallery card rendering.
+
+Raw local result:
+
+```text
+output/perf-baselines/phase2-gallery-large/gallery-large-0d4e11918e04.json
+```
+
+`output/` is ignored by git; rerun the command above for fresh machine-local metrics.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Commit | `0d4e11918e04d1f5728bba16bbba80eaa7935f88` |
+| OS | Darwin `25.5.0` |
+| Architecture | `arm64` |
+| CPU | Apple M4, 10 cores |
+| Memory | 17179869184 bytes |
+| Fixture | `gallery-large` |
+| Fixture assets | 2400 |
+| Fixture folders | 96 |
+| Fixture state size | 1510172 bytes |
+
+## Before And After
+
+Phase 0 baseline values come from `docs/perf/gallery-baseline.md`.
+
+| Path | Phase 0 median | Phase 2 median | State writes |
+| --- | ---: | ---: | ---: |
+| `app:getSnapshot` handler-equivalent | 44.700 ms | 1.590 ms | 0 |
+| `gallery:list` handler-equivalent | 40.130 ms | 0.001 ms | 0 |
+| `galleryFolders:list` handler-equivalent | 39.094 ms | 0.001 ms | 0 |
+| Electron main `app:getSnapshot` | 88.510 ms | 0.093 ms | 0 |
+| Electron main `gallery:list` | 62.592 ms | 0.008 ms | 0 |
+| Electron main `galleryFolders:list` | 60.172 ms | 0.006 ms | 0 |
+
+## Recovery And Sync Metrics
+
+| Metric | Phase 2 median | Notes |
+| --- | ---: | --- |
+| `scanGalleryDisk` full | 38.079 ms | Full recovery path remains available. |
+| `scanGalleryDisk` incremental file | 0.038 ms | Used when watcher reports a changed file. |
+| `scanGalleryDisk` incremental folder | 1.773 ms | Used when watcher reports a changed subtree. |
+| `app:getSnapshot` full-scan recovery-equivalent | 39.219 ms | Explicit recovery still scans and reconciles the full Gallery. |
+| Full sync with no Gallery changes | 0 writes | Dirty detection no longer uses full `JSON.stringify` comparisons. |
+
+## Notes
+
+- Read-only IPC now returns cached Gallery state when the watcher is current and no disk changes are pending.
+- Pending watcher changes are consumed before read responses; file/subtree changes use incremental scan inputs and null watcher events still force full recovery.
+- Watcher restart uses folder paths derived from reconciled state instead of scanning the Gallery only to discover watched folders.

--- a/scripts/measure-gallery-performance.mjs
+++ b/scripts/measure-gallery-performance.mjs
@@ -218,11 +218,21 @@ function createReconcileOptions() {
   };
 }
 
-function galleryCollectionsChanged(before, after) {
-  return (
-    JSON.stringify(before.galleryFolders) !== JSON.stringify(after.galleryFolders) ||
-    JSON.stringify(before.galleryAssets) !== JSON.stringify(after.galleryAssets)
-  );
+function measureCommandFor(args) {
+  const parts = [
+    "node",
+    "scripts/measure-gallery-performance.mjs",
+    "--fixture",
+    path.relative(repoRoot, args.fixture),
+    "--output",
+    path.relative(repoRoot, args.output),
+    "--iterations",
+    String(args.iterations)
+  ];
+  if (args.skipBuild) parts.push("--skip-build");
+  if (args.noElectron) parts.push("--no-electron");
+  if (args.noRenderer) parts.push("--no-renderer");
+  return parts.join(" ");
 }
 
 function statePayloadBytes(state) {
@@ -245,7 +255,7 @@ function summarizeState(state) {
   };
 }
 
-function commonMutationWriteScenarios(state, reconciledState) {
+function commonMutationWriteScenarios(state, reconciledState, galleryCollectionsChanged) {
   const scenarios = [];
   scenarios.push({
     name: "full sync with no Gallery changes",
@@ -448,7 +458,7 @@ async function main() {
   }
 
   const galleryDiskSync = await import(pathToFileURL(path.join(repoRoot, "dist", "main", "services", "galleryDiskSync.js")).href);
-  const { scanGalleryDisk, reconcileGalleryDiskState, reconcileGalleryDiskChanges } = galleryDiskSync;
+  const { scanGalleryDisk, reconcileGalleryDiskState, reconcileGalleryDiskChanges, galleryCollectionsChanged } = galleryDiskSync;
 
   await fs.mkdir(args.output, { recursive: true });
 
@@ -499,33 +509,37 @@ async function main() {
 
   const handlerEquivalent = [];
   handlerEquivalent.push(await measureRepeated(
-    "app:getSnapshot handler-equivalent",
+    "app:getSnapshot handler-equivalent watcher-fresh",
+    args.iterations,
+    async () => {
+      return { ...summarizeState(reconciledState), stateWriteCountDelta: 0 };
+    },
+    (result) => result
+  ));
+  handlerEquivalent.push(await measureRepeated(
+    "gallery:list handler-equivalent watcher-fresh",
+    args.iterations,
+    async () => {
+      return { assetCount: reconciledState.galleryAssets.length, stateWriteCountDelta: 0 };
+    },
+    (result) => result
+  ));
+  handlerEquivalent.push(await measureRepeated(
+    "galleryFolders:list handler-equivalent watcher-fresh",
+    args.iterations,
+    async () => {
+      return { folderCount: reconciledState.galleryFolders.length, stateWriteCountDelta: 0 };
+    },
+    (result) => result
+  ));
+  handlerEquivalent.push(await measureRepeated(
+    "app:getSnapshot full-scan recovery-equivalent",
     args.iterations,
     async () => {
       const nextDisk = await scanGalleryDisk(manifest.galleryDir);
       const nextState = reconcileGalleryDiskState(state, nextDisk, createReconcileOptions());
       const changed = galleryCollectionsChanged(state, nextState);
       return { ...summarizeState(nextState), stateWriteCountDelta: changed ? 1 : 0 };
-    },
-    (result) => result
-  ));
-  handlerEquivalent.push(await measureRepeated(
-    "gallery:list handler-equivalent",
-    args.iterations,
-    async () => {
-      const nextDisk = await scanGalleryDisk(manifest.galleryDir);
-      const nextState = reconcileGalleryDiskState(state, nextDisk, createReconcileOptions());
-      return { assetCount: nextState.galleryAssets.length, stateWriteCountDelta: galleryCollectionsChanged(state, nextState) ? 1 : 0 };
-    },
-    (result) => result
-  ));
-  handlerEquivalent.push(await measureRepeated(
-    "galleryFolders:list handler-equivalent",
-    args.iterations,
-    async () => {
-      const nextDisk = await scanGalleryDisk(manifest.galleryDir);
-      const nextState = reconcileGalleryDiskState(state, nextDisk, createReconcileOptions());
-      return { folderCount: nextState.galleryFolders.length, stateWriteCountDelta: galleryCollectionsChanged(state, nextState) ? 1 : 0 };
     },
     (result) => result
   ));
@@ -573,7 +587,7 @@ async function main() {
     },
     commands: {
       fixture: manifest.commands?.regenerate,
-      measure: `node scripts/measure-gallery-performance.mjs --fixture ${path.relative(repoRoot, args.fixture)} --output ${path.relative(repoRoot, args.output)}`,
+      measure: measureCommandFor(args),
       mainHandlerCapture: `CROSSGEN_USER_DATA_DIR=${manifest.userDataDir} CROSSGEN_PERF_RESULT_PATH=${path.join(args.output, "electron-main-handler-metrics.json")} electron .`,
       rendererCapture: `VITE_DEV_SERVER_URL=http://127.0.0.1:<port> CROSSGEN_USER_DATA_DIR=${manifest.userDataDir} CROSSGEN_RENDERER_PERF_RESULT_PATH=${path.join(args.output, "electron-renderer-metrics.json")} electron .`
     },
@@ -585,7 +599,7 @@ async function main() {
       stateFile: {
         path: manifest.statePath,
         bytes: stateStat.size,
-        commonMutationWriteScenarios: commonMutationWriteScenarios(state, reconciledState)
+        commonMutationWriteScenarios: commonMutationWriteScenarios(state, reconciledState, galleryCollectionsChanged)
       },
       thumbnails: thumbnailBaselineEstimate(reconciledState),
       renderer: {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -70,9 +70,10 @@ import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./se
 import { buildProviderConfigForSave, providerDisplayName } from "./services/providerConfigSave.js";
 import { assertManagedRegularFile, assertManagedRegularFileInRoots, collectOwnedJobFilePaths, normalizeManagedAssetPath, resolveManagedFileName } from "./services/assetOwnership.js";
 import {
+  diskGalleryFoldersFromState,
   isIgnoredGalleryEntryName,
-  reconcileGalleryDiskChanges,
-  reconcileGalleryDiskState,
+  reconcileGalleryDiskChangesWithResult,
+  reconcileGalleryDiskStateWithResult,
   scanGalleryDisk,
   startGalleryDiskWatchers,
   type GalleryWatchHandle
@@ -935,7 +936,7 @@ function sendGalleryEvent(state: AppStateFile, reason: "disk" | "mutation"): voi
 }
 
 async function handleGetSnapshot(): Promise<AppSnapshot> {
-  const state = await syncGalleryWithDisk(await readState());
+  const state = await syncGalleryForRead(await readState());
   return snapshotFromState(state);
 }
 
@@ -1435,26 +1436,61 @@ async function syncGalleryWithDisk(inputState: AppStateFile, changedRelPaths?: s
     createFolderId: () => `gallery_folder_${randomUUID()}`,
     createAssetId: () => `gallery_${randomUUID()}`
   };
-  const state = hasIncrementalChanges
-    ? reconcileGalleryDiskChanges(baseState, disk, changedRelPaths ?? [], reconcileOptions)
-    : reconcileGalleryDiskState(baseState, disk, reconcileOptions);
-  if (
-    JSON.stringify(baseState.galleryFolders) !== JSON.stringify(state.galleryFolders) ||
-    JSON.stringify(baseState.galleryAssets) !== JSON.stringify(state.galleryAssets)
-  ) {
-    await writeState(state, { updateBackup: false });
+  const result = hasIncrementalChanges
+    ? reconcileGalleryDiskChangesWithResult(baseState, disk, changedRelPaths ?? [], reconcileOptions)
+    : reconcileGalleryDiskStateWithResult(baseState, disk, reconcileOptions);
+  if (result.changed) {
+    await writeState(result.state, { updateBackup: false });
+    return result.state;
   }
 
-  return state;
+  return baseState;
+}
+
+function isGalleryWatchCurrentForState(state: AppStateFile): boolean {
+  return Boolean(
+    galleryWatchRoot &&
+    galleryWatchers.length > 0 &&
+    sameResolvedPath(galleryWatchRoot, getGalleryDir(state))
+  );
+}
+
+function takePendingGalleryWatchSync(): { changedRelPaths?: string[] } | null {
+  if (!galleryWatchNeedsFullSync && galleryWatchChangedRelPaths.size === 0) return null;
+  if (galleryWatchDebounce) {
+    clearTimeout(galleryWatchDebounce);
+    galleryWatchDebounce = null;
+  }
+  const needsFullSync = galleryWatchNeedsFullSync;
+  const changedRelPaths = needsFullSync ? undefined : [...galleryWatchChangedRelPaths];
+  galleryWatchNeedsFullSync = false;
+  galleryWatchChangedRelPaths = new Set();
+  return { changedRelPaths };
+}
+
+async function syncGalleryForRead(inputState: AppStateFile): Promise<AppStateFile> {
+  if (!isGalleryWatchCurrentForState(inputState)) {
+    return syncGalleryWithDisk(inputState);
+  }
+
+  const pendingSync = takePendingGalleryWatchSync();
+  if (!pendingSync) {
+    return stateCache ?? inputState;
+  }
+
+  const synced = await syncGalleryWithDisk(inputState, pendingSync.changedRelPaths);
+  await startGalleryWatcherForState(synced);
+  sendGalleryEvent(synced, "disk");
+  return synced;
 }
 
 async function handleListGallery(): Promise<GalleryAsset[]> {
-  const state = await syncGalleryWithDisk(await readState());
+  const state = await syncGalleryForRead(await readState());
   return state.galleryAssets;
 }
 
 async function handleListGalleryFolders(): Promise<GalleryFolder[]> {
-  const state = await syncGalleryWithDisk(await readState());
+  const state = await syncGalleryForRead(await readState());
   return state.galleryFolders;
 }
 
@@ -2381,10 +2417,9 @@ function stopGalleryWatcher(): void {
 async function startGalleryWatcherForState(state: AppStateFile): Promise<void> {
   const galleryDir = getGalleryDir(state);
   await ensureDir(galleryDir);
-  const disk = await scanGalleryDisk(galleryDir);
   stopGalleryWatcher();
   galleryWatchRoot = galleryDir;
-  galleryWatchers = startGalleryDiskWatchers(galleryDir, disk.folders, scheduleGalleryDiskSync, {
+  galleryWatchers = startGalleryDiskWatchers(galleryDir, diskGalleryFoldersFromState(state), scheduleGalleryDiskSync, {
     onWatchError: (error) => console.warn("[CrossGen] Failed to watch Gallery directory.", sanitizeError(error))
   });
 }
@@ -2441,6 +2476,9 @@ function summarizePerformanceResult(value: unknown): Record<string, unknown> {
 }
 
 async function runMainPerformanceCapture(resultPath: string): Promise<void> {
+  const initialState = await syncGalleryWithDisk(await readState());
+  await startGalleryWatcherForState(initialState);
+
   const measurements: Array<Record<string, unknown>> = [];
   const measure = async (channel: string, operation: () => Promise<unknown>) => {
     const writeCountBefore = stateWriteCount;

--- a/src/main/services/galleryDiskSync.test.ts
+++ b/src/main/services/galleryDiskSync.test.ts
@@ -5,9 +5,13 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { GalleryAsset, GalleryFolder } from "../../shared/types";
 import { getDefaultState, type AppStateFile } from "./stateMigration";
 import {
+  diskGalleryFoldersFromState,
+  galleryCollectionsChanged,
   isIgnoredGalleryEntryName,
   reconcileGalleryDiskChanges,
+  reconcileGalleryDiskChangesWithResult,
   reconcileGalleryDiskState,
+  reconcileGalleryDiskStateWithResult,
   scanGalleryDisk,
   startGalleryDiskWatchers,
   type DiskGalleryAsset,
@@ -75,6 +79,16 @@ function reconcile(input: AppStateFile, folders: DiskGalleryFolder[], assets: Di
     createFolderId: () => `new-folder-${folderId += 1}`,
     createAssetId: () => `new-asset-${assetId += 1}`
   });
+}
+
+function reconcileOptions() {
+  let folderId = 0;
+  let assetId = 0;
+  return {
+    now: later,
+    createFolderId: () => `new-folder-${folderId += 1}`,
+    createAssetId: () => `new-asset-${assetId += 1}`
+  };
 }
 
 async function waitFor(condition: () => boolean, timeoutMs = 2500): Promise<void> {
@@ -191,6 +205,17 @@ describe("gallery disk sync reconciliation", () => {
     expect(changed).toEqual(["root.png", "Products/Hero/shot.png", null]);
   });
 
+  it("builds watcher folder entries from nested state folders", () => {
+    const products = folder("Products", { id: "folder-products" });
+    const hero = folder("Hero", { id: "folder-hero", parentId: products.id });
+    const missingParent = folder("Orphan", { id: "folder-orphan", parentId: "missing-parent" });
+
+    expect(diskGalleryFoldersFromState(state({ galleryFolders: [hero, missingParent, products] }))).toEqual([
+      { relPath: "Products", parentRelPath: null, name: "Products" },
+      { relPath: "Products/Hero", parentRelPath: "Products", name: "Hero" }
+    ]);
+  });
+
   it("receives real fs.watch events for non-ignored Gallery changes", async () => {
     const galleryDir = await makeTempDir();
     let syncCount = 0;
@@ -252,6 +277,36 @@ describe("gallery disk sync reconciliation", () => {
         modifiedAt: later
       })
     ]);
+  });
+
+  it("does not mark full reconciliation dirty when Gallery collections are unchanged", () => {
+    const products = folder("Products", { id: "folder-products" });
+    const existing = asset("Products/hero.png", {
+      id: "asset-hero",
+      folderId: products.id,
+      sizeBytes: 2048,
+      modifiedAt: later
+    });
+    const input = state({ galleryFolders: [products], galleryAssets: [existing] });
+
+    const result = reconcileGalleryDiskStateWithResult(
+      input,
+      {
+        folders: [{ relPath: "Products", parentRelPath: null, name: "Products" }],
+        assets: [{
+          relPath: "Products/hero.png",
+          folderRelPath: "Products",
+          originalName: "hero.png",
+          mimeType: "image/png",
+          sizeBytes: 2048,
+          modifiedAt: later
+        }]
+      },
+      reconcileOptions()
+    );
+
+    expect(galleryCollectionsChanged(input, result.state)).toBe(false);
+    expect(result.changed).toBe(false);
   });
 
   it("adds new disk files and drops state entries that no longer exist on disk", () => {
@@ -317,6 +372,66 @@ describe("gallery disk sync reconciliation", () => {
       existing,
       expect.objectContaining({ id: "asset-new", fileName: "Products/new.png", folderId: products.id })
     ]);
+  });
+
+  it("does not mark incremental reconciliation dirty when the changed file metadata is unchanged", () => {
+    const products = folder("Products", { id: "folder-products" });
+    const existing = asset("Products/hero.png", {
+      id: "asset-hero",
+      folderId: products.id,
+      sizeBytes: 2048,
+      modifiedAt: later
+    });
+    const input = state({ galleryFolders: [products], galleryAssets: [existing] });
+
+    const result = reconcileGalleryDiskChangesWithResult(
+      input,
+      {
+        folders: [],
+        assets: [{
+          relPath: "Products/hero.png",
+          folderRelPath: "Products",
+          originalName: "hero.png",
+          mimeType: "image/png",
+          sizeBytes: 2048,
+          modifiedAt: later
+        }]
+      },
+      ["Products/hero.png"],
+      reconcileOptions()
+    );
+
+    expect(result.changed).toBe(false);
+  });
+
+  it("marks incremental reconciliation dirty when changed file metadata differs", () => {
+    const products = folder("Products", { id: "folder-products" });
+    const existing = asset("Products/hero.png", {
+      id: "asset-hero",
+      folderId: products.id,
+      sizeBytes: 2048,
+      modifiedAt: later
+    });
+    const input = state({ galleryFolders: [products], galleryAssets: [existing] });
+
+    const result = reconcileGalleryDiskChangesWithResult(
+      input,
+      {
+        folders: [],
+        assets: [{
+          relPath: "Products/hero.png",
+          folderRelPath: "Products",
+          originalName: "hero.png",
+          mimeType: "image/png",
+          sizeBytes: 4096,
+          modifiedAt: "2026-07-06T02:00:00.000Z"
+        }]
+      },
+      ["Products/hero.png"],
+      reconcileOptions()
+    );
+
+    expect(result.changed).toBe(true);
   });
 
   it("reflects an incremental disk file rename as old removal and new file addition", () => {

--- a/src/main/services/galleryDiskSync.ts
+++ b/src/main/services/galleryDiskSync.ts
@@ -30,6 +30,11 @@ export interface GalleryDiskReconcileOptions {
   createAssetId: () => string;
 }
 
+export interface GalleryDiskReconcileResult {
+  state: AppStateFile;
+  changed: boolean;
+}
+
 export interface ScanGalleryDiskOptions {
   rootRelPaths?: string[];
 }
@@ -323,8 +328,90 @@ export function reconcileGalleryDiskState(
   };
 }
 
+export function diskGalleryFoldersFromState(state: AppStateFile): DiskGalleryFolder[] {
+  const byId = new Map(state.galleryFolders.map((folder) => [folder.id, folder]));
+  const folders: DiskGalleryFolder[] = [];
+  for (const folder of state.galleryFolders) {
+    try {
+      const parent = folder.parentId ? byId.get(folder.parentId) : undefined;
+      if (folder.parentId && !parent) continue;
+      folders.push({
+        relPath: galleryFolderRelativePath(state, folder),
+        parentRelPath: parent ? galleryFolderRelativePath(state, parent) : null,
+        name: folder.name
+      });
+    } catch {
+      // Ignore malformed legacy folder hierarchies; disk reconciliation will rebuild them on full recovery.
+    }
+  }
+  return folders.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
 function isPathWithin(rootRelPath: string, candidateRelPath: string): boolean {
   return candidateRelPath === rootRelPath || candidateRelPath.startsWith(`${rootRelPath}/`);
+}
+
+function stringArraysEqual(a: readonly string[] | undefined, b: readonly string[] | undefined): boolean {
+  if (!a?.length && !b?.length) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((item, index) => item === b[index]);
+}
+
+function galleryFoldersEqual(a: GalleryFolder, b: GalleryFolder): boolean {
+  return (
+    a.id === b.id &&
+    a.name === b.name &&
+    (a.parentId ?? null) === (b.parentId ?? null) &&
+    a.color === b.color &&
+    a.createdAt === b.createdAt &&
+    a.updatedAt === b.updatedAt
+  );
+}
+
+function galleryAssetsEqual(a: GalleryAsset, b: GalleryAsset): boolean {
+  return (
+    a.id === b.id &&
+    a.fileName === b.fileName &&
+    a.originalName === b.originalName &&
+    a.mimeType === b.mimeType &&
+    a.sizeBytes === b.sizeBytes &&
+    a.width === b.width &&
+    a.height === b.height &&
+    (a.folderId ?? null) === (b.folderId ?? null) &&
+    stringArraysEqual(a.tags, b.tags) &&
+    a.source === b.source &&
+    a.createdAt === b.createdAt &&
+    a.updatedAt === b.updatedAt &&
+    a.contentHash === b.contentHash &&
+    a.sourcePathHash === b.sourcePathHash &&
+    a.sourceJobId === b.sourceJobId &&
+    a.sourceAssetId === b.sourceAssetId &&
+    a.modifiedAt === b.modifiedAt
+  );
+}
+
+export function galleryCollectionsChanged(before: AppStateFile, after: AppStateFile): boolean {
+  if (before.galleryFolders.length !== after.galleryFolders.length) return true;
+  if (before.galleryAssets.length !== after.galleryAssets.length) return true;
+  for (let index = 0; index < before.galleryFolders.length; index += 1) {
+    if (!galleryFoldersEqual(before.galleryFolders[index], after.galleryFolders[index])) return true;
+  }
+  for (let index = 0; index < before.galleryAssets.length; index += 1) {
+    if (!galleryAssetsEqual(before.galleryAssets[index], after.galleryAssets[index])) return true;
+  }
+  return false;
+}
+
+export function reconcileGalleryDiskStateWithResult(
+  inputState: AppStateFile,
+  disk: { folders: DiskGalleryFolder[]; assets: DiskGalleryAsset[] },
+  options: GalleryDiskReconcileOptions
+): GalleryDiskReconcileResult {
+  const state = reconcileGalleryDiskState(inputState, disk, options);
+  return {
+    state,
+    changed: galleryCollectionsChanged(inputState, state)
+  };
 }
 
 export function reconcileGalleryDiskChanges(
@@ -463,5 +550,18 @@ export function reconcileGalleryDiskChanges(
     ...inputState,
     galleryFolders: folders,
     galleryAssets
+  };
+}
+
+export function reconcileGalleryDiskChangesWithResult(
+  inputState: AppStateFile,
+  disk: { folders: DiskGalleryFolder[]; assets: DiskGalleryAsset[] },
+  changedRelPaths: string[],
+  options: GalleryDiskReconcileOptions
+): GalleryDiskReconcileResult {
+  const state = reconcileGalleryDiskChanges(inputState, disk, changedRelPaths, options);
+  return {
+    state,
+    changed: galleryCollectionsChanged(inputState, state)
   };
 }


### PR DESCRIPTION
## Summary\n- avoid full Gallery disk scans for read-only IPC when the Gallery watcher is current and no disk changes are pending\n- consume pending watcher changes before read responses and keep full-scan recovery for unknown/null watcher events\n- replace full Gallery JSON.stringify dirty checks with field-level collection comparison\n- restart Gallery watchers from reconciled state folder paths instead of scanning only to discover watched folders\n- update the performance harness and record Phase 2 backend metrics\n\n## Validation\n- pnpm vitest run src/main/services/galleryDiskSync.test.ts\n- pnpm typecheck\n- pnpm build\n- node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force\n- node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase2-gallery-large --iterations 3 --no-renderer\n\n## Metrics\nFixture: gallery-large, 96 folders, 2400 assets, Apple M4 / Darwin 25.5.0. Renderer capture skipped because Phase 2 targets backend read/sync paths.\n\nBefore values are Phase 0 baseline from docs/perf/gallery-baseline.md. After values are from docs/perf/gallery-phase2.md / local result output/perf-baselines/phase2-gallery-large/gallery-large-0d4e11918e04.json.\n\n| Path | Before median | After median | State writes |\n| --- | ---: | ---: | ---: |\n| app:getSnapshot handler-equivalent | 44.700 ms | 1.590 ms | 0 |\n| gallery:list handler-equivalent | 40.130 ms | 0.001 ms | 0 |\n| galleryFolders:list handler-equivalent | 39.094 ms | 0.001 ms | 0 |\n| Electron main app:getSnapshot | 88.510 ms | 0.093 ms | 0 |\n| Electron main gallery:list | 62.592 ms | 0.008 ms | 0 |\n| Electron main galleryFolders:list | 60.172 ms | 0.006 ms | 0 |\n\nFull recovery remains explicit: app:getSnapshot full-scan recovery-equivalent median 39.219 ms; full sync with no Gallery changes remains 0 writes.