### PR TITLE
Add theme mode toggle entry

### DIFF
--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -53,6 +53,7 @@ afterEach(() => {
   root = null;
   container?.remove();
   container = null;
+  document.documentElement.removeAttribute("data-theme");
   delete window.crossgen;
   delete window.image2tools;
 });
@@ -1466,6 +1467,33 @@ describe("renderer multi-model smoke", () => {
     expect(configSection.compareDocumentPosition(launchSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(launchSection.compareDocumentPosition(parameterSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(parameterSection.compareDocumentPosition(updatePanel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("offers a persistent theme mode toggle in the left rail", async () => {
+    await renderApp(snapshot());
+    const themeButton = document.querySelector<HTMLButtonElement>(".theme-mode-button")!;
+
+    expect(themeButton.getAttribute("aria-label")).toBe("Theme: System");
+    expect(themeButton.textContent).toContain("System");
+    expect(document.documentElement.getAttribute("data-theme")).toBeNull();
+
+    await click(themeButton);
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(window.localStorage.getItem("image2tools.theme")).toBe("light");
+    expect(themeButton.getAttribute("aria-label")).toBe("Theme: Light");
+
+    await click(themeButton);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(window.localStorage.getItem("image2tools.theme")).toBe("dark");
+    expect(themeButton.getAttribute("aria-label")).toBe("Theme: Dark");
+
+    await click(themeButton);
+    expect(document.documentElement.getAttribute("data-theme")).toBeNull();
+    expect(window.localStorage.getItem("image2tools.theme")).toBe("system");
+    expect(themeButton.getAttribute("aria-label")).toBe("Theme: System");
+
+    await click(document.querySelector<HTMLButtonElement>(".sidebar-collapse-button")!);
+    expect(document.querySelector<HTMLButtonElement>('.sidebar-mini-utility button[aria-label="Theme: System"]')).toBeTruthy();
   });
 
   it("uses a clear Chinese update failure label instead of an exception shorthand", async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,6 +26,8 @@ import {
   List,
   Loader2,
   LibraryBig,
+  Monitor,
+  Moon,
   Paintbrush,
   Pencil,
   Radar,
@@ -36,6 +38,7 @@ import {
   SlidersHorizontal,
   Sparkles,
   SquarePen,
+  Sun,
   Tags,
   Trash2,
   Plus,
@@ -248,6 +251,34 @@ const DEFAULT_HISTORY_MODEL_DISPLAY = "GPT Image 2";
 const PROMPT_ACTION_ICON_BUTTON_WIDTH = 40;
 const PROMPT_ACTION_EDGE_GUARD = 4;
 type TabMode = "text2img" | "img2img";
+type ThemeMode = "system" | "light" | "dark";
+
+const THEME_STORAGE_KEY = "image2tools.theme";
+const themeModeOrder: ThemeMode[] = ["system", "light", "dark"];
+
+function getInitialThemeMode(): ThemeMode {
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+}
+
+function applyThemeMode(mode: ThemeMode) {
+  if (mode === "system") {
+    document.documentElement.removeAttribute("data-theme");
+    return;
+  }
+  document.documentElement.dataset.theme = mode;
+}
+
+function nextThemeMode(mode: ThemeMode): ThemeMode {
+  const index = themeModeOrder.indexOf(mode);
+  return themeModeOrder[(index + 1) % themeModeOrder.length] ?? "system";
+}
+
+function themeModeLabel(copy: UiCopy, mode: ThemeMode): string {
+  if (mode === "light") return copy.themeLight;
+  if (mode === "dark") return copy.themeDark;
+  return copy.themeSystem;
+}
 
 function getReferenceImageLimit(params: ImageParams): number {
   if (isOpenAIImageParams(params)) {
@@ -832,6 +863,7 @@ async function inspectMask(
 export function App() {
   const bridge = getBridge();
   const [language, setLanguage] = useState<Language>(() => getInitialLanguage());
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => getInitialThemeMode());
   const copy = translations[language];
   const [snapshot, setSnapshot] = useState<AppSnapshot>(fallbackSnapshot);
   const [tabMode, setTabMode] = useState<TabMode>("text2img");
@@ -1430,6 +1462,11 @@ export function App() {
   useEffect(() => {
     window.localStorage.setItem("image2tools.language", language);
   }, [language]);
+
+  useEffect(() => {
+    applyThemeMode(themeMode);
+    window.localStorage.setItem(THEME_STORAGE_KEY, themeMode);
+  }, [themeMode]);
 
   useEffect(() => {
     if (!editingHistoryTagsId) return undefined;
@@ -3039,6 +3076,16 @@ export function App() {
 
   function toggleLanguage() {
     setLanguage((current) => (current === "en" ? "zh" : "en"));
+  }
+
+  function toggleThemeMode() {
+    setThemeMode((current) => nextThemeMode(current));
+  }
+
+  function renderThemeIcon() {
+    if (themeMode === "light") return <Sun size={15} />;
+    if (themeMode === "dark") return <Moon size={15} />;
+    return <Monitor size={15} />;
   }
 
   function showReferenceLimitHint(max: number) {
@@ -4961,6 +5008,9 @@ export function App() {
           <button type="button" className="icon-button" onClick={toggleLanguage} aria-label={copy.language} data-tooltip={copy.language}>
             <span className="language-short">{language === "en" ? "En" : "简"}</span>
           </button>
+          <button type="button" className="icon-button" onClick={toggleThemeMode} aria-label={`${copy.theme}: ${themeModeLabel(copy, themeMode)}`} data-tooltip={`${copy.theme}: ${themeModeLabel(copy, themeMode)}`}>
+            {renderThemeIcon()}
+          </button>
           {updateCheck?.status === "available" ? (
             <button type="button" className="icon-button" onClick={downloadAndInstallUpdate} disabled={!bridge || isInstallingUpdate} aria-label={copy.installUpdate} data-tooltip={copy.installUpdate}>
               {isInstallingUpdate ? <Loader2 className="spin" size={16} /> : <ChevronUp size={17} />}
@@ -5019,6 +5069,10 @@ export function App() {
           <div className="sidebar-utility-left">
             <button type="button" className="language-pill" onClick={toggleLanguage} aria-label={copy.language} data-tooltip={copy.language}>
               {language === "en" ? "En" : "简"}
+            </button>
+            <button type="button" className="theme-mode-button" onClick={toggleThemeMode} aria-label={`${copy.theme}: ${themeModeLabel(copy, themeMode)}`} data-tooltip={`${copy.theme}: ${themeModeLabel(copy, themeMode)}`}>
+              {renderThemeIcon()}
+              <span>{themeModeLabel(copy, themeMode)}</span>
             </button>
             {updateCheck?.status === "available" ? (
               <button type="button" className="icon-button utility-check-button" onClick={downloadAndInstallUpdate} disabled={!bridge || isCheckingUpdate || isInstallingUpdate} aria-label={copy.installUpdate} data-tooltip={copy.installUpdate}>

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -71,6 +71,10 @@ interface ValidationCopy {
 
 export interface UiCopy {
   language: string;
+  theme: string;
+  themeSystem: string;
+  themeLight: string;
+  themeDark: string;
   english: string;
   chinese: string;
   tagline: string;
@@ -422,6 +426,10 @@ export interface UiCopy {
 export const translations: Record<Language, UiCopy> = {
   en: {
     language: "Language",
+    theme: "Theme",
+    themeSystem: "System",
+    themeLight: "Light",
+    themeDark: "Dark",
     english: "English",
     chinese: "中文",
     tagline: "An easy-to-use, all-in-one AI image generation management tool.",
@@ -836,6 +844,10 @@ export const translations: Record<Language, UiCopy> = {
   },
   zh: {
     language: "语言",
+    theme: "外观",
+    themeSystem: "跟随系统",
+    themeLight: "浅色",
+    themeDark: "深色",
     english: "English",
     chinese: "中文",
     tagline: "方便易用的一站式AI生图管理工具。",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -98,7 +98,7 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme="light"]) {
       --surface-app: #101720;
       --surface-panel: #17212c;
       --surface-panel-muted: #202c38;
@@ -135,6 +135,44 @@
       --modal-backdrop-surface: rgba(2, 7, 13, 0.86);
       color-scheme: dark;
     }
+  }
+
+  :root[data-theme="dark"] {
+    --surface-app: #101720;
+    --surface-panel: #17212c;
+    --surface-panel-muted: #202c38;
+    --surface-raised: #223040;
+    --surface-selected: #2a2b31;
+    --surface-hover: #233241;
+    --text-primary: #f4f7fb;
+    --text-secondary: #c3cbd6;
+    --text-muted: #9ba7b5;
+    --text-inverse: #fffaf4;
+    --text-on-accent: #17120e;
+    --border-subtle: #2e3d4d;
+    --border-strong: #4b5d70;
+    --accent: #ff9857;
+    --accent-strong: #ffb172;
+    --accent-soft: #33251d;
+    --accent-border: rgba(255, 152, 87, 0.36);
+    --accent-rgb: 255, 152, 87;
+    --success: #63d6b4;
+    --success-strong: #8be5cc;
+    --success-soft: #12372f;
+    --success-border: rgba(99, 214, 180, 0.34);
+    --danger: #ff8585;
+    --danger-strong: #ffaaaa;
+    --danger-soft: #3a2026;
+    --warning: #f2c066;
+    --warning-soft: #372b18;
+    --shadow-soft: 0 14px 30px rgba(0, 0, 0, 0.24);
+    --shadow-popover: 0 20px 54px rgba(0, 0, 0, 0.42);
+    --surface-floating: color-mix(in srgb, var(--surface-panel) 82%, transparent);
+    --checker-mark: rgba(231, 238, 246, 0.045);
+    --glass-surface: rgba(23, 33, 44, 0.66);
+    --crop-overlay: rgba(2, 7, 13, 0.46);
+    --modal-backdrop-surface: rgba(2, 7, 13, 0.86);
+    color-scheme: dark;
   }
 
   * {
@@ -539,6 +577,32 @@
   }
 
   .language-pill:hover:not(:disabled) {
+    border-color: var(--border-strong);
+    background: var(--surface-hover);
+    color: var(--text-primary);
+  }
+
+  .theme-mode-button {
+    width: auto;
+    min-width: 0;
+    min-height: 36px;
+    gap: 6px;
+    border-color: var(--border-subtle);
+    background: var(--surface-panel);
+    color: var(--text-secondary);
+    padding: 0 9px;
+  }
+
+  .theme-mode-button span {
+    max-width: 66px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+    font-weight: 750;
+    white-space: nowrap;
+  }
+
+  .theme-mode-button:hover:not(:disabled) {
     border-color: var(--border-strong);
     background: var(--surface-hover);
     color: var(--text-primary);


### PR DESCRIPTION
## Summary\n- add a persistent left-rail theme mode toggle for System, Light, and Dark\n- support explicit data-theme overrides while preserving system-following dark mode\n- keep the theme control available in the collapsed sidebar and add smoke coverage\n\n## Validation\n- pnpm typecheck\n- pnpm vitest run src/renderer/App.smoke.test.tsx\n- pnpm build