### PR TITLE
Add shared dialog focus shell

### DIFF
--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -1569,6 +1569,35 @@ describe("renderer multi-model smoke", () => {
     expect(document.body.textContent).not.toContain("Clear all history?");
   });
 
+  it("traps focus inside shared dialogs and returns focus to the opener", async () => {
+    await renderApp(snapshot({ history: [geminiJob(0), geminiJob(1)] }));
+    const clearAllButton = document.querySelector<HTMLButtonElement>('button[aria-label="Clear all history records"]')!;
+
+    clearAllButton.focus();
+    expect(document.activeElement).toBe(clearAllButton);
+    await click(clearAllButton);
+    await flushAsync();
+
+    const dialog = document.querySelector<HTMLElement>(".confirm-dialog")!;
+    const cancelButton = buttonByText("Cancel", ".confirm-dialog button");
+    const confirmButton = buttonByText("Clear all", ".confirm-dialog button");
+
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(document.activeElement).toBe(cancelButton);
+
+    await keyDown(dialog, "Tab", { shiftKey: true });
+    expect(document.activeElement).toBe(confirmButton);
+
+    await keyDown(dialog, "Tab");
+    expect(document.activeElement).toBe(cancelButton);
+
+    await keyDown(dialog, "Escape");
+    await flushAsync();
+
+    expect(document.querySelector(".confirm-dialog")).toBeNull();
+    expect(document.activeElement).toBe(clearAllButton);
+  });
+
   it("can set History and Gallery storage to the same local path", async () => {
     const bridge = await renderApp(snapshot());
     const storageConfigButton = document.querySelector<HTMLButtonElement>('button[aria-label="Library path settings"]')!;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -105,6 +105,7 @@ import {
 } from "../shared/modelCatalog";
 import { PromptComposer } from "./PromptComposer";
 import { ImageEditor } from "./ImageEditor";
+import { DialogShell } from "./DialogShell";
 import { HistoryFilterToolbar, HistoryFloatingPager, HistoryItemCard, HistoryListShell } from "./HistoryPanel";
 import { ApiConfigDialog, LaunchSection, ProviderSummarySection } from "./ProviderConfigPanel";
 import { ParameterSection } from "./ParameterConfigPanel";
@@ -5840,14 +5841,7 @@ export function App() {
         />
       )}
       {isTemplatesOpen && (
-        <div
-          className="modal-backdrop"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) setIsTemplatesOpen(false);
-          }}
-        >
-          <section className="template-dialog" role="dialog" aria-modal="true" aria-labelledby="prompt-template-dialog-title">
+        <DialogShell className="template-dialog" labelledBy="prompt-template-dialog-title" onClose={() => setIsTemplatesOpen(false)}>
             <header className="history-header">
               <div>
                 <h2 id="prompt-template-dialog-title">{copy.promptTemplates}</h2>
@@ -5933,18 +5927,10 @@ export function App() {
                 </div>
               </div>
             </div>
-          </section>
-        </div>
+        </DialogShell>
       )}
       {galleryFolderDialog && (
-        <div
-          className="modal-backdrop"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) closeGalleryFolderDialog();
-          }}
-        >
-          <section className="confirm-dialog gallery-folder-dialog" role="dialog" aria-modal="true" aria-labelledby="gallery-folder-dialog-title">
+        <DialogShell className="confirm-dialog gallery-folder-dialog" labelledBy="gallery-folder-dialog-title" onClose={closeGalleryFolderDialog}>
             <div>
               <h2 id="gallery-folder-dialog-title">
                 {galleryFolderDialog.mode === "create" ? copy.galleryFolderCreate : copy.galleryFolderRename}
@@ -5980,18 +5966,10 @@ export function App() {
                 {galleryFolderDialog.mode === "create" ? copy.galleryFolderCreate : copy.galleryFolderRename}
               </button>
             </div>
-          </section>
-        </div>
+        </DialogShell>
       )}
       {galleryAssetDialog && (
-        <div
-          className="modal-backdrop"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) closeGalleryAssetDialog();
-          }}
-        >
-          <section className="confirm-dialog gallery-asset-dialog" role="dialog" aria-modal="true" aria-labelledby="gallery-asset-dialog-title">
+        <DialogShell className="confirm-dialog gallery-asset-dialog" labelledBy="gallery-asset-dialog-title" onClose={closeGalleryAssetDialog}>
             <div>
               <h2 id="gallery-asset-dialog-title">{copy.galleryAssetRename}</h2>
               <p>{copy.galleryAssetDialogDescription}</p>
@@ -6025,18 +6003,10 @@ export function App() {
                 {copy.galleryAssetRename}
               </button>
             </div>
-          </section>
-        </div>
+        </DialogShell>
       )}
       {storageDialogKind && (
-        <div
-          className="modal-backdrop"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) setStorageDialogKind(null);
-          }}
-        >
-          <section className="confirm-dialog storage-dialog" role="dialog" aria-modal="true" aria-labelledby="storage-dialog-title">
+        <DialogShell className="confirm-dialog storage-dialog" labelledBy="storage-dialog-title" onClose={() => setStorageDialogKind(null)}>
             <div>
               <h2 id="storage-dialog-title">{copy.libraryConfig}</h2>
               <p>{copy.storageFolderDialogDescription}</p>
@@ -6093,18 +6063,10 @@ export function App() {
                 {copy.cancel}
               </button>
             </div>
-          </section>
-        </div>
+        </DialogShell>
       )}
       {confirmDialog && (
-        <div
-          className="modal-backdrop"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) setConfirmDialog(null);
-          }}
-        >
-          <section className="confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+        <DialogShell className="confirm-dialog" labelledBy="confirm-dialog-title" onClose={() => setConfirmDialog(null)}>
             <div>
               <h2 id="confirm-dialog-title">{confirmDialog.title}</h2>
               <p>{confirmDialog.body}</p>
@@ -6118,18 +6080,10 @@ export function App() {
                 {confirmDialog.confirmLabel}
               </button>
             </div>
-          </section>
-        </div>
+        </DialogShell>
       )}
       {gallerySaveChoiceDialog && (
-        <div
-          className="modal-backdrop"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) setGallerySaveChoiceDialog(null);
-          }}
-        >
-          <section className="confirm-dialog gallery-save-choice-dialog" role="dialog" aria-modal="true" aria-labelledby="gallery-save-choice-title">
+        <DialogShell className="confirm-dialog gallery-save-choice-dialog" labelledBy="gallery-save-choice-title" onClose={() => setGallerySaveChoiceDialog(null)}>
             <div>
               <h2 id="gallery-save-choice-title">{copy.gallerySaveEditedTitle}</h2>
               <p>{copy.gallerySaveEditedBody(gallerySaveChoiceDialog.asset.originalName)}</p>
@@ -6147,8 +6101,7 @@ export function App() {
                 {copy.galleryOverwrite}
               </button>
             </div>
-          </section>
-        </div>
+        </DialogShell>
       )}
       {isPreviewOpen && activePreviewSource && (
         <div

--- a/src/renderer/DialogShell.tsx
+++ b/src/renderer/DialogShell.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, type KeyboardEvent, type ReactNode } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+  "[contenteditable='true']"
+].join(",");
+
+interface DialogShellProps {
+  children: ReactNode;
+  className: string;
+  labelledBy: string;
+  onClose: () => void;
+  backdropClassName?: string;
+  closeOnBackdrop?: boolean;
+}
+
+function focusableElements(root: HTMLElement): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter((element) => {
+    if (element.getAttribute("aria-hidden") === "true") return false;
+    return element.tabIndex >= 0;
+  });
+}
+
+export function DialogShell({
+  children,
+  className,
+  labelledBy,
+  onClose,
+  backdropClassName = "modal-backdrop",
+  closeOnBackdrop = true
+}: DialogShellProps) {
+  const dialogRef = useRef<HTMLElement | null>(null);
+  const openerRef = useRef<HTMLElement | null>(
+    typeof document !== "undefined" && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null
+  );
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return undefined;
+
+    if (!(document.activeElement instanceof HTMLElement) || !dialog.contains(document.activeElement)) {
+      const firstFocusable = focusableElements(dialog)[0];
+      (firstFocusable ?? dialog).focus();
+    }
+
+    return () => {
+      const opener = openerRef.current;
+      if (opener && document.contains(opener)) {
+        opener.focus();
+      }
+    };
+  }, []);
+
+  function handleKeyDown(event: KeyboardEvent<HTMLElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const focusable = focusableElements(dialog);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+      return;
+    }
+    if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  return (
+    <div
+      className={backdropClassName}
+      role="presentation"
+      onMouseDown={(event) => {
+        if (closeOnBackdrop && event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        ref={dialogRef}
+        className={className}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelledBy}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+      >
+        {children}
+      </section>
+    </div>
+  );
+}

--- a/src/renderer/ProviderConfigPanel.tsx
+++ b/src/renderer/ProviderConfigPanel.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, KeyRound, LibraryBig, Loader2, Plus, Radar, Rocket, Save, Trash2, Wrench, X } from "lucide-react";
 import type { FocusedLaunchId, ProviderConfig, ProviderKind } from "../shared/types";
+import { DialogShell } from "./DialogShell";
 import type { UiCopy } from "./i18n";
 
 type DiscoveredProviderModel = ProviderConfig["discoveredModels"][number];
@@ -385,14 +386,7 @@ export function ApiConfigDialog({
   );
 
   return (
-    <div
-      className="modal-backdrop"
-      role="presentation"
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <section className="api-config-dialog" role="dialog" aria-modal="true" aria-labelledby="api-config-dialog-title">
+    <DialogShell className="api-config-dialog" labelledBy="api-config-dialog-title" onClose={onClose}>
         <header className="history-header">
           <div>
             <h2 id="api-config-dialog-title">{copy.provider}</h2>
@@ -460,8 +454,7 @@ export function ApiConfigDialog({
             onDelete={() => onDeleteConfig(selectedConfig)}
           />
         </div>
-      </section>
-    </div>
+    </DialogShell>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a shared DialogShell for modal aria wiring, initial focus, Tab focus wrap, Escape close, and opener focus return
- convert App-owned dialogs and the API config dialog to use the shared shell
- add smoke coverage for focus trapping and opener focus return on a destructive confirmation dialog

## Accessibility evidence
- gallery-small renderer accessibility smoke: ok
- axe result unchanged from known categories: aria-required-children, color-contrast, landmark-unique

## Validation
- pnpm vitest run src/renderer/App.smoke.test.tsx
- pnpm typecheck
- pnpm build
- node scripts/create-large-gallery-fixture.mjs --profile gallery-small --output output/perf-fixtures/gallery-small --force
- node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-small --output output/perf-baselines/phase6-dialog-gallery-small --iterations 1