### PR TITLE
Refine preview modal keyboard opener

### DIFF
--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -524,7 +524,7 @@ describe("renderer multi-model smoke", () => {
     expect(document.querySelector(".notice-area")?.getAttribute("aria-live")).toBe("polite");
     expect(document.querySelector(".notice-area")?.getAttribute("aria-atomic")).toBe("true");
 
-    const previewOpener = document.querySelector<HTMLElement>(".zoom-surface")!;
+    const previewOpener = document.querySelector<HTMLElement>(".preview-image-frame img")!;
     previewOpener.focus();
     expect(document.activeElement).toBe(previewOpener);
     await keyDown(previewOpener, "Enter");

--- a/src/renderer/ImageEditor.tsx
+++ b/src/renderer/ImageEditor.tsx
@@ -189,15 +189,7 @@ export function ImageEditor({
             <div
               ref={zoomSurfaceRef}
               className={isPanning ? "zoom-surface panning" : previewZoom > 1 ? "zoom-surface pannable" : "zoom-surface"}
-              role="button"
-              tabIndex={0}
-              aria-label={copy.resultViewer}
               onDoubleClick={onOpenPreview}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") return;
-                event.preventDefault();
-                onOpenPreview();
-              }}
               onPointerDown={onPreviewPanStart}
               onPointerMove={onPreviewPanMove}
               onPointerUp={onPreviewPanEnd}
@@ -212,9 +204,17 @@ export function ImageEditor({
                   ref={annotationImageRef}
                   src={activePreviewSource}
                   alt={copy.generatedResult}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={copy.resultViewer}
                   crossOrigin={/^(?:https?:|image2tools-asset:)/i.test(activePreviewSource) ? "anonymous" : undefined}
                   draggable={false}
                   onLoad={() => onResizeAnnotationCanvas(true)}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    event.preventDefault();
+                    onOpenPreview();
+                  }}
                   onContextMenu={onImageContextMenu}
                 />
                 {annotationDrawingLayers.map((layer) => (


### PR DESCRIPTION
## Summary\n- move the keyboard opener for enlarged preview from the whole zoom surface to the image element\n- avoid assigning button semantics to a container that can include annotation overlays\n- keep the preview modal focus-return smoke coverage aligned with the actual opener\n\n## Validation\n- pnpm typecheck\n- pnpm vitest run src/renderer/App.smoke.test.tsx\n- pnpm build