### PR TITLE
Avoid full gallery sync when picking assets

### DIFF
--- a/docs/perf/gallery-phase2.md
+++ b/docs/perf/gallery-phase2.md
@@ -63,3 +63,30 @@ Phase 0 baseline values come from `docs/perf/gallery-baseline.md`.
 - Read-only IPC now returns cached Gallery state when the watcher is current and no disk changes are pending.
 - Pending watcher changes are consumed before read responses; file/subtree changes use incremental scan inputs and null watcher events still force full recovery.
 - Watcher restart uses folder paths derived from reconciled state instead of scanning the Gallery only to discover watched folders.
+
+## Follow-up: `gallery:pick`
+
+Captured: 2026-07-08
+
+`gallery:pick` is a read path used when adding a Gallery image as a reference input. It still forced `syncGalleryWithDisk(...)` after the initial Phase 2 work. The follow-up switches it to `syncGalleryForRead(...)` and adds the handler to the Electron main-process performance capture.
+
+Command:
+
+```bash
+node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force
+node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase2-gallery-pick --iterations 3 --no-renderer
+```
+
+Raw local result:
+
+```text
+output/perf-baselines/phase2-gallery-pick/gallery-large-6623cb62484a.json
+```
+
+Before was measured with the same capture instrumentation and the previous one-line `syncGalleryWithDisk(...)` implementation restored temporarily.
+
+| IPC handler | Before | After | State writes |
+| --- | ---: | ---: | ---: |
+| `gallery:pick` | 63.722 ms | 0.215 ms | 0 |
+
+The watcher-fresh read path now avoids a full Gallery disk scan while preserving the managed-file assertion before returning the picked `InputAsset`.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1907,7 +1907,7 @@ async function handleRemoveGalleryAsset(_event: IpcMainInvokeEvent, id: string):
 }
 
 async function handlePickGalleryAsset(_event: IpcMainInvokeEvent, id: string): Promise<InputAsset> {
-  const state = await syncGalleryWithDisk(await readState());
+  const state = await syncGalleryForRead(await readState());
   const asset = state.galleryAssets.find((item) => item.id === id);
   if (!asset) throw new Error("Gallery 资源不存在。");
   const galleryDir = getGalleryDir(state);
@@ -2593,6 +2593,10 @@ async function runMainPerformanceCapture(resultPath: string): Promise<void> {
   await measure("app:getSnapshot", handleGetSnapshot);
   await measure("gallery:list", handleListGallery);
   await measure("galleryFolders:list", handleListGalleryFolders);
+  const sampleGalleryAsset = initialState.galleryAssets[0];
+  if (sampleGalleryAsset) {
+    await measure("gallery:pick", () => handlePickGalleryAsset(null as unknown as IpcMainInvokeEvent, sampleGalleryAsset.id));
+  }
 
   const state = await readState();
   await ensureDir(path.dirname(resultPath));


### PR DESCRIPTION
## Summary
- switch gallery:pick to the watcher-aware syncGalleryForRead path
- add gallery:pick to Electron main-process performance capture
- document gallery-large before/after metrics for the read path

## Performance evidence
Profile: gallery-large
Command: node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase2-gallery-pick --iterations 3 --no-renderer
Before: gallery:pick 63.722 ms using the previous syncGalleryWithDisk path
After: gallery:pick 0.215 ms using syncGalleryForRead
State writes: 0 before and after

## Validation
- pnpm typecheck
- pnpm vitest run src/main/services/galleryDiskSync.test.ts src/main/services/assetOwnership.test.ts
- node scripts/create-large-gallery-fixture.mjs --profile gallery-large --output output/perf-fixtures/gallery-large --force
- node scripts/measure-gallery-performance.mjs --fixture output/perf-fixtures/gallery-large --output output/perf-baselines/phase2-gallery-pick --iterations 3 --no-renderer
- pnpm build