### PR TITLE
refactor: extract provider summary section

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,7 +41,6 @@ import {
   Trash2,
   Plus,
   Type,
-  Wrench,
   X
 } from "lucide-react";
 import {
@@ -108,7 +107,7 @@ import {
 import { PromptComposer } from "./PromptComposer";
 import { ImageEditor } from "./ImageEditor";
 import { HistoryFilterToolbar, HistoryFloatingPager, HistoryItemCard, HistoryListShell } from "./HistoryPanel";
-import { ApiConfigDialog } from "./ProviderConfigPanel";
+import { ApiConfigDialog, ProviderSummarySection } from "./ProviderConfigPanel";
 import {
   GalleryCompactControls,
   GalleryContentGrid,
@@ -5027,41 +5026,19 @@ export function App() {
         </div>
         <div className="sidebar-full-stack">
 
-        <section className="tool-section model-config-section api-access-section">
-          <div className="section-title config-title">
-            <div className="section-title-label">
-              <KeyRound size={16} />
-              <h2>{copy.provider}</h2>
-            </div>
-            <span className="connection-badge" data-status={connectionCheck.status} title={connectionTitle}>
-              {isTestingConnection || connectionCheck.status === "checking" ? (
-                <Loader2 className="spin" size={13} />
-              ) : connectionCheck.status === "ok" ? (
-                <CheckCircle2 size={13} />
-              ) : connectionCheck.status === "error" ? (
-                <AlertTriangle size={13} />
-              ) : (
-                <span className="connection-dot" />
-              )}
-              {connectionLabel}
-            </span>
-          </div>
-
-          <button
-            type="button"
-            className="api-access-current"
-            onClick={() => openApiConfigDialog(activeConfig)}
-          >
-            <span>
-              <strong>{apiAccessDisplayName(activeConfig, copy.apiAccessUntitled)}</strong>
-              <small>{providerLabelFromKind(activeConfig.kind)} · {summarizeBaseURL(activeConfig.baseURL)}</small>
-              <small>
-                {activeConfig.apiKeySaved ? copy.keySaved : copy.noKeySaved} · {discoveryText}
-              </small>
-            </span>
-            <Wrench size={16} />
-          </button>
-        </section>
+        <ProviderSummarySection
+          copy={copy}
+          activeConfig={activeConfig}
+          displayName={apiAccessDisplayName(activeConfig, copy.apiAccessUntitled)}
+          providerLabel={providerLabelFromKind(activeConfig.kind)}
+          baseUrlSummary={summarizeBaseURL(activeConfig.baseURL)}
+          discoveryText={discoveryText}
+          connectionStatus={connectionCheck.status}
+          connectionLabel={connectionLabel}
+          connectionTitle={connectionTitle}
+          testingConnection={isTestingConnection}
+          onOpen={() => openApiConfigDialog(activeConfig)}
+        />
 
         <section className="tool-section launch-section">
           <div className="section-title launch-title">

--- a/src/renderer/ProviderConfigPanel.tsx
+++ b/src/renderer/ProviderConfigPanel.tsx
@@ -1,9 +1,24 @@
 import type React from "react";
-import { CheckCircle2, ChevronUp, KeyRound, LibraryBig, Loader2, Plus, Radar, Save, Trash2, X } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronUp, KeyRound, LibraryBig, Loader2, Plus, Radar, Save, Trash2, Wrench, X } from "lucide-react";
 import type { ProviderConfig, ProviderKind } from "../shared/types";
 import type { UiCopy } from "./i18n";
 
 type DiscoveredProviderModel = ProviderConfig["discoveredModels"][number];
+type ConnectionStatus = "idle" | "checking" | "ok" | "error";
+
+interface ProviderSummarySectionProps {
+  copy: UiCopy;
+  activeConfig: ProviderConfig;
+  displayName: string;
+  providerLabel: string;
+  baseUrlSummary: string;
+  discoveryText: string;
+  connectionStatus: ConnectionStatus;
+  connectionLabel: string;
+  connectionTitle: string;
+  testingConnection: boolean;
+  onOpen: () => void;
+}
 
 interface ApiConfigCardProps {
   copy: UiCopy;
@@ -29,6 +44,54 @@ interface ApiConfigCardProps {
   onSelect: () => void;
   onDelete: () => void;
   onDiscover: () => void;
+}
+
+export function ProviderSummarySection({
+  copy,
+  activeConfig,
+  displayName,
+  providerLabel,
+  baseUrlSummary,
+  discoveryText,
+  connectionStatus,
+  connectionLabel,
+  connectionTitle,
+  testingConnection,
+  onOpen
+}: ProviderSummarySectionProps) {
+  return (
+    <section className="tool-section model-config-section api-access-section">
+      <div className="section-title config-title">
+        <div className="section-title-label">
+          <KeyRound size={16} />
+          <h2>{copy.provider}</h2>
+        </div>
+        <span className="connection-badge" data-status={connectionStatus} title={connectionTitle}>
+          {testingConnection || connectionStatus === "checking" ? (
+            <Loader2 className="spin" size={13} />
+          ) : connectionStatus === "ok" ? (
+            <CheckCircle2 size={13} />
+          ) : connectionStatus === "error" ? (
+            <AlertTriangle size={13} />
+          ) : (
+            <span className="connection-dot" />
+          )}
+          {connectionLabel}
+        </span>
+      </div>
+
+      <button type="button" className="api-access-current" onClick={onOpen}>
+        <span>
+          <strong>{displayName}</strong>
+          <small>{providerLabel} · {baseUrlSummary}</small>
+          <small>
+            {activeConfig.apiKeySaved ? copy.keySaved : copy.noKeySaved} · {discoveryText}
+          </small>
+        </span>
+        <Wrench size={16} />
+      </button>
+    </section>
+  );
 }
 
 interface ApiConfigDetailProps {


### PR DESCRIPTION
## Summary\n- extract the sidebar Provider/API summary section into ProviderConfigPanel\n- keep connection testing, provider state, and dialog-open behavior in App\n- continue Phase 5 App.tsx decomposition with behavior-preserving view boundaries\n\n## Verification\n- git diff --check\n- pnpm typecheck\n- pnpm vitest run src/renderer/App.smoke.test.tsx\n- pnpm build