### PR TITLE
perf: serve gallery thumbnails from cache

### DIFF
--- a/docs/perf/gallery-phase3.md
+++ b/docs/perf/gallery-phase3.md
@@ -1,0 +1,69 @@
+# Gallery Phase 3 Thumbnail Results
+
+Captured: 2026-07-08
+
+Phase 3 adds a managed Gallery thumbnail protocol path. Gallery cards request cached thumbnails, while original preview/download behavior continues to use the original asset path and `no-store` responses.
+
+## Commands
+
+```bash
+node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force
+node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase3-gallery-large --iterations 3
+```
+
+Raw local result:
+
+```text
+output/perf-baselines/phase3-gallery-large/gallery-large-da09f407a30f.json
+```
+
+`output/` is ignored by git; rerun the commands above for fresh machine-local metrics.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Commit | `da09f407a30f39e81417855c13d0b485af02b003` |
+| OS | Darwin `25.5.0` |
+| Architecture | `arm64` |
+| CPU | Apple M4, 10 cores |
+| Memory | 17179869184 bytes |
+| Fixture | `gallery-large` |
+| Fixture assets | 2400 |
+| Fixture folders | 96 |
+| Fixture state size | 1510172 bytes |
+
+## Thumbnail Bytes
+
+Phase 0 baseline values come from `docs/perf/gallery-baseline.md`. Phase 3 records the renderer asset protocol counters after opening Gallery from a cold regenerated fixture.
+
+| Metric | Phase 0 | Phase 3 |
+| --- | ---: | ---: |
+| Gallery card URL mode | Original asset URLs | Thumbnail asset URLs |
+| DOM Gallery images using thumbnail URLs | 0 | 2400 |
+| Protocol original Gallery requests during capture | 40 sampled | 0 |
+| Protocol thumbnail requests during capture | 0 | 3 |
+| Bytes served for comparable visible sample | 13201 | 1522 |
+| Byte reduction | 0% | 88.5% |
+| Thumbnail cache hits / misses | n/a | 0 / 3 |
+| Thumbnail fallbacks | n/a | 1 |
+
+The single fallback is the fixture's tiny WebP sample, which Electron `nativeImage` does not decode in this environment. It still travels through the thumbnail protocol URL and does not request the original Gallery protocol path; unsupported decode falls back to the source file with `no-store`.
+
+## Render And Accessibility
+
+| Metric | Phase 0 | Phase 3 |
+| --- | ---: | ---: |
+| Time to first Gallery grid render | 1066.100 ms | 1050.300 ms |
+| Gallery grid entries | 2404 | 2404 |
+| Renderer accessibility smoke | Baseline issues documented separately | ok |
+| axe violations | Existing baseline issues | 3 existing violations |
+
+The first-grid render improvement is small because the renderer still mounts a large Gallery DOM in the capture. The main Phase 3 gain is reduced card image bytes and separating card thumbnails from original preview/download delivery. Broader render reductions remain part of the later App decomposition work.
+
+## Behavior Notes
+
+- Card thumbnails use `image2tools-asset://image?gallery=...&thumb=1&v=...`.
+- Original Gallery preview, edit, download, and history asset requests continue to use original URLs.
+- Thumbnail cache keys include Gallery relative path, source file size, source modified time, and target thumbnail width.
+- Cached thumbnails are stored under the Electron userData directory and can be regenerated from source assets.

--- a/scripts/measure-gallery-performance.mjs
+++ b/scripts/measure-gallery-performance.mjs
@@ -312,14 +312,24 @@ function commonMutationWriteScenarios(state, reconciledState, galleryCollections
   return scenarios;
 }
 
-function thumbnailBaselineEstimate(state, sampleSize = 40) {
+function thumbnailBaselineEstimate(state, electronRenderer, sampleSize = 40) {
   const sampledAssets = state.galleryAssets.slice(0, sampleSize);
+  const originalBytesForVisibleSample = sampledAssets.reduce((sum, asset) => sum + asset.sizeBytes, 0);
+  const assetProtocol = electronRenderer.status === "ok" ? electronRenderer.metrics?.result?.assetProtocol : null;
+  const thumbnailBytes = typeof assetProtocol?.galleryThumbnailBytes === "number" ? assetProtocol.galleryThumbnailBytes : null;
+  const thumbnailRequests = typeof assetProtocol?.galleryThumbnailRequests === "number" ? assetProtocol.galleryThumbnailRequests : null;
   return {
-    currentBehavior: "Gallery card images request full original asset URLs; Phase 3 should replace these with thumbnails.",
+    currentBehavior: "Gallery card images request managed thumbnail asset URLs.",
     sampledCardCount: sampledAssets.length,
-    requestCount: sampledAssets.length,
-    totalBytesServed: sampledAssets.reduce((sum, asset) => sum + asset.sizeBytes, 0),
-    averageBytesPerRequest: sampledAssets.length === 0 ? 0 : sampledAssets.reduce((sum, asset) => sum + asset.sizeBytes, 0) / sampledAssets.length
+    originalRequestCountBeforePhase3: sampledAssets.length,
+    originalBytesForVisibleSample,
+    thumbnailRequestCount: thumbnailRequests,
+    thumbnailBytesServed: thumbnailBytes,
+    thumbnailCacheHits: typeof assetProtocol?.galleryThumbnailCacheHits === "number" ? assetProtocol.galleryThumbnailCacheHits : null,
+    thumbnailCacheMisses: typeof assetProtocol?.galleryThumbnailCacheMisses === "number" ? assetProtocol.galleryThumbnailCacheMisses : null,
+    thumbnailFallbacks: typeof assetProtocol?.galleryThumbnailFallbacks === "number" ? assetProtocol.galleryThumbnailFallbacks : null,
+    bytesSavedForVisibleSample: thumbnailBytes === null ? null : originalBytesForVisibleSample - thumbnailBytes,
+    byteReductionRatio: thumbnailBytes === null || originalBytesForVisibleSample === 0 ? null : 1 - (thumbnailBytes / originalBytesForVisibleSample)
   };
 }
 
@@ -601,7 +611,7 @@ async function main() {
         bytes: stateStat.size,
         commonMutationWriteScenarios: commonMutationWriteScenarios(state, reconciledState, galleryCollectionsChanged)
       },
-      thumbnails: thumbnailBaselineEstimate(reconciledState),
+      thumbnails: thumbnailBaselineEstimate(reconciledState, electronRenderer),
       renderer: {
         electronRenderer,
         timeToFirstGalleryGridRender: electronRenderer.status === "ok"

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,6 +3,7 @@ import {
   BrowserWindow,
   dialog,
   ipcMain,
+  nativeImage,
   protocol,
   safeStorage,
   shell,
@@ -78,6 +79,7 @@ import {
   startGalleryDiskWatchers,
   type GalleryWatchHandle
 } from "./services/galleryDiskSync.js";
+import { DEFAULT_GALLERY_THUMBNAIL_SIZE, galleryThumbnailCachePath } from "./services/galleryThumbnailCache.js";
 import { recoverInterruptedJobs } from "./services/stateRecovery.js";
 import { type AppStateFile, type StoredProviderConfig, STATE_VERSION, getDefaultState, normalizeImageParams, normalizeState } from "./services/stateMigration.js";
 import { verifyUpdateAssetBytes } from "./services/updateInstallerVerification.js";
@@ -162,6 +164,36 @@ let galleryWatchNeedsFullSync = false;
 let galleryWatchChangedRelPaths = new Set<string>();
 let stateWriteCount = 0;
 
+interface AssetProtocolPerfMetrics {
+  galleryOriginalRequests: number;
+  galleryOriginalBytes: number;
+  galleryThumbnailRequests: number;
+  galleryThumbnailBytes: number;
+  galleryThumbnailCacheHits: number;
+  galleryThumbnailCacheMisses: number;
+  galleryThumbnailFallbacks: number;
+  historyRequests: number;
+  historyBytes: number;
+  totalBytes: number;
+}
+
+function createAssetProtocolPerfMetrics(): AssetProtocolPerfMetrics {
+  return {
+    galleryOriginalRequests: 0,
+    galleryOriginalBytes: 0,
+    galleryThumbnailRequests: 0,
+    galleryThumbnailBytes: 0,
+    galleryThumbnailCacheHits: 0,
+    galleryThumbnailCacheMisses: 0,
+    galleryThumbnailFallbacks: 0,
+    historyRequests: 0,
+    historyBytes: 0,
+    totalBytes: 0
+  };
+}
+
+let assetProtocolPerfMetrics = createAssetProtocolPerfMetrics();
+
 interface WriteStateOptions {
   updateBackup?: boolean;
 }
@@ -229,14 +261,19 @@ function registerAssetProtocol(): void {
     const url = new URL(request.url);
     const assetPath = url.searchParams.get("path") ?? "";
     const galleryFileName = url.searchParams.get("gallery");
+    const galleryThumbnail = galleryFileName ? url.searchParams.get("thumb") === "1" : false;
     let normalized: string | null = null;
+    let galleryRelPath = "";
 
     try {
       const state = await readState();
       const galleryDir = getGalleryDir(state);
-      normalized = galleryFileName
-        ? resolveManagedFileName(galleryDir, galleryFileName)
-        : assertKnownHistoryAssetPath(state, assetPath);
+      if (galleryFileName) {
+        galleryRelPath = normalizeGalleryRelativePath(galleryFileName);
+        normalized = resolveManagedFileName(galleryDir, galleryRelPath);
+      } else {
+        normalized = assertKnownHistoryAssetPath(state, assetPath);
+      }
     } catch {
       return new Response("Forbidden", { status: 403 });
     }
@@ -251,13 +288,20 @@ function registerAssetProtocol(): void {
       const safePath = galleryFileName
         ? await assertManagedRegularFile(galleryDir, normalized)
         : await assertKnownHistoryRegularAsset(state, normalized);
-      const content = await fs.readFile(safePath);
-      const mimeType = mimeTypeForFile(safePath);
-      return new Response(new Blob([content], { type: mimeType }), {
+      const served = galleryThumbnail && galleryRelPath
+        ? await getOrCreateGalleryThumbnail(galleryRelPath, safePath)
+        : { filePath: safePath, mimeType: mimeTypeForFile(safePath), cacheable: false, cacheHit: false, fallback: false };
+      const content = await fs.readFile(served.filePath);
+      recordAssetProtocolResponse(
+        galleryFileName ? (galleryThumbnail ? "gallery-thumbnail" : "gallery-original") : "history",
+        content.byteLength,
+        served
+      );
+      return new Response(new Blob([content], { type: served.mimeType }), {
         headers: {
           "access-control-allow-origin": "*",
-          "cache-control": "no-store",
-          "content-type": mimeType
+          "cache-control": served.cacheable ? "private, max-age=31536000, immutable" : "no-store",
+          "content-type": served.mimeType
         }
       });
     } catch (error) {
@@ -296,6 +340,10 @@ function getImagesDir(state?: AppStateFile | null): string {
 
 function getGalleryDir(state?: AppStateFile | null): string {
   return getStorageSettings(state ?? stateCache).galleryDir;
+}
+
+function getGalleryThumbnailCacheDir(): string {
+  return path.join(app.getPath("userData"), "gallery-thumbnails");
 }
 
 function getHistoryImageRoots(state?: AppStateFile | null): string[] {
@@ -573,8 +621,63 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+async function getOrCreateGalleryThumbnail(relPath: string, sourcePath: string): Promise<{ filePath: string; mimeType: string; cacheable: boolean; cacheHit: boolean; fallback: boolean }> {
+  const stat = await fs.stat(sourcePath);
+  const cacheDir = getGalleryThumbnailCacheDir();
+  const cachePath = galleryThumbnailCachePath(cacheDir, {
+    relPath,
+    sizeBytes: stat.size,
+    modifiedMs: stat.mtimeMs,
+    width: DEFAULT_GALLERY_THUMBNAIL_SIZE
+  });
+
+  if (await pathExists(cachePath)) {
+    return { filePath: cachePath, mimeType: "image/png", cacheable: true, cacheHit: true, fallback: false };
+  }
+
+  const source = await fs.readFile(sourcePath);
+  const image = nativeImage.createFromBuffer(source);
+  if (image.isEmpty()) {
+    return { filePath: sourcePath, mimeType: mimeTypeForFile(sourcePath), cacheable: false, cacheHit: false, fallback: true };
+  }
+
+  const resized = image.resize({ width: DEFAULT_GALLERY_THUMBNAIL_SIZE, quality: "best" });
+  const png = resized.toPNG();
+  if (png.length === 0) {
+    return { filePath: sourcePath, mimeType: mimeTypeForFile(sourcePath), cacheable: false, cacheHit: false, fallback: true };
+  }
+
+  await ensureDir(cacheDir);
+  const tmpPath = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, png);
+  await fs.rename(tmpPath, cachePath).catch(async (error) => {
+    await fs.unlink(tmpPath).catch(() => undefined);
+    if (!isNodeError(error) || error.code !== "EEXIST") throw error;
+  });
+  return { filePath: cachePath, mimeType: "image/png", cacheable: true, cacheHit: false, fallback: false };
+}
+
 function sameResolvedPath(a: string, b: string): boolean {
   return path.resolve(a) === path.resolve(b);
+}
+
+function recordAssetProtocolResponse(kind: "gallery-original" | "gallery-thumbnail" | "history", bytes: number, served?: { cacheHit?: boolean; fallback?: boolean }): void {
+  assetProtocolPerfMetrics.totalBytes += bytes;
+  if (kind === "gallery-thumbnail") {
+    assetProtocolPerfMetrics.galleryThumbnailRequests += 1;
+    assetProtocolPerfMetrics.galleryThumbnailBytes += bytes;
+    if (served?.cacheHit) assetProtocolPerfMetrics.galleryThumbnailCacheHits += 1;
+    else assetProtocolPerfMetrics.galleryThumbnailCacheMisses += 1;
+    if (served?.fallback) assetProtocolPerfMetrics.galleryThumbnailFallbacks += 1;
+    return;
+  }
+  if (kind === "gallery-original") {
+    assetProtocolPerfMetrics.galleryOriginalRequests += 1;
+    assetProtocolPerfMetrics.galleryOriginalBytes += bytes;
+    return;
+  }
+  assetProtocolPerfMetrics.historyRequests += 1;
+  assetProtocolPerfMetrics.historyBytes += bytes;
 }
 
 async function fileContentHash(filePath: string): Promise<string> {
@@ -2527,6 +2630,7 @@ function sleep(ms: number): Promise<void> {
 
 async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: string): Promise<void> {
   await waitForWindowLoad(window);
+  assetProtocolPerfMetrics = createAssetProtocolPerfMetrics();
   const state = await readState();
   const expectedGalleryAssetCount = state.galleryAssets.length;
   const sampleGalleryAsset = state.galleryAssets[0];
@@ -2591,6 +2695,9 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
       const grid = await waitForGalleryGridReady();
       await new Promise((resolve) => requestAnimationFrame(() => resolve()));
       const gridReadyAt = performance.now();
+      const galleryImages = [...grid.querySelectorAll(".gallery-thumb img")];
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      const thumbnailWaitDoneAt = performance.now();
       const buttonsWithoutNames = [...document.querySelectorAll("button")].filter((button) => !accessibleName(button)).map((button) => button.className || button.outerHTML.slice(0, 120));
       const imagesMissingAlt = [...document.querySelectorAll("img:not([alt])")].map((image) => image.className || image.getAttribute("src") || image.outerHTML.slice(0, 120));
       const dialogsWithoutModal = [...document.querySelectorAll('[role="dialog"]')].filter((dialog) => dialog.getAttribute("aria-modal") !== "true").length;
@@ -2601,12 +2708,15 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
         title: document.title,
         timings: {
           pageToGalleryTabReadyMs: tabReadyAt - pageStartedAt,
-          timeToFirstGalleryGridRenderMs: gridReadyAt - galleryClickAt
+          timeToFirstGalleryGridRenderMs: gridReadyAt - galleryClickAt,
+          thumbnailWaitAfterGridReadyMs: thumbnailWaitDoneAt - gridReadyAt
         },
         galleryGrid: {
           totalCount: Number(grid.dataset.totalCount || "0"),
           renderedCount: Number(grid.dataset.renderedCount || "0"),
-          itemCount: grid.querySelectorAll(".gallery-item").length
+          itemCount: grid.querySelectorAll(".gallery-item").length,
+          imageCount: galleryImages.length,
+          thumbnailSrcCount: galleryImages.filter((image) => image.getAttribute("src")?.includes("thumb=1")).length
         },
         accessibilitySmoke: {
           status: buttonsWithoutNames.length === 0 && imagesMissingAlt.length === 0 && dialogsWithoutModal === 0 && !noticeMissingLiveRegion ? "ok" : "violations",
@@ -2651,6 +2761,7 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
     profilerEventCount: Array.isArray(profilerEvents) ? profilerEvents.length : 0,
     events: Array.isArray(profilerEvents) ? profilerEvents : []
   };
+  (rendererResult as Record<string, unknown>).assetProtocol = assetProtocolPerfMetrics;
   try {
     const axeSource = readFileSync(path.join(app.getAppPath(), "node_modules", "axe-core", "axe.min.js"), "utf8");
     await window.webContents.executeJavaScript(axeSource);

--- a/src/main/services/galleryThumbnailCache.test.ts
+++ b/src/main/services/galleryThumbnailCache.test.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_GALLERY_THUMBNAIL_SIZE,
+  galleryThumbnailCacheFileName,
+  galleryThumbnailCachePath
+} from "./galleryThumbnailCache";
+
+describe("gallery thumbnail cache keys", () => {
+  it("normalizes path separators for stable cache names", () => {
+    const posix = galleryThumbnailCacheFileName({
+      relPath: "Products/Hero/shot.png",
+      sizeBytes: 1024,
+      modifiedMs: 1234,
+      width: DEFAULT_GALLERY_THUMBNAIL_SIZE
+    });
+    const windows = galleryThumbnailCacheFileName({
+      relPath: "Products\\Hero\\shot.png",
+      sizeBytes: 1024,
+      modifiedMs: 1234,
+      width: DEFAULT_GALLERY_THUMBNAIL_SIZE
+    });
+
+    expect(windows).toBe(posix);
+    expect(posix).toMatch(/^[a-f0-9]{64}\.png$/);
+  });
+
+  it("invalidates cache names when source metadata or target size changes", () => {
+    const base = {
+      relPath: "Products/Hero/shot.png",
+      sizeBytes: 1024,
+      modifiedMs: 1234,
+      width: DEFAULT_GALLERY_THUMBNAIL_SIZE
+    };
+
+    expect(galleryThumbnailCacheFileName({ ...base, sizeBytes: 2048 })).not.toBe(galleryThumbnailCacheFileName(base));
+    expect(galleryThumbnailCacheFileName({ ...base, modifiedMs: 5678 })).not.toBe(galleryThumbnailCacheFileName(base));
+    expect(galleryThumbnailCacheFileName({ ...base, width: 512 })).not.toBe(galleryThumbnailCacheFileName(base));
+  });
+
+  it("returns cache paths inside the configured cache directory", () => {
+    const cacheDir = path.join("/tmp", "crossgen-thumbs");
+    const cachePath = galleryThumbnailCachePath(cacheDir, {
+      relPath: "Products/Hero/shot.png",
+      sizeBytes: 1024,
+      modifiedMs: 1234
+    });
+
+    expect(path.dirname(cachePath)).toBe(cacheDir);
+    expect(path.basename(cachePath)).toMatch(/^[a-f0-9]{64}\.png$/);
+  });
+});

--- a/src/main/services/galleryThumbnailCache.ts
+++ b/src/main/services/galleryThumbnailCache.ts
@@ -1,0 +1,31 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+export const DEFAULT_GALLERY_THUMBNAIL_SIZE = 256;
+
+export interface GalleryThumbnailCacheInput {
+  relPath: string;
+  sizeBytes: number;
+  modifiedMs: number;
+  width?: number;
+}
+
+function normalizeThumbnailRelPath(value: string): string {
+  return value.trim().replace(/\\/g, "/");
+}
+
+export function galleryThumbnailCacheFileName(input: GalleryThumbnailCacheInput): string {
+  const hash = createHash("sha256")
+    .update(JSON.stringify({
+      relPath: normalizeThumbnailRelPath(input.relPath),
+      sizeBytes: input.sizeBytes,
+      modifiedMs: Math.trunc(input.modifiedMs),
+      width: input.width ?? DEFAULT_GALLERY_THUMBNAIL_SIZE
+    }))
+    .digest("hex");
+  return `${hash}.png`;
+}
+
+export function galleryThumbnailCachePath(cacheDir: string, input: GalleryThumbnailCacheInput): string {
+  return path.join(cacheDir, galleryThumbnailCacheFileName(input));
+}

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -514,10 +514,12 @@ describe("renderer multi-model smoke", () => {
     const thumbnailImage = document.querySelector<HTMLImageElement>(".gallery-thumb img")!;
     expect(thumbnailImage.getAttribute("loading")).toBe("lazy");
     expect(thumbnailImage.getAttribute("decoding")).toBe("async");
+    expect(thumbnailImage.getAttribute("src")).toContain("&thumb=1&");
     await click(document.querySelector<HTMLButtonElement>(".gallery-thumb")!);
 
     expect(bridge.pickGalleryAsset).not.toHaveBeenCalled();
     expect(document.querySelector<HTMLImageElement>(".preview-image-frame img")?.src).toContain(`image2tools-asset://image?gallery=${asset.fileName}`);
+    expect(document.querySelector<HTMLImageElement>(".preview-image-frame img")?.src).not.toContain("thumb=1");
     expect(document.body.textContent).toContain("gallery-preview.png opened in the editor.");
     expect(document.querySelector(".notice-area")?.getAttribute("aria-live")).toBe("polite");
     expect(document.querySelector(".notice-area")?.getAttribute("aria-atomic")).toBe("true");

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2139,6 +2139,12 @@ export function App() {
     return `image2tools-asset://image?gallery=${encodeURIComponent(asset.fileName)}&v=${version}`;
   }
 
+  function galleryAssetThumbnailPath(asset: GalleryAsset): string {
+    if (asset.previewUrl) return asset.previewUrl;
+    const version = encodeURIComponent(asset.modifiedAt ?? asset.updatedAt ?? asset.createdAt);
+    return `image2tools-asset://image?gallery=${encodeURIComponent(asset.fileName)}&thumb=1&v=${version}`;
+  }
+
   async function importToGallery() {
     if (!bridge) return;
     try {
@@ -6392,7 +6398,7 @@ export function App() {
                     onContextMenu={(event) => openGalleryAssetContextMenu(event, entry.asset)}
                     title={copy.galleryOpenItem(entry.asset.originalName)}
                   >
-                    <img src={galleryAssetPath(entry.asset)} alt={entry.asset.originalName} draggable={false} loading="lazy" decoding="async" />
+                    <img src={galleryAssetThumbnailPath(entry.asset)} alt={entry.asset.originalName} draggable={false} loading="lazy" decoding="async" />
                   </button>
                   <div className="gallery-meta">
                     <strong title={entry.asset.originalName}>{entry.asset.originalName}</strong>


### PR DESCRIPTION
## Summary\n- add managed Gallery thumbnail URLs for Gallery cards while preserving original URLs for preview/edit/download paths\n- generate 256px PNG thumbnails in Electron main with cache keys based on relative path, file size, modified time, and target width\n- keep original asset responses on no-store; thumbnail responses use a private immutable cache header when generated successfully\n- add thumbnail cache key unit coverage and renderer smoke coverage for thumb=1 Gallery cards\n- extend the performance harness to record asset protocol thumbnail/original request counts and bytes\n\n## Validation\n- pnpm vitest run src/main/services/galleryThumbnailCache.test.ts src/renderer/App.smoke.test.tsx\n- pnpm typecheck\n- pnpm build\n- node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force\n- node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase3-gallery-large --iterations 3\n\n## Metrics\nFixture: gallery-large, 96 folders, 2400 assets, Apple M4 / Darwin 25.5.0. Raw local output: output/perf-baselines/phase3-gallery-large/gallery-large-da09f407a30f.json.\n\n| Metric | Phase 0 | Phase 3 |\n| --- | ---: | ---: |\n| Gallery card URL mode | original URLs | thumbnail URLs |\n| DOM Gallery images using thumb=1 | 0 | 2400 |\n| Gallery original protocol requests during renderer capture | 40 sampled | 0 |\n| Thumbnail protocol requests during renderer capture | 0 | 3 |\n| Bytes for comparable visible sample | 13201 | 1522 |\n| Byte reduction | 0% | 88.5% |\n| Time to first Gallery grid render | 1066.100 ms | 1050.300 ms |\n\nNote: the cold fixture run has 3 thumbnail cache misses and 1 fixture WebP fallback because Electron nativeImage does not decode that tiny fixture WebP in this environment. The request still uses the thumbnail URL and original Gallery protocol requests remain 0.