### PR TITLE
Use dialog shell for image preview modal

### DIFF
--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -523,6 +523,25 @@ describe("renderer multi-model smoke", () => {
     expect(document.body.textContent).toContain("gallery-preview.png opened in the editor.");
     expect(document.querySelector(".notice-area")?.getAttribute("aria-live")).toBe("polite");
     expect(document.querySelector(".notice-area")?.getAttribute("aria-atomic")).toBe("true");
+
+    const previewOpener = document.querySelector<HTMLElement>(".zoom-surface")!;
+    previewOpener.focus();
+    expect(document.activeElement).toBe(previewOpener);
+    await keyDown(previewOpener, "Enter");
+    await flushAsync();
+
+    const previewDialog = document.querySelector<HTMLElement>(".preview-modal-dialog")!;
+    const previewClose = document.querySelector<HTMLButtonElement>(".preview-modal-close")!;
+    expect(previewDialog.getAttribute("aria-modal")).toBe("true");
+    expect(previewDialog.getAttribute("aria-labelledby")).toBe("preview-modal-title");
+    expect(document.querySelector("#preview-modal-title")?.textContent).toBe("Image preview");
+    expect(document.activeElement).toBe(previewClose);
+
+    await keyDown(previewDialog, "Escape");
+    await flushAsync();
+
+    expect(document.querySelector(".preview-modal-dialog")).toBeNull();
+    expect(document.activeElement).toBe(previewOpener);
   });
 
   it("picks a Gallery image as a reference asset from the context menu", async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6104,13 +6104,8 @@ export function App() {
         </DialogShell>
       )}
       {isPreviewOpen && activePreviewSource && (
-        <div
-          className="preview-modal-backdrop"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) setIsPreviewOpen(false);
-          }}
-        >
+        <DialogShell className="preview-modal-dialog" backdropClassName="preview-modal-backdrop" labelledBy="preview-modal-title" onClose={() => setIsPreviewOpen(false)}>
+          <h2 id="preview-modal-title" className="visually-hidden">{copy.resultViewer}</h2>
           <button type="button" className="preview-modal-close icon-button tooltip-below" onClick={() => setIsPreviewOpen(false)} aria-label={copy.cancel} data-tooltip={copy.cancel}>
             <X size={18} />
           </button>
@@ -6120,7 +6115,7 @@ export function App() {
             className="preview-modal-image"
             onContextMenu={(e) => handleImageContextMenu(e, activeImage, activeJob?.prompt ?? '')}
           />
-        </div>
+        </DialogShell>
       )}
       {contextMenu && (
         <div

--- a/src/renderer/ImageEditor.tsx
+++ b/src/renderer/ImageEditor.tsx
@@ -189,7 +189,15 @@ export function ImageEditor({
             <div
               ref={zoomSurfaceRef}
               className={isPanning ? "zoom-surface panning" : previewZoom > 1 ? "zoom-surface pannable" : "zoom-surface"}
+              role="button"
+              tabIndex={0}
+              aria-label={copy.resultViewer}
               onDoubleClick={onOpenPreview}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter" && event.key !== " ") return;
+                event.preventDefault();
+                onOpenPreview();
+              }}
               onPointerDown={onPreviewPanStart}
               onPointerMove={onPreviewPanMove}
               onPointerUp={onPreviewPanEnd}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -264,6 +264,18 @@
     margin: 0;
   }
 
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+  }
+
   h1 {
     font-size: 24px;
     line-height: 1.1;
@@ -3645,6 +3657,14 @@
     place-items: center;
     background: var(--modal-backdrop-surface);
     padding: 32px;
+  }
+
+  .preview-modal-dialog {
+    display: grid;
+    place-items: center;
+    max-width: 100%;
+    max-height: 100%;
+    outline: none;
   }
 
   .preview-modal-image {


### PR DESCRIPTION
## Summary\n- route the enlarged image preview modal through the shared DialogShell focus/escape/backdrop behavior\n- make the preview canvas keyboard-focusable so Enter/Space opens the enlarged preview with a real opener for focus return\n- add renderer smoke coverage for preview modal aria-modal, labelledby, Escape close, and focus return\n\n## Validation\n- pnpm typecheck\n- pnpm vitest run src/renderer/App.smoke.test.tsx\n- pnpm build