### PR TITLE
Record Phase 5 profiler evidence

### DIFF
--- a/docs/perf/app-decomposition-phase5.md
+++ b/docs/perf/app-decomposition-phase5.md
@@ -1,0 +1,78 @@
+# App Decomposition Phase 5 Profiler Evidence
+
+Captured: 2026-07-08
+
+Phase 5 extracted the editor, Gallery, History, Provider, launch, and parameter surfaces out of `App.tsx`. This capture adds renderer-only React Profiler zones so partial-image streaming can be compared against the Phase 0 baseline and any remaining unrelated panel work is explicit.
+
+## Commands
+
+```bash
+node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force
+node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase5-gallery-large --iterations 3
+```
+
+Raw local result:
+
+```text
+output/perf-baselines/phase5-gallery-large/gallery-large-44ef31f5a730.json
+```
+
+`output/` is ignored by git; rerun the commands above for fresh machine-local metrics.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Commit | `44ef31f5a730caa6155bcbc6c5309298219c3e4a` |
+| OS | Darwin `25.5.0` |
+| Architecture | `arm64` |
+| CPU | Apple M4, 10 cores |
+| Memory | 17179869184 bytes |
+| Fixture | `gallery-large` |
+| Fixture assets | 2400 |
+| Fixture folders | 96 |
+| Fixture state size | 1510208 bytes |
+
+## Renderer And Profiler
+
+The measurement harness opens Gallery, records the React Profiler event index, then simulates three partial-image job events.
+
+| Metric | Phase 0 baseline | Phase 5 capture |
+| --- | ---: | ---: |
+| Time to first Gallery grid render | 1066.100 ms | 661.600 ms |
+| Gallery entries reported by grid | 2404 | 2404 |
+| Gallery images using thumbnail URLs | 0 | 2400 |
+| Simulated partial image events | 3 | 3 |
+| React Profiler events after partial events | 2 App events | 4 zone events |
+| App partial-update `actualDuration` | 1149.200 ms | 247.100 ms |
+| App partial-update `baseDuration` | 1140.500 ms | 236.800 ms |
+
+Profiler events by zone after the simulated partial-image events:
+
+| Profiler zone | Events | Total actual duration | Max actual duration | Total base duration | Phases |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `App` | 1 | 247.100 ms | 247.100 ms | 236.800 ms | `update: 1` |
+| `Sidebar` | 1 | 0.400 ms | 0.400 ms | 0.400 ms | `update: 1` |
+| `Workspace` | 1 | 0.500 ms | 0.500 ms | 0.100 ms | `update: 1` |
+| `RightRail` | 1 | 245.900 ms | 245.900 ms | 236.000 ms | `update: 1` |
+
+## Conclusion
+
+Phase 5 decomposition lowered the measured App-level partial-image update cost from the Phase 0 baseline, but partial-image streaming still re-renders the unrelated `RightRail` subtree when Gallery is active. The residual is now measured and isolated: almost all partial-update time is in `RightRail`, not the sidebar or workspace shell.
+
+The next Phase 5 optimization should focus on keeping partial-image state changes from invalidating the right rail, either by moving partial-image state below the workspace/editor boundary or memoizing the Gallery/History rail after stabilizing its callback props.
+
+## Accessibility Smoke
+
+| Check | Result |
+| --- | --- |
+| Buttons without accessible names | 0 |
+| Images missing `alt` | 0 |
+| Dialogs missing `aria-modal="true"` | 0 |
+| Notice live region | Present |
+| Notice `aria-live` | `polite` |
+| Notice `aria-atomic` | `true` |
+| axe violations | 3 existing violations |
+| axe incomplete | 2 |
+
+The remaining axe violations match the previously documented baseline categories and are not introduced by the profiler boundaries.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2749,10 +2749,39 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
     await sleep(120);
   }
   const profilerEvents = await window.webContents.executeJavaScript(`(window.__crossgenProfilerEvents ?? []).slice(${Number(profilerStartIndex) || 0})`);
+  const profilerEventsById = Array.isArray(profilerEvents)
+    ? profilerEvents.reduce<Record<string, {
+      eventCount: number;
+      totalActualDuration: number;
+      maxActualDuration: number;
+      totalBaseDuration: number;
+      phases: Record<string, number>;
+    }>>((summary, event) => {
+      const id = typeof event.id === "string" ? event.id : "unknown";
+      const actualDuration = typeof event.actualDuration === "number" ? event.actualDuration : 0;
+      const baseDuration = typeof event.baseDuration === "number" ? event.baseDuration : 0;
+      const phase = typeof event.phase === "string" ? event.phase : "unknown";
+      const current = summary[id] ?? {
+        eventCount: 0,
+        totalActualDuration: 0,
+        maxActualDuration: 0,
+        totalBaseDuration: 0,
+        phases: {}
+      };
+      current.eventCount += 1;
+      current.totalActualDuration += actualDuration;
+      current.maxActualDuration = Math.max(current.maxActualDuration, actualDuration);
+      current.totalBaseDuration += baseDuration;
+      current.phases[phase] = (current.phases[phase] ?? 0) + 1;
+      summary[id] = current;
+      return summary;
+    }, {})
+    : {};
   (rendererResult as Record<string, unknown>).reactProfilerPartialImageTrace = {
     status: Array.isArray(profilerEvents) ? "ok" : "unavailable",
     simulatedPartialEventCount: sampleGalleryAsset ? 3 : 0,
     profilerEventCount: Array.isArray(profilerEvents) ? profilerEvents.length : 0,
+    eventsById: profilerEventsById,
     events: Array.isArray(profilerEvents) ? profilerEvents : []
   };
   (rendererResult as Record<string, unknown>).assetProtocol = assetProtocolPerfMetrics;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Profiler, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   BookOpen,
@@ -180,6 +180,44 @@ interface GallerySaveChoiceDialogState {
 }
 type BatchTagTarget = "history" | "gallery";
 type ImageContextMenuState = { x: number; y: number; asset: ImageAsset; jobPrompt: string };
+type CrossgenProfilerEvent = {
+  id: string;
+  phase: "mount" | "update" | "nested-update";
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+};
+
+declare global {
+  interface Window {
+    __crossgenProfilerEvents?: CrossgenProfilerEvent[];
+  }
+}
+
+function PerfProfiler({ id, children }: { id: string; children: ReactNode }) {
+  if (typeof window === "undefined" || !window.__crossgenProfilerEvents) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Profiler
+      id={id}
+      onRender={(profilerId, phase, actualDuration, baseDuration, startTime, commitTime) => {
+        window.__crossgenProfilerEvents?.push({
+          id: profilerId,
+          phase,
+          actualDuration,
+          baseDuration,
+          startTime,
+          commitTime
+        });
+      }}
+    >
+      {children}
+    </Profiler>
+  );
+}
 
 const sizePresets = ["auto", "1024x1024", "1536x1024", "1024x1536", "2048x1152", "2048x2048", "3840x2160", "2160x3840"];
 const qualityOptions: ImageQuality[] = ["auto", "low", "medium", "high"];
@@ -4885,6 +4923,7 @@ export function App() {
         } as React.CSSProperties
       }
     >
+      <PerfProfiler id="Sidebar">
       <aside className={isSidebarCompact ? "sidebar collapsed" : "sidebar"}>
         <header className="brand-block">
           <img className="brand-icon" src="./brand-logo.png" alt="" />
@@ -5008,6 +5047,7 @@ export function App() {
         </section>
         </div>
       </aside>
+      </PerfProfiler>
 
       <div
         className="column-resizer sidebar-resizer"
@@ -5029,6 +5069,7 @@ export function App() {
         }}
       />
 
+      <PerfProfiler id="Workspace">
       <section className="workspace">
         <div className="preview-layout" ref={previewLayoutRef}>
           <ImageEditor
@@ -5351,6 +5392,7 @@ export function App() {
           </section>
         </div>
       </section>
+      </PerfProfiler>
 
       <div
         className="column-resizer history-resizer"
@@ -5372,6 +5414,7 @@ export function App() {
         }}
       />
 
+      <PerfProfiler id="RightRail">
       <aside className={isRightRailCollapsed ? "history right-rail collapsed" : "history right-rail"}>
         <button
           type="button"
@@ -5731,6 +5774,7 @@ export function App() {
           </div>
         </div>
       </aside>
+      </PerfProfiler>
       {isActiveApiConfigOpen && (
         <ApiConfigDialog
           copy={copy}


### PR DESCRIPTION
## Summary
- add perf-only React Profiler zones for Sidebar, Workspace, and RightRail
- summarize partial-image profiler events by zone in renderer perf capture
- document Phase 5 gallery-large profiler evidence and residual RightRail re-render cost

## Performance evidence
Profile: gallery-large
Command: node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase5-gallery-large --iterations 3
Result: App partial update actualDuration 247.100 ms; RightRail 245.900 ms; time to first Gallery grid render 661.600 ms
Residual: partial-image streaming still re-renders RightRail when Gallery is active; documented for the next Phase 5 optimization slice.

## Validation
- pnpm vitest run src/renderer/App.smoke.test.tsx
- pnpm typecheck
- node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force
- node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase5-gallery-large --iterations 3
- pnpm build