### PR TITLE
refactor: extract gallery tree rows

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -114,6 +114,7 @@ import {
   GalleryContentGrid,
   GalleryDirectoryTree,
   GallerySortToolbar,
+  GalleryTreeRows,
   type GalleryExplorerEntry,
   type GalleryFolderFilter,
   type GallerySortMode,
@@ -4961,70 +4962,6 @@ export function App() {
     );
   }
 
-  const renderGalleryTreeRows = (parentId: string | null, depth = 0): React.ReactNode[] => {
-    const folders = galleryFoldersByParent.get(parentId) ?? [];
-    return folders.flatMap((folder) => {
-      const hasChildren = (galleryFoldersByParent.get(folder.id) ?? []).length > 0;
-      const isExpanded = expandedGalleryFolderIds.has(folder.id);
-      const entry: GalleryExplorerEntry = { kind: "folder", id: folder.id, folder };
-      const row = (
-        <div
-          key={folder.id}
-          className={`gallery-tree-row ${activeGalleryFolderId === folder.id ? "active" : ""} ${galleryFolderDragTarget === folder.id ? "drop-target" : ""}`}
-          style={{ "--depth": depth } as React.CSSProperties}
-          draggable
-          onDragStart={(event) => prepareGalleryEntryDrag(event, entry)}
-          onContextMenu={(event) => openGalleryFolderContextMenu(event, folder.id)}
-          {...galleryFolderDropHandlers(folder.id)}
-        >
-          <button
-            type="button"
-            className="gallery-tree-expander"
-            onClick={(event) => {
-              event.stopPropagation();
-              if (hasChildren) toggleGalleryFolderExpanded(folder.id);
-            }}
-            disabled={!hasChildren}
-            aria-label={isExpanded ? copy.hide : copy.show}
-            data-tooltip={isExpanded ? copy.hide : copy.show}
-          >
-            {hasChildren ? (isExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />) : <span />}
-          </button>
-          {isGalleryBatchMode && (
-            <input
-              type="checkbox"
-              checked={selectedGalleryFolderIds.has(folder.id)}
-              onClick={(event) => {
-                event.stopPropagation();
-                const checked = event.currentTarget.checked;
-                setSelectedGalleryFolderIds((current) => {
-                  const next = new Set(current);
-                  if (checked) next.add(folder.id);
-                  else next.delete(folder.id);
-                  return next;
-                });
-              }}
-              onChange={() => undefined}
-              aria-label={copy.gallerySelectItem(folder.name)}
-            />
-          )}
-          <button
-            type="button"
-            className="gallery-tree-folder-button"
-            onClick={() => navigateGalleryFolder(folder.id)}
-            onDoubleClick={() => navigateGalleryFolder(folder.id)}
-            title={galleryFolderDisplayPath(folder)}
-          >
-            <Folder size={14} />
-            <span>{folder.name}</span>
-            <small>{galleryFolderSubtreeAssetCounts.get(folder.id) ?? 0}</small>
-          </button>
-        </div>
-      );
-      return isExpanded ? [row, ...renderGalleryTreeRows(folder.id, depth + 1)] : [row];
-    });
-  };
-
   return (
     <main
       className={[
@@ -6008,7 +5945,31 @@ export function App() {
                 onNavigate={navigateGalleryFolder}
                 onContextMenu={openGalleryFolderContextMenu}
               >
-                {renderGalleryTreeRows(null)}
+                <GalleryTreeRows
+                  copy={copy}
+                  parentId={null}
+                  foldersByParent={galleryFoldersByParent}
+                  activeFolderId={activeGalleryFolderId}
+                  batchMode={isGalleryBatchMode}
+                  expandedFolderIds={expandedGalleryFolderIds}
+                  selectedFolderIds={selectedGalleryFolderIds}
+                  dragTargetId={galleryFolderDragTarget}
+                  subtreeAssetCounts={galleryFolderSubtreeAssetCounts}
+                  dropHandlersForFolder={galleryFolderDropHandlers}
+                  folderDisplayPath={galleryFolderDisplayPath}
+                  onPrepareEntryDrag={prepareGalleryEntryDrag}
+                  onFolderContextMenu={openGalleryFolderContextMenu}
+                  onToggleExpanded={toggleGalleryFolderExpanded}
+                  onToggleSelectedFolder={(folderId, checked) => {
+                    setSelectedGalleryFolderIds((current) => {
+                      const next = new Set(current);
+                      if (checked) next.add(folderId);
+                      else next.delete(folderId);
+                      return next;
+                    });
+                  }}
+                  onNavigateFolder={navigateGalleryFolder}
+                />
               </GalleryDirectoryTree>
               <GalleryContentGrid
                 copy={copy}

--- a/src/renderer/GalleryPanel.tsx
+++ b/src/renderer/GalleryPanel.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { ArrowDownUp, ChevronDown, FileUp, Folder, FolderOpen, FolderPlus, Pencil, Save, Tags, Trash2 } from "lucide-react";
+import { ArrowDownUp, ChevronDown, ChevronRight, FileUp, Folder, FolderOpen, FolderPlus, Pencil, Save, Tags, Trash2 } from "lucide-react";
 import type { GalleryAsset, GalleryFolder } from "../shared/types";
 import type { UiCopy } from "./i18n";
 
@@ -99,6 +99,26 @@ interface GalleryDirectoryTreeProps {
   children: React.ReactNode;
   onNavigate: (folderId: GalleryFolderFilter) => void;
   onContextMenu: (event: React.MouseEvent<HTMLElement>, folderId: GalleryFolderFilter) => void;
+}
+
+interface GalleryTreeRowsProps {
+  copy: UiCopy;
+  parentId: string | null;
+  depth?: number;
+  foldersByParent: ReadonlyMap<string | null, GalleryFolder[]>;
+  activeFolderId: GalleryFolderFilter;
+  batchMode: boolean;
+  expandedFolderIds: ReadonlySet<string>;
+  selectedFolderIds: ReadonlySet<string>;
+  dragTargetId: GalleryFolderFilter | null;
+  subtreeAssetCounts: ReadonlyMap<string, number>;
+  dropHandlersForFolder: (folderId: GalleryFolderFilter) => GalleryEntryDropHandlers;
+  folderDisplayPath: (folder: GalleryFolder) => string;
+  onPrepareEntryDrag: (event: React.DragEvent<HTMLElement>, entry: GalleryExplorerEntry) => void;
+  onFolderContextMenu: (event: React.MouseEvent<HTMLElement>, folderId: GalleryFolderFilter) => void;
+  onToggleExpanded: (folderId: string) => void;
+  onToggleSelectedFolder: (folderId: string, checked: boolean) => void;
+  onNavigateFolder: (folderId: GalleryFolderFilter) => void;
 }
 
 interface GalleryContentGridProps {
@@ -268,6 +288,105 @@ export function GalleryDirectoryTree({
       </div>
     </aside>
   );
+}
+
+export function GalleryTreeRows({
+  copy,
+  parentId,
+  depth = 0,
+  foldersByParent,
+  activeFolderId,
+  batchMode,
+  expandedFolderIds,
+  selectedFolderIds,
+  dragTargetId,
+  subtreeAssetCounts,
+  dropHandlersForFolder,
+  folderDisplayPath,
+  onPrepareEntryDrag,
+  onFolderContextMenu,
+  onToggleExpanded,
+  onToggleSelectedFolder,
+  onNavigateFolder
+}: GalleryTreeRowsProps): React.ReactNode[] {
+  const folders = foldersByParent.get(parentId) ?? [];
+  return folders.flatMap((folder) => {
+    const hasChildren = (foldersByParent.get(folder.id) ?? []).length > 0;
+    const isExpanded = expandedFolderIds.has(folder.id);
+    const entry: GalleryExplorerEntry = { kind: "folder", id: folder.id, folder };
+    const row = (
+      <div
+        key={folder.id}
+        className={`gallery-tree-row ${activeFolderId === folder.id ? "active" : ""} ${dragTargetId === folder.id ? "drop-target" : ""}`}
+        style={{ "--depth": depth } as React.CSSProperties}
+        draggable
+        onDragStart={(event) => onPrepareEntryDrag(event, entry)}
+        onContextMenu={(event) => onFolderContextMenu(event, folder.id)}
+        {...dropHandlersForFolder(folder.id)}
+      >
+        <button
+          type="button"
+          className="gallery-tree-expander"
+          onClick={(event) => {
+            event.stopPropagation();
+            if (hasChildren) onToggleExpanded(folder.id);
+          }}
+          disabled={!hasChildren}
+          aria-label={isExpanded ? copy.hide : copy.show}
+          data-tooltip={isExpanded ? copy.hide : copy.show}
+        >
+          {hasChildren ? (isExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />) : <span />}
+        </button>
+        {batchMode && (
+          <input
+            type="checkbox"
+            checked={selectedFolderIds.has(folder.id)}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleSelectedFolder(folder.id, event.currentTarget.checked);
+            }}
+            onChange={() => undefined}
+            aria-label={copy.gallerySelectItem(folder.name)}
+          />
+        )}
+        <button
+          type="button"
+          className="gallery-tree-folder-button"
+          onClick={() => onNavigateFolder(folder.id)}
+          onDoubleClick={() => onNavigateFolder(folder.id)}
+          title={folderDisplayPath(folder)}
+        >
+          <Folder size={14} />
+          <span>{folder.name}</span>
+          <small>{subtreeAssetCounts.get(folder.id) ?? 0}</small>
+        </button>
+      </div>
+    );
+    return isExpanded
+      ? [
+          row,
+          ...GalleryTreeRows({
+            copy,
+            parentId: folder.id,
+            depth: depth + 1,
+            foldersByParent,
+            activeFolderId,
+            batchMode,
+            expandedFolderIds,
+            selectedFolderIds,
+            dragTargetId,
+            subtreeAssetCounts,
+            dropHandlersForFolder,
+            folderDisplayPath,
+            onPrepareEntryDrag,
+            onFolderContextMenu,
+            onToggleExpanded,
+            onToggleSelectedFolder,
+            onNavigateFolder
+          })
+        ]
+      : [row];
+  });
 }
 
 export function GalleryFolderCard({


### PR DESCRIPTION
## Summary
- move recursive Gallery folder tree row rendering into GalleryTreeRows
- keep folder expansion, selection, drag/drop, and navigation state in App
- continue Phase 5 App decomposition with a behavior-preserving Gallery view boundary

## Validation
- git diff --check
- pnpm typecheck
- pnpm vitest run src/renderer/App.smoke.test.tsx
- pnpm build