### PR TITLE
Add dialog keyboard accessibility smoke

### DIFF
--- a/docs/perf/dialog-accessibility-phase6.md
+++ b/docs/perf/dialog-accessibility-phase6.md
@@ -1,0 +1,68 @@
+# Dialog Accessibility Phase 6 Evidence
+
+Captured: 2026-07-08
+
+Phase 6 introduces shared dialog keyboard behavior through `DialogShell` and adds repeatable renderer accessibility smoke coverage for the storage settings dialog.
+
+## Commands
+
+```bash
+node scripts/create-large-gallery-fixture.mjs --profile gallery-small --output output/perf-fixtures/gallery-small --force
+node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-small --output output/perf-baselines/phase6-dialog-smoke-gallery-small --iterations 1
+```
+
+Raw local result:
+
+```text
+output/perf-baselines/phase6-dialog-smoke-gallery-small/gallery-small-460ddcfbb5af.json
+```
+
+`output/` is ignored by git; rerun the commands above for fresh machine-local evidence.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Commit | `460ddcfbb5af7e6702bec1d347edd2a0f83984bf` |
+| OS | Darwin `25.5.0` |
+| Architecture | `arm64` |
+| CPU | Apple M4, 10 cores |
+| Memory | 17179869184 bytes |
+| Fixture | `gallery-small` |
+| Fixture assets | 180 |
+| Fixture folders | 18 |
+| Fixture state size | 114612 bytes |
+
+## Dialog Keyboard Smoke
+
+The renderer smoke opens the Library path settings dialog and verifies the shared keyboard contract.
+
+| Check | Result |
+| --- | --- |
+| Dialog smoke status | `ok` |
+| Opener focused before opening | `true` |
+| Dialog opened | `true` |
+| Initial focus inside dialog | `true` |
+| Focusable controls found | 6 |
+| `Shift+Tab` wraps from first to last control | `true` |
+| `Escape` closes dialog | `true` |
+| Focus returns to opener | `true` |
+
+## Accessibility Smoke
+
+| Check | Result |
+| --- | --- |
+| Buttons without accessible names | 0 |
+| Images missing `alt` | 0 |
+| Dialogs missing `aria-modal="true"` | 0 |
+| Notice live region | Present |
+| Notice `aria-live` | `polite` |
+| Notice `aria-atomic` | `true` |
+| axe violations | 3 existing violations |
+| axe incomplete | 2 |
+
+Remaining axe categories are unchanged from the known baseline: `aria-required-children`, `color-contrast`, and `landmark-unique`.
+
+## Scope Notes
+
+This evidence covers shared dialog focus behavior and the renderer smoke path. Dark mode remains a separate Phase 6 theming task and is intentionally not included in this slice.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2681,6 +2681,62 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
         node.textContent ||
         ""
       ).trim();
+      const dialogFocusableSelector = [
+        "a[href]",
+        "button:not([disabled])",
+        "input:not([disabled])",
+        "select:not([disabled])",
+        "textarea:not([disabled])",
+        "[tabindex]:not([tabindex='-1'])",
+        "[contenteditable='true']"
+      ].join(",");
+      const dialogFocusableElements = (root) => [...root.querySelectorAll(dialogFocusableSelector)].filter((element) => element.tabIndex >= 0);
+      const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+      const runDialogKeyboardSmoke = async () => {
+        const storageButton = [...document.querySelectorAll("button")].find((button) => {
+          const name = accessibleName(button);
+          return name === "Library path settings" || name === "库路径配置";
+        });
+        if (!storageButton) {
+          return {
+            status: "violations",
+            reason: "Library path settings button was not found."
+          };
+        }
+
+        storageButton.focus();
+        const openerFocusedBeforeOpen = document.activeElement === storageButton;
+        storageButton.click();
+        const dialog = await waitForSelector(".storage-dialog");
+        await nextFrame();
+
+        const focusable = dialogFocusableElements(dialog);
+        const firstFocusable = focusable[0] ?? null;
+        const lastFocusable = focusable[focusable.length - 1] ?? null;
+        const initialFocusInside = document.activeElement instanceof HTMLElement && dialog.contains(document.activeElement);
+
+        if (firstFocusable) firstFocusable.focus();
+        dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true, cancelable: true }));
+        await nextFrame();
+        const shiftTabWrappedToLast = Boolean(lastFocusable && document.activeElement === lastFocusable);
+
+        dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+        await nextFrame();
+        const closedOnEscape = !document.querySelector(".storage-dialog");
+        const focusReturnedToOpener = document.activeElement === storageButton;
+        const ok = openerFocusedBeforeOpen && initialFocusInside && shiftTabWrappedToLast && closedOnEscape && focusReturnedToOpener;
+
+        return {
+          status: ok ? "ok" : "violations",
+          openerFocusedBeforeOpen,
+          opened: Boolean(dialog),
+          initialFocusInside,
+          focusableCount: focusable.length,
+          shiftTabWrappedToLast,
+          closedOnEscape,
+          focusReturnedToOpener
+        };
+      };
       const pageStartedAt = performance.now();
       const galleryTab = await waitForSelector(".right-rail-tabs button:nth-child(2)");
       const tabReadyAt = performance.now();
@@ -2692,6 +2748,7 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
       const galleryImages = [...grid.querySelectorAll(".gallery-thumb img")];
       await new Promise((resolve) => setTimeout(resolve, 750));
       const thumbnailWaitDoneAt = performance.now();
+      const dialogKeyboardSmoke = await runDialogKeyboardSmoke();
       const buttonsWithoutNames = [...document.querySelectorAll("button")].filter((button) => !accessibleName(button)).map((button) => button.className || button.outerHTML.slice(0, 120));
       const imagesMissingAlt = [...document.querySelectorAll("img:not([alt])")].map((image) => image.className || image.getAttribute("src") || image.outerHTML.slice(0, 120));
       const dialogsWithoutModal = [...document.querySelectorAll('[role="dialog"]')].filter((dialog) => dialog.getAttribute("aria-modal") !== "true").length;
@@ -2713,13 +2770,14 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
           thumbnailSrcCount: galleryImages.filter((image) => image.getAttribute("src")?.includes("thumb=1")).length
         },
         accessibilitySmoke: {
-          status: buttonsWithoutNames.length === 0 && imagesMissingAlt.length === 0 && dialogsWithoutModal === 0 && !noticeMissingLiveRegion ? "ok" : "violations",
+          status: buttonsWithoutNames.length === 0 && imagesMissingAlt.length === 0 && dialogsWithoutModal === 0 && !noticeMissingLiveRegion && dialogKeyboardSmoke.status === "ok" ? "ok" : "violations",
           buttonsWithoutNames,
           imagesMissingAlt,
           dialogsWithoutModal,
           noticeMissingLiveRegion,
           noticeAriaLive: notice?.getAttribute("aria-live") ?? null,
-          noticeAriaAtomic: notice?.getAttribute("aria-atomic") ?? null
+          noticeAriaAtomic: notice?.getAttribute("aria-atomic") ?? null,
+          dialogKeyboardSmoke
         }
       };
     })();


### PR DESCRIPTION
## Summary
- extend renderer performance/accessibility capture with dialog keyboard smoke
- verify the Library path settings dialog initial focus, Shift+Tab wrap, Escape close, and focus return
- document Phase 6 dialog accessibility smoke evidence

## Accessibility evidence
Profile: gallery-small
Command: node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-small --output output/perf-baselines/phase6-dialog-smoke-gallery-small --iterations 1
Dialog keyboard smoke: ok
axe categories unchanged: aria-required-children, color-contrast, landmark-unique

## Validation
- pnpm typecheck
- node scripts/create-large-gallery-fixture.mjs --profile gallery-small --output output/perf-fixtures/gallery-small --force
- node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-small --output output/perf-baselines/phase6-dialog-smoke-gallery-small --iterations 1
- pnpm build