### PR TITLE
refactor: extract add api config form

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -108,7 +108,7 @@ import {
 import { PromptComposer } from "./PromptComposer";
 import { ImageEditor } from "./ImageEditor";
 import { HistoryFilterToolbar, HistoryFloatingPager, HistoryItemCard, HistoryListShell } from "./HistoryPanel";
-import { ApiConfigCard, ApiConfigDetail } from "./ProviderConfigPanel";
+import { AddApiConfigForm, ApiConfigCard, ApiConfigDetail } from "./ProviderConfigPanel";
 import {
   GalleryCompactControls,
   GalleryContentGrid,
@@ -5989,44 +5989,23 @@ export function App() {
                     );
                   })}
                 </div>
-                <button type="button" className="secondary" onClick={() => setIsAddingApiAccess((current) => !current)}>
-                  <Plus size={16} />
-                  {copy.addApiAccess}
-                </button>
-                {isAddingApiAccess && (
-                  <div className="api-access-add-form">
-                    <label>
-                      {copy.apiAccessKind}
-                      <select value={newApiAccessKind} onChange={(event) => changeNewApiAccessKind(event.target.value as ProviderKind)}>
-                        <option value="openai">OpenAI</option>
-                        <option value="gemini">Gemini</option>
-                        <option value="custom">Custom</option>
-                      </select>
-                    </label>
-                    <label>
-                      {copy.apiAccessName}
-                      <input value={newApiAccessName} onChange={(event) => setNewApiAccessName(event.target.value)} placeholder={providerLabelFromKind(newApiAccessKind)} />
-                    </label>
-                    <label>
-                      {copy.baseURL}
-                      <input value={newApiAccessBaseURL} onChange={(event) => setNewApiAccessBaseURL(event.target.value)} />
-                    </label>
-                    <label>
-                      {copy.apiKey}
-                      <input type="text" autoComplete="off" value={newApiAccessKey} onChange={(event) => setNewApiAccessKey(event.target.value)} placeholder={copy.pasteApiKey} />
-                    </label>
-                    <div className="button-row">
-                      <button type="button" onClick={addApiAccess} disabled={isSavingConfig}>
-                        {isSavingConfig ? <Loader2 className="spin" size={16} /> : <Plus size={16} />}
-                        {isSavingConfig ? copy.addingApiAccess : copy.addApiAccess}
-                      </button>
-                      <button type="button" className="ghost" onClick={() => setIsAddingApiAccess(false)}>
-                        <X size={16} />
-                        {copy.cancel}
-                      </button>
-                    </div>
-                  </div>
-                )}
+                <AddApiConfigForm
+                  copy={copy}
+                  open={isAddingApiAccess}
+                  saving={isSavingConfig}
+                  kind={newApiAccessKind}
+                  name={newApiAccessName}
+                  baseURL={newApiAccessBaseURL}
+                  apiKey={newApiAccessKey}
+                  namePlaceholder={providerLabelFromKind(newApiAccessKind)}
+                  onToggle={() => setIsAddingApiAccess((current) => !current)}
+                  onKindChange={changeNewApiAccessKind}
+                  onNameChange={setNewApiAccessName}
+                  onBaseURLChange={setNewApiAccessBaseURL}
+                  onApiKeyChange={setNewApiAccessKey}
+                  onAdd={() => void addApiAccess()}
+                  onCancel={() => setIsAddingApiAccess(false)}
+                />
               </aside>
 
               <ApiConfigDetail

--- a/src/renderer/ProviderConfigPanel.tsx
+++ b/src/renderer/ProviderConfigPanel.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
-import { CheckCircle2, ChevronUp, KeyRound, LibraryBig, Loader2, Radar, Save, Trash2 } from "lucide-react";
-import type { ProviderConfig } from "../shared/types";
+import { CheckCircle2, ChevronUp, KeyRound, LibraryBig, Loader2, Plus, Radar, Save, Trash2, X } from "lucide-react";
+import type { ProviderConfig, ProviderKind } from "../shared/types";
 import type { UiCopy } from "./i18n";
 
 type DiscoveredProviderModel = ProviderConfig["discoveredModels"][number];
@@ -58,6 +58,85 @@ interface ApiConfigDetailProps {
   onSubmit: () => void;
   onDiscover: () => void;
   onDelete: () => void;
+}
+
+interface AddApiConfigFormProps {
+  copy: UiCopy;
+  open: boolean;
+  saving: boolean;
+  kind: ProviderKind;
+  name: string;
+  baseURL: string;
+  apiKey: string;
+  namePlaceholder: string;
+  onToggle: () => void;
+  onKindChange: (kind: ProviderKind) => void;
+  onNameChange: (value: string) => void;
+  onBaseURLChange: (value: string) => void;
+  onApiKeyChange: (value: string) => void;
+  onAdd: () => void;
+  onCancel: () => void;
+}
+
+export function AddApiConfigForm({
+  copy,
+  open,
+  saving,
+  kind,
+  name,
+  baseURL,
+  apiKey,
+  namePlaceholder,
+  onToggle,
+  onKindChange,
+  onNameChange,
+  onBaseURLChange,
+  onApiKeyChange,
+  onAdd,
+  onCancel
+}: AddApiConfigFormProps) {
+  return (
+    <>
+      <button type="button" className="secondary" onClick={onToggle}>
+        <Plus size={16} />
+        {copy.addApiAccess}
+      </button>
+      {open && (
+        <div className="api-access-add-form">
+          <label>
+            {copy.apiAccessKind}
+            <select value={kind} onChange={(event) => onKindChange(event.target.value as ProviderKind)}>
+              <option value="openai">OpenAI</option>
+              <option value="gemini">Gemini</option>
+              <option value="custom">Custom</option>
+            </select>
+          </label>
+          <label>
+            {copy.apiAccessName}
+            <input value={name} onChange={(event) => onNameChange(event.target.value)} placeholder={namePlaceholder} />
+          </label>
+          <label>
+            {copy.baseURL}
+            <input value={baseURL} onChange={(event) => onBaseURLChange(event.target.value)} />
+          </label>
+          <label>
+            {copy.apiKey}
+            <input type="text" autoComplete="off" value={apiKey} onChange={(event) => onApiKeyChange(event.target.value)} placeholder={copy.pasteApiKey} />
+          </label>
+          <div className="button-row">
+            <button type="button" onClick={onAdd} disabled={saving}>
+              {saving ? <Loader2 className="spin" size={16} /> : <Plus size={16} />}
+              {saving ? copy.addingApiAccess : copy.addApiAccess}
+            </button>
+            <button type="button" className="ghost" onClick={onCancel}>
+              <X size={16} />
+              {copy.cancel}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
 }
 
 export function ApiConfigDetail({


### PR DESCRIPTION
## Summary
- extract the Add API config toggle and form into AddApiConfigForm
- keep new provider draft state and add behavior in App
- continue Phase 5 Provider/API configuration decomposition without behavior changes

## Validation
- git diff --check
- pnpm typecheck
- pnpm vitest run src/renderer/App.smoke.test.tsx
- pnpm build