### PR TITLE
Define v0.3.1 runtime contracts

### DIFF
--- a/docs/plans/model-expansion-radar.md
+++ b/docs/plans/model-expansion-radar.md
@@ -1,0 +1,47 @@
+# CrossGen Model Expansion Radar
+
+> Status: Phase 0 planning artifact
+
+## Decision
+
+v0.3.1 does not add large provider-native adapters. It freezes capability contracts and keeps discovered models conservative so agents cannot infer unsupported edit/reference/inpaint/video behavior.
+
+## Current Tracks
+
+| Track | Contract | Confidence | v0.3.1 stance |
+| --- | --- | --- | --- |
+| GPT Image 2 | `openai-image` | `verified` | image generate/edit/inpaint/reference/streaming |
+| Nano Banana 3 / Gemini image | `gemini-generate-content` | `verified` | image generate/edit/reference/outputText |
+| General fallback | compatible or Gemini content route | `assumed` / `discovered` | prompt-only generation for agents |
+
+## Confidence
+
+- `verified`: tests or smoke evidence cover the operation.
+- `discovered`: provider discovery found the model but operation shape is not fully verified.
+- `assumed`: model name suggests image capability only.
+- `unknown`: no safe generation claim.
+
+## v0.3.1 Surface Rules
+
+- Callable `mediaKinds` and `outputAssetKinds` are `["image"]`.
+- `animatedGif` and `video` are false/non-callable.
+- Discovered FLUX, SDXL, Recraft, Imagen, Seedream, Qwen, Ideogram, or similar names do not imply edit/reference/inpaint.
+- OpenAI-compatible General fallback uses minimal prompt-only generation.
+- Models requiring public URL input must set `requiresPublicUrl: true`.
+
+## Radar Candidates
+
+| Candidate | Likely contract | v0.3.1 stance | v0.3.2+ entry criteria |
+| --- | --- | --- | --- |
+| OpenAI-compatible image models | `openai-compatible-minimal` | conservative General fallback | mock smoke and no edit/reference claims |
+| Additional Gemini image models | `gemini-generate-content` | readonly/discovered unless verified | adapter tests per claimed operation |
+| Imagen / Vertex | `provider-native` | radar only | auth/config model and mock adapter |
+| Seedream / Jimeng | `provider-native` | radar only | official API validation and redaction tests |
+| Qwen-Image | provider-native or compatible | radar only | one verified host route |
+| Ideogram | `provider-native` | radar only | parameter/refusal mock coverage |
+| Recraft | provider-native or compatible | radar only | raster-only contract first |
+| Hosted FLUX | provider-native or compatible | radar only | pick one hosted route |
+| Stable Diffusion / SDXL API | `provider-native` | radar only | minimal prompt contract |
+| ComfyUI / local runtime | `local-workflow` | v0.4.0+ | local-runtime permissions and queue stages |
+
+Do not start video/GIF adapter work from this radar.

--- a/docs/plans/v0.3.1-agent-integration-contract.md
+++ b/docs/plans/v0.3.1-agent-integration-contract.md
@@ -1,0 +1,70 @@
+# CrossGen v0.3.1 Agent Integration Contract
+
+> Status: Phase 0 contract freeze
+
+## Rules
+
+- CLI/MCP are agent runtime surfaces, not diagnostics-only utilities.
+- MCP is stdio only and defaults to `readonly`.
+- Write and generate modes are explicit.
+- CLI `--json` writes exactly one JSON object to stdout.
+- Logs and human-readable diagnostics go to stderr.
+- Paid generation requires `--yes` or MCP `confirm: true`.
+- Path disclosure requires explicit confirmation.
+- Secrets and private provider details are redacted.
+
+## Identifiers
+
+- `requestId`: one CLI invocation or MCP call.
+- `correlationId`: optional workflow id.
+- `idempotencyKey`: write/generate duplicate protection.
+- `queueId`: durable execution id.
+- `historyJobId`: user-facing history id.
+- `assetId`: Gallery asset id.
+- `managedPath`: CrossGen-managed path, hidden unless confirmed.
+- `exportedPath`: caller-requested copy destination.
+
+## JSON Envelope
+
+Success:
+
+```json
+{"ok":true,"schemaVersion":1,"requestId":"req_01","data":{}}
+```
+
+Error:
+
+```json
+{"ok":false,"schemaVersion":1,"requestId":"req_01","error":{"code":"CONFIG_NOT_FOUND","message":"CrossGen state was not found.","retryable":false,"nextActions":[]}}
+```
+
+## Required Commands
+
+Discovery:
+
+- `crossgen --version --json`
+- `crossgen doctor --agent --json`
+- `crossgen mcp config --client codex|claude-code|cursor --mode readonly|write|generate --json`
+
+Readonly:
+
+- `config status`, `provider list`, `models list`
+- `queue status`, `job list`, `job status`
+- `folder tree`, `gallery list`, `asset inspect`
+
+Write:
+
+- `folder create|rename|move|delete`
+- `asset import|move|update|remove|open|path|export`
+
+Generate:
+
+- `generate`, `edit`, `job cancel`, `job retry`, `queue config get|set`
+
+## MCP Modes
+
+- `readonly`: read tools only.
+- `write`: readonly plus Gallery mutation/export.
+- `generate`: write plus generate/edit/cancel/retry/queue config.
+
+Higher-mode tools are not registered in lower modes.

--- a/docs/plans/v0.3.1-generation-queue-audit.md
+++ b/docs/plans/v0.3.1-generation-queue-audit.md
@@ -1,0 +1,54 @@
+# CrossGen v0.3.1 Generation Queue Audit
+
+> Date: 2026-07-13
+> Baseline: `main@c18985b1b3b476a0c351d58447cc340600c4c583`
+
+## Current Desktop Path
+
+```text
+renderer App.runJob()
+  -> preload bridge.runJob()
+  -> ipcMain "job:run"
+  -> handleRunJob()
+  -> provider adapter runJob()
+  -> upsert history job
+  -> return GenerationJob
+```
+
+The renderer currently waits for the provider call to finish. Queue introduction must preserve that desktop facade.
+
+## Risks
+
+- `galleryOperationQueue` serializes only one Electron process.
+- State writes have tmp+rename but no cross-process lock.
+- History is capped and cannot be queue truth.
+- Startup recovery currently maps queued/running history jobs to failed; durable queue needs stale running to become interrupted.
+- Cancel is process-local through `AbortController`.
+- Queue items must persist resolved provider id and normalized request.
+- Queue must never persist API keys.
+- Partial outputs must remain visible and retained.
+
+## Extraction Order
+
+1. `dataDirs`, `stateStore`, `keyring`, `events`.
+2. `queueStore` with lock and worker heartbeat.
+3. Provider selection and capability contract.
+4. `generation` request normalization and adapter orchestration.
+5. `generationQueue` scheduler and desktop facade.
+6. Gallery mutation under shared critical sections.
+
+## Acceptance Matrix
+
+- queued -> running -> succeeded
+- queued -> cancelled
+- running -> failed
+- running -> interrupted after stale lease
+- retry transient 429/5xx with backoff
+- no automatic retry for auth/quota/safety/interrupted
+- failed_with_outputs preserves outputs
+- default global concurrency 1
+- mock global concurrency 2
+- provider concurrency cap
+- two worker hosts do not over-claim
+- no live worker host returns `NO_LIVE_QUEUE_WORKER`
+- desktop Promise and events remain compatible

--- a/docs/plans/v0.3.1-image-core-regression-checklist.md
+++ b/docs/plans/v0.3.1-image-core-regression-checklist.md
@@ -1,0 +1,41 @@
+# CrossGen v0.3.1 Image Core Regression Checklist
+
+Run after every phase that changes generation, queue, providers, Gallery, or image editing.
+
+## Desktop Generation
+
+- OpenAI text-to-image preserves size, quality, format, background, moderation, route, and timeout.
+- OpenAI image-to-image sends selected reference images.
+- OpenAI inpaint sends mask and input image.
+- OpenAI partial streaming preserves partial and final outputs.
+- Gemini text-to-image honors aspect ratio, resolution, output count, thinking, search grounding, and timeout.
+- Gemini image-to-image sends reference images.
+- General fallback remains prompt-only for agents unless verified.
+- Provider switching does not change queued request provider ids.
+- User-configured timeout is respected by workers.
+
+## Desktop UX
+
+- Existing `job:run` Promise resolves to `GenerationJob`.
+- Existing job events reach the renderer.
+- User can cancel a running desktop generation.
+- Waiting timer and attempt display still work.
+- History duration display still works.
+
+## Gallery And Editing
+
+- Generated outputs can be downloaded and added to Gallery.
+- Gallery import, move, tag, rename, remove, and export remain image-safe.
+- History and Gallery tags remain unified.
+- Duplicate import prompts cancel/replace/copy.
+- Canvas export is not tainted.
+- Edited image download/save includes annotations.
+- Text boxes and drawings remain anchored to image coordinates and scale with zoom.
+- Crop selected region can be saved as a separate Gallery asset.
+
+## Agent Surfaces
+
+- CLI `--json` emits one JSON object only.
+- MCP does not expose keys or paths unless explicitly confirmed.
+- `models list` does not expose video/GIF as callable.
+- Async generation without live worker returns `NO_LIVE_QUEUE_WORKER`.

--- a/docs/plans/v0.3.1-plan.md
+++ b/docs/plans/v0.3.1-plan.md
@@ -1,0 +1,191 @@
+# CrossGen v0.3.1 CLI + MCP Master Plan
+
+> Updated: 2026-07-13
+> Baseline: `main@c18985b1b3b476a0c351d58447cc340600c4c583`
+> Source: `/Users/alive/Library/CloudStorage/SynologyDrive-ob/Alive/Dev/image2tools/Library/0.3.x/CrossGen v0.3.1 CLI + MCP 主计划.md`
+
+## Decision
+
+v0.3.1 is an agent-ready local runtime release, not a diagnostics-only CLI/MCP release. It is complete only when a local agent can:
+
+```text
+discover provider/model/capability
+  -> submit generate/edit work
+  -> execute through durable queue
+  -> poll job status
+  -> manage/export Gallery assets
+```
+
+Existing desktop image workflows must not regress: generation, edit, inpaint, OpenAI partial streaming, Gemini reference images, provider switching, Gallery import/move/download, and image editing remain protected.
+
+## Boundaries
+
+- No HTTP server and no local port.
+- MCP uses stdio only.
+- CLI/MCP default to `readonly`.
+- Write and generate modes must be explicit.
+- Paid generation requires `--yes` or MCP `confirm: true`.
+- Generation always goes through the queue.
+- Default concurrency is `1`; higher concurrency is explicit and bounded.
+- API keys are resolved through keyring and never persisted to queue/stdout/MCP results.
+- Local path disclosure requires explicit confirmation.
+- v0.3.1 is image-only; video/GIF fields are non-callable forward-compatible metadata.
+- No large provider adapter sweep in v0.3.1.
+
+## Current Baseline
+
+- Package name: `crossgen`; product name: `CrossGen`; package version: `0.3.0`.
+- Legacy userData remains `Image2Tools`; state file remains `image2tools-state.v1.json`.
+- `src/main/main.ts` still owns Electron lifecycle, IPC, state, safeStorage, Gallery mutation, provider execution, dialog, and shell.
+- No `src/core`, `src/cli`, or `src/mcp` existed before this phase.
+- `galleryOperationQueue` is process-local.
+- `job:run` executes adapters directly and writes history, not durable queue state.
+- `JobStatus` needs `cancelled` and `interrupted`.
+- Provider adapters already accept runtime injection and are reusable.
+
+## Target Architecture
+
+```text
+src/core/
+  dataDirs.ts
+  stateStore.ts
+  queueStore.ts
+  keyring.ts
+  providers.ts
+  modelCapabilities.ts
+  gallery.ts
+  generation.ts
+  generationQueue.ts
+  mediaTypes.ts
+  events.ts
+
+src/main/
+  Electron lifecycle, UI IPC, safeStorage keyring, BrowserWindow event sink
+
+src/cli/
+  command parser, JSON stdout contract, command-mode bootstrap
+
+src/mcp/
+  stdio server, tool schemas, mode-based registration
+```
+
+Rules:
+
+- `src/core` must not import `electron`.
+- State and queue writes share one cross-process lock.
+- Gallery file mutation and matching state write happen in one critical section.
+- CLI and MCP call core APIs directly; MCP does not shell out to CLI.
+- BrowserWindow, safeStorage, dialog, shell, and native image serving stay outside core.
+
+## Agent Contract
+
+Required discovery:
+
+- `crossgen --version --json`
+- `crossgen doctor --agent --json`
+- `crossgen mcp config --client codex|claude-code|cursor --mode readonly|write|generate --json`
+
+Every CLI/MCP result includes `schemaVersion: 1`, `requestId`, optional `correlationId`, and either `data` or structured `error`.
+
+Stable errors include `CONFIG_NOT_FOUND`, `API_KEY_MISSING`, `CONFIRMATION_REQUIRED`, `NO_LIVE_QUEUE_WORKER`, `CAPABILITY_UNSUPPORTED`, `UNSUPPORTED_IN_THIS_VERSION`, `RATE_LIMITED`, `PROVIDER_ERROR`, `LOCK_TIMEOUT`, `PATH_NOT_ALLOWED`, and `ASSET_NOT_FOUND`.
+
+Write/generate operations accept `idempotencyKey` when repeated agent calls could duplicate cost or file mutation.
+
+## Queue Semantics
+
+Queue file: `crossgen-queue.v1.json`.
+
+Queue item fields include `queueId`, `source`, `providerId`, normalized `request`, `status`, priority, attempt counters, timestamps, `lastError`, `historyJobId`, `outputAssetIds`, `cancelRequested`, `costConfirmed`, worker host/heartbeat/lease fields, `executionKind`, `stage`, remote poll/local step reserved fields, `outputMediaKinds`, `idempotencyKey`, `requestId`, and `correlationId`.
+
+Rules:
+
+- History is user-visible; queue is execution truth.
+- Queue cannot depend on history retention.
+- Stale `running` items recover to `interrupted`.
+- `interrupted` never retries without explicit confirmation.
+- `remoteJobHandle` prevents blind resubmit after crash.
+- `stage` is secondary; `status` is the public coarse state.
+
+## Worker Hosts
+
+Allowed:
+
+- Desktop Electron main.
+- `CrossGen --mcp` with `CROSSGEN_MCP_MODE=generate`.
+- `CrossGen --cli generate --wait` or explicit CLI worker.
+
+`--async` can return queue id only when a live worker host exists. Without one, it returns `NO_LIVE_QUEUE_WORKER`.
+
+## Capability Contract
+
+`src/shared/types.ts` owns capability types; `src/core/modelCapabilities.ts` computes them.
+
+Additional agent fields include `asyncJob`, `mediaKinds`, `outputAssetKinds`, `requiresPublicUrl`, `supportsBase64Input`, `estimatedCostSignals`, `supportsLocalRuntime`, `animatedGif`, `video`, `videoRouteStrategy`, `contract`, and `confidence`.
+
+v0.3.1 stance:
+
+- GPT Image 2: `verified`, `openai-image`, image generate/edit/inpaint/reference/streaming.
+- Nano Banana 3 / Gemini image: `verified`, `gemini-generate-content`, image generate/edit/reference/outputText.
+- General fallback: prompt-only generation for agents.
+- Discovered image-like models: conservative prompt-only unless verified.
+- Video and animated GIF are not callable.
+
+## Phases
+
+### Phase 0: Plan, Runtime Spike, Contract Freeze
+
+Deliver this plan, runtime spike note, queue audit, agent contract, model radar, image regression checklist, worker host design, v0.4.0 foundation note, shared queue/CLI/capability types, and initial no-window command mode spike.
+
+Acceptance: `pnpm build`, macOS dev command mode smoke, stable JSON contracts, frozen no-live-worker async behavior, reproducible image core regression checklist.
+
+### Phase 1: Core Extraction + State / Queue Lock
+
+Deliver `dataDirs`, `stateStore`, `queueStore`, `keyring`, `events`, `providers`, `gallery`, and `mediaTypes`.
+
+Acceptance: old state reads/writes, Gallery tests pass, lock covers state/queue/Gallery critical sections, stale lock tests pass, desktop behavior unchanged.
+
+### Phase 2: Durable Queue + Bounded Workers
+
+Deliver `generation`, `generationQueue`, worker scheduler, and desktop `job:run` compatibility facade.
+
+Acceptance: queue state transitions, retry/cancel/interrupted recovery, partial output retention, concurrency 1/2 tests, two-host claim test, provider cap test, desktop event compatibility.
+
+### Phase 3: Readonly CLI + Readonly MCP
+
+Deliver config/provider/models/queue/job/folder/gallery/asset readonly commands, `doctor --agent`, `mcp config`, and MCP readonly tools.
+
+Acceptance: JSON snapshots, MCP readonly default, no key/path leakage, capability output, doctor and config snippets.
+
+### Phase 4: Gallery Asset Management
+
+Deliver folder and asset write commands/tools, path/export confirmation, idempotent export, and write mode registration.
+
+Acceptance: path traversal/symlink/illegal filename/Windows reserved tests, watcher sync, concurrent mutation safety, existing Gallery behavior preserved.
+
+### Phase 5: CLI/MCP Generation + Edit
+
+Deliver generate/edit, batch prompt file, async/wait, MCP `generate_image`/`edit_image`, cancel/retry, cost confirmation, idempotency, and Gallery output integration.
+
+Acceptance: mock OpenAI/Gemini generation, env key fallback, safeStorage command mode where available, unsupported capability errors, generate tools only in generate mode, full agent smoke.
+
+### Phase 6: Docs, Packaging, Release Gate
+
+Deliver CLI docs, MCP examples, Codex/Claude Code/Cursor integration examples, queue docs, known limitations, and release evidence.
+
+Acceptance: `pnpm build`, mock API verifiers, packaged CLI smoke, MCP readonly/generate smoke, agent integration smoke, queue concurrency smoke, Gallery mutation smoke, image core regression checklist.
+
+## Branch Plan
+
+Each branch starts from latest `origin/main` in its own worktree:
+
+1. `feat/v0.3.1-runtime-contracts`
+2. `feat/v0.3.1-core-state-queue-lock`
+3. `feat/v0.3.1-generation-queue-workers`
+4. `feat/v0.3.1-cli-readonly`
+5. `feat/v0.3.1-mcp-readonly`
+6. `feat/v0.3.1-gallery-asset-management`
+7. `feat/v0.3.1-agent-generation`
+8. `research/v0.3.1-model-expansion-radar`
+9. `release/v0.3.1`
+
+Reports must include worktree path, branch, base SHA, ahead/behind, dirty status, validation commands, queue/parallel evidence, risks, and cleanup records.

--- a/docs/plans/v0.3.1-runtime-spike.md
+++ b/docs/plans/v0.3.1-runtime-spike.md
@@ -1,0 +1,35 @@
+# CrossGen v0.3.1 Runtime Spike
+
+> Date: 2026-07-13
+> Branch: `feat/v0.3.1-runtime-contracts`
+
+## Goal
+
+Prove Electron can enter no-window command mode before BrowserWindow, IPC handlers, asset protocol, and Gallery watchers start.
+
+Preferred production entry:
+
+```bash
+CrossGen --cli <command> [--json]
+CrossGen --mcp
+```
+
+Pure Node is not assumed to decrypt Electron `safeStorage`.
+
+## Phase 0 Spike
+
+Supported now:
+
+```bash
+electron . --cli --version --json
+electron . --cli doctor --agent --json
+```
+
+The command path runs after `app.whenReady()` and legacy userData path preservation, then exits before normal desktop startup.
+
+## Required Follow-Up
+
+- Move command parsing into `src/cli`.
+- Add `--data-dir`, `--correlation-id`, mode parsing, and `mcp config`.
+- Add packaged macOS/Windows/Linux smoke evidence.
+- Keep no-window command mode covered by smoke tests.

--- a/docs/plans/v0.3.1-worker-host-design.md
+++ b/docs/plans/v0.3.1-worker-host-design.md
@@ -1,0 +1,38 @@
+# CrossGen v0.3.1 Worker Host And Async Execution Design
+
+## Worker Hosts
+
+Allowed hosts:
+
+- Desktop Electron main process.
+- MCP process running `CrossGen --mcp` with `CROSSGEN_MCP_MODE=generate`.
+- CLI process running a wait/worker command.
+
+No background daemon is started implicitly.
+
+## Heartbeat And Lease
+
+Each worker host writes `hostId`, `kind`, `processId`, `mode`, `heartbeatAt`, `leaseExpiresAt`, and keyring capability summary. Only non-expired leases count as live workers.
+
+## Claim Rules
+
+- Claim happens under the shared state/queue lock.
+- Running count is derived from durable queue items with valid leases.
+- Stale running items recover to `interrupted` before new claims.
+- Provider and global caps are enforced inside the lock.
+- A worker cannot claim work if its keyring cannot resolve the queued provider key.
+
+## Async Rules
+
+- `--async` requires a live worker host.
+- If no worker host exists, return `NO_LIVE_QUEUE_WORKER`.
+- `--wait` allows the current CLI process to act as a worker.
+- MCP generate mode can return queue id and continue processing as a host.
+- Desktop host can consume CLI/MCP-submitted queue items.
+
+## Cancellation
+
+- Queued cancel is reliable and sets `cancelled`.
+- Running cancel sets durable `cancelRequested`.
+- Owning host converts `cancelRequested` to `AbortController.abort()`.
+- Non-owning callers return `cancel_requested` or `not_owner_or_not_running`.

--- a/docs/plans/v0.4.0-foundation-note.md
+++ b/docs/plans/v0.4.0-foundation-note.md
@@ -1,0 +1,26 @@
+# CrossGen v0.4.0 Foundation Note From v0.3.1
+
+v0.3.1 may add forward-compatible fields required by future media and long-running workflows, but it must not expose unimplemented product features.
+
+## Allowed In v0.3.1
+
+- `MediaKind`: `image | animated-gif | video`.
+- Optional `ImageAsset.kind` and `GalleryAsset.kind`.
+- Queue `executionKind`: `sync-provider | remote-poll | local-cpu`.
+- Queue `stage` values for remote polling and local postprocessing.
+- `remoteJobHandle`, `remoteProviderStatus`, `remoteExpiresAt`, `lastPollAt`.
+- `localStep` and `sourceAssetIds`.
+- Capability fields `video`, `animatedGif`, and `videoRouteStrategy` as non-callable metadata.
+
+## Not Allowed In v0.3.1
+
+- No video generation UI.
+- No GIF generation UI.
+- No `generate_video` MCP tool.
+- No automatic frame extraction or poster generation.
+- No local model download or GPU runtime manager.
+- No silent local server or port assumption.
+
+## Compatibility Rule
+
+Old history and Gallery assets without `kind` behave exactly like image assets. Media-aware helpers must not change download, edit, Gallery thumbnail, tag, search, or folder behavior for existing images.

--- a/src/core/modelCapabilities.test.ts
+++ b/src/core/modelCapabilities.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { GENERAL_LAUNCH_ID, GPT_IMAGE_2_LAUNCH_ID, NANO_BANANA_3_LAUNCH_ID } from "../shared/modelCatalog";
+import type { ProviderConfig } from "../shared/types";
+import { capabilityContractForFocusedModel, capabilitySummaryForDiscoveredModel, listProviderModelCapabilitySummaries } from "./modelCapabilities";
+import { getFocusedModelDefinition } from "../shared/modelCatalog";
+
+function provider(patch: Partial<ProviderConfig> = {}): ProviderConfig {
+  const now = "2026-07-13T00:00:00.000Z";
+  return {
+    id: "provider-openai",
+    kind: "openai",
+    name: "OpenAI",
+    apiKeySaved: true,
+    baseURL: "https://api.openai.com/v1",
+    enabled: true,
+    defaultModel: "gpt-image-2",
+    defaultSize: "1024x1024",
+    defaultQuality: "auto",
+    timeoutMs: 120000,
+    streamingPartialsEnabled: false,
+    discoveredModels: [],
+    activeLaunchId: GPT_IMAGE_2_LAUNCH_ID,
+    activeModelId: "gpt-image-2",
+    updatedAt: now,
+    ...patch
+  };
+}
+
+describe("model capability contracts", () => {
+  it("marks GPT Image 2 as verified image-only OpenAI image capability", () => {
+    const definition = getFocusedModelDefinition(GPT_IMAGE_2_LAUNCH_ID);
+    expect(definition).toBeDefined();
+
+    const contract = capabilityContractForFocusedModel(definition!);
+
+    expect(contract).toMatchObject({
+      generate: true,
+      edit: true,
+      inpaint: "exact-mask",
+      referenceImages: true,
+      streamingPartials: true,
+      asyncJob: false,
+      mediaKinds: ["image"],
+      outputAssetKinds: ["image"],
+      animatedGif: false,
+      video: false,
+      videoRouteStrategy: "none",
+      contract: "openai-image",
+      confidence: "verified"
+    });
+  });
+
+  it("marks Nano Banana 3 as verified Gemini image-only capability", () => {
+    const definition = getFocusedModelDefinition(NANO_BANANA_3_LAUNCH_ID);
+    expect(definition).toBeDefined();
+
+    const contract = capabilityContractForFocusedModel(definition!);
+
+    expect(contract).toMatchObject({
+      generate: true,
+      edit: true,
+      inpaint: "guided-region",
+      referenceImages: true,
+      streamingPartials: false,
+      outputText: true,
+      mediaKinds: ["image"],
+      animatedGif: false,
+      video: false,
+      contract: "gemini-generate-content",
+      confidence: "verified"
+    });
+  });
+
+  it("keeps General fallback prompt-only for agents", () => {
+    const definition = getFocusedModelDefinition(GENERAL_LAUNCH_ID);
+    expect(definition).toBeDefined();
+
+    const contract = capabilityContractForFocusedModel(definition!);
+
+    expect(contract).toMatchObject({
+      generate: true,
+      edit: false,
+      inpaint: false,
+      referenceImages: false,
+      maxReferenceImages: 0,
+      mediaKinds: ["image"],
+      animatedGif: false,
+      video: false,
+      contract: "openai-compatible-minimal",
+      confidence: "assumed"
+    });
+  });
+
+  it("reports discovered image-like models conservatively", () => {
+    const discovered = capabilitySummaryForDiscoveredModel("custom-provider", {
+      id: "flux-pro",
+      providerKind: "custom",
+      displayName: "Flux Pro"
+    });
+
+    expect(discovered).toMatchObject({
+      providerId: "custom-provider",
+      source: "discovered",
+      capabilities: {
+        generate: true,
+        edit: false,
+        referenceImages: false,
+        contract: "openai-compatible-minimal",
+        confidence: "discovered",
+        video: false,
+        animatedGif: false
+      }
+    });
+  });
+
+  it("lists provider focused, active general, and discovered capabilities without duplicates", () => {
+    const summaries = listProviderModelCapabilitySummaries(
+      provider({
+        activeLaunchId: GENERAL_LAUNCH_ID,
+        activeModelId: "dall-e-3",
+        discoveredModels: [
+          { id: "gpt-image-2", providerKind: "openai" },
+          { id: "dall-e-3", providerKind: "openai" },
+          { id: "text-only", providerKind: "openai" }
+        ]
+      })
+    );
+
+    expect(summaries.map((summary) => summary.modelId)).toEqual(["gpt-image-2", "general", "dall-e-3", "text-only"]);
+    expect(summaries.find((summary) => summary.modelId === "text-only")?.capabilities.confidence).toBe("unknown");
+    expect(summaries.find((summary) => summary.modelId === "dall-e-3")?.capabilities).toMatchObject({
+      generate: true,
+      edit: false,
+      confidence: "discovered"
+    });
+  });
+});

--- a/src/core/modelCapabilities.ts
+++ b/src/core/modelCapabilities.ts
@@ -1,0 +1,205 @@
+import {
+  FOCUSED_MODEL_CATALOG,
+  GENERAL_LAUNCH_ID,
+  GPT_IMAGE_2_LAUNCH_ID,
+  NANO_BANANA_3_LAUNCH_ID,
+  getFocusedModelsForProvider,
+  getModelDisplayName,
+  isFocusedImageModelId,
+  isPotentialGeneralImageModel,
+  normalizeModelId
+} from "../shared/modelCatalog.js";
+import type {
+  DiscoveredModel,
+  FocusedLaunchId,
+  FocusedModelDefinition,
+  ImageCapabilityConfidence,
+  ImageCapabilityContractKind,
+  ImageModelCapabilities,
+  ImageModelCapabilityContract,
+  MediaKind,
+  ProviderConfig,
+  ProviderKind,
+  VideoRouteStrategy
+} from "../shared/types.js";
+
+export type ModelCapabilitySource = "focused-catalog" | "discovered" | "general-fallback" | "unknown";
+
+export interface ModelCapabilitySummary {
+  providerId?: string;
+  providerKind: ProviderKind;
+  modelId: string;
+  displayName: string;
+  launchId?: FocusedLaunchId;
+  source: ModelCapabilitySource;
+  capabilities: ImageModelCapabilityContract;
+}
+
+const IMAGE_MEDIA_KINDS: MediaKind[] = ["image"];
+
+const NO_VIDEO_ROUTE: VideoRouteStrategy = "none";
+
+function imageOnlyKinds(): MediaKind[] {
+  return [...IMAGE_MEDIA_KINDS];
+}
+
+function focusedContractKind(launchId: FocusedLaunchId, providerKind: ProviderKind): ImageCapabilityContractKind {
+  if (launchId === GPT_IMAGE_2_LAUNCH_ID) return "openai-image";
+  if (launchId === NANO_BANANA_3_LAUNCH_ID) return "gemini-generate-content";
+  return providerKind === "gemini" ? "gemini-generate-content" : "openai-compatible-minimal";
+}
+
+function baseContract(
+  capabilities: ImageModelCapabilities,
+  contract: ImageCapabilityContractKind,
+  confidence: ImageCapabilityConfidence
+): ImageModelCapabilityContract {
+  return {
+    ...capabilities,
+    asyncJob: false,
+    mediaKinds: imageOnlyKinds(),
+    outputAssetKinds: imageOnlyKinds(),
+    requiresPublicUrl: false,
+    supportsBase64Input: true,
+    estimatedCostSignals: true,
+    supportsLocalRuntime: false,
+    animatedGif: false,
+    video: false,
+    videoRouteStrategy: NO_VIDEO_ROUTE,
+    contract,
+    confidence
+  };
+}
+
+function promptOnlyCapabilities(providerKind: ProviderKind, confidence: ImageCapabilityConfidence): ImageModelCapabilityContract {
+  return baseContract(
+    {
+      generate: true,
+      edit: false,
+      inpaint: false,
+      referenceImages: false,
+      maxReferenceImages: 0,
+      multiTurn: false,
+      streamingPartials: false,
+      outputText: false,
+      configurableOutputFormat: false,
+      configurableResolution: "none",
+      supportsThinking: false,
+      supportsSearchGrounding: false
+    },
+    providerKind === "gemini" ? "gemini-generate-content" : "openai-compatible-minimal",
+    confidence
+  );
+}
+
+function unknownCapabilities(): ImageModelCapabilityContract {
+  return baseContract(
+    {
+      generate: false,
+      edit: false,
+      inpaint: false,
+      referenceImages: false,
+      maxReferenceImages: 0,
+      multiTurn: false,
+      streamingPartials: false,
+      outputText: false,
+      configurableOutputFormat: false,
+      configurableResolution: "none",
+      supportsThinking: false,
+      supportsSearchGrounding: false
+    },
+    "provider-native",
+    "unknown"
+  );
+}
+
+export function capabilityContractForFocusedModel(definition: FocusedModelDefinition): ImageModelCapabilityContract {
+  if (definition.launchId === GENERAL_LAUNCH_ID) {
+    return promptOnlyCapabilities(definition.providerKind, "assumed");
+  }
+  return baseContract(definition.capabilities, focusedContractKind(definition.launchId, definition.providerKind), "verified");
+}
+
+function summaryForFocusedModel(providerId: string | undefined, definition: FocusedModelDefinition, modelId = definition.defaultModelId): ModelCapabilitySummary {
+  return {
+    providerId,
+    providerKind: definition.providerKind,
+    modelId,
+    displayName: getModelDisplayName(definition.launchId, modelId),
+    launchId: definition.launchId,
+    source: definition.launchId === GENERAL_LAUNCH_ID ? "general-fallback" : "focused-catalog",
+    capabilities: capabilityContractForFocusedModel(definition)
+  };
+}
+
+function focusedDefinitionForModel(providerKind: ProviderKind, modelId: string): FocusedModelDefinition | undefined {
+  const normalized = normalizeModelId(modelId);
+  return FOCUSED_MODEL_CATALOG.find(
+    (definition) =>
+      definition.launchId !== GENERAL_LAUNCH_ID &&
+      definition.providerKind === providerKind &&
+      definition.modelIds.some((candidate) => normalizeModelId(candidate) === normalized)
+  );
+}
+
+export function capabilitySummaryForDiscoveredModel(providerId: string | undefined, model: DiscoveredModel): ModelCapabilitySummary {
+  const focusedDefinition = focusedDefinitionForModel(model.providerKind, model.id);
+  if (focusedDefinition) {
+    return summaryForFocusedModel(providerId, focusedDefinition, model.id);
+  }
+
+  const displayName = model.displayName?.trim() || model.id;
+  if (isPotentialGeneralImageModel(model)) {
+    return {
+      providerId,
+      providerKind: model.providerKind,
+      modelId: model.id,
+      displayName,
+      source: "discovered",
+      capabilities: promptOnlyCapabilities(model.providerKind, "discovered")
+    };
+  }
+
+  return {
+    providerId,
+    providerKind: model.providerKind,
+    modelId: model.id,
+    displayName,
+    source: "unknown",
+    capabilities: unknownCapabilities()
+  };
+}
+
+export function listProviderModelCapabilitySummaries(provider: ProviderConfig): ModelCapabilitySummary[] {
+  const summaries = new Map<string, ModelCapabilitySummary>();
+
+  for (const definition of getFocusedModelsForProvider(provider.kind)) {
+    summaries.set(`${definition.providerKind}:${normalizeModelId(definition.defaultModelId)}`, summaryForFocusedModel(provider.id, definition));
+  }
+
+  for (const model of provider.discoveredModels) {
+    const summary = capabilitySummaryForDiscoveredModel(provider.id, model);
+    summaries.set(`${summary.providerKind}:${normalizeModelId(summary.modelId)}`, summary);
+  }
+
+  if (
+    provider.activeLaunchId === GENERAL_LAUNCH_ID &&
+    provider.activeModelId &&
+    !isFocusedImageModelId(provider.kind, provider.activeModelId)
+  ) {
+    const activeGeneralKey = `${provider.kind}:${normalizeModelId(provider.activeModelId)}`;
+    if (!summaries.has(activeGeneralKey)) {
+      summaries.set(activeGeneralKey, {
+        providerId: provider.id,
+        providerKind: provider.kind,
+        modelId: provider.activeModelId,
+        displayName: provider.activeModelId,
+        launchId: GENERAL_LAUNCH_ID,
+        source: "general-fallback",
+        capabilities: promptOnlyCapabilities(provider.kind, "assumed")
+      });
+    }
+  }
+
+  return [...summaries.values()];
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,6 +18,9 @@ import { fileURLToPath } from "node:url";
 import type {
   AppSnapshot,
   ConnectionTestResult,
+  CrossGenJsonErrorCode,
+  CrossGenJsonFailure,
+  CrossGenJsonResponse,
   DownloadRequest,
   EditedImageDownloadRequest,
   EditedGalleryImageInput,
@@ -139,6 +142,7 @@ const PERF_RESULT_PATH_ENV = "CROSSGEN_PERF_RESULT_PATH";
 const RENDERER_PERF_RESULT_PATH_ENV = "CROSSGEN_RENDERER_PERF_RESULT_PATH";
 const THEME_SOURCE_ENV = "CROSSGEN_THEME_SOURCE";
 const RENDERER_SCREENSHOT_DIR_ENV = "CROSSGEN_RENDERER_SCREENSHOT_DIR";
+const CLI_SCHEMA_VERSION = 1;
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -587,7 +591,11 @@ function sanitizeError(error: unknown): string {
 }
 
 function redactLikelySecrets(value: string): string {
-  return value.replace(/sk-[A-Za-z0-9_-]{8,}/g, "sk-...redacted");
+  return value
+    .replace(/sk-[A-Za-z0-9_-]{8,}/g, "sk-...redacted")
+    .replace(/AIza[A-Za-z0-9_-]{8,}/g, "AIza...redacted")
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer ...redacted")
+    .replace(/([?&]key=)[^&\s]+/gi, "$1...redacted");
 }
 
 function getUpdatesDir(): string {
@@ -3054,6 +3062,169 @@ async function runRendererPerformanceCapture(window: BrowserWindow, resultPath: 
   );
 }
 
+function getCliCommandArgs(): string[] | null {
+  const cliIndex = process.argv.indexOf("--cli");
+  if (cliIndex < 0) return null;
+  return process.argv.slice(cliIndex + 1);
+}
+
+function hasCliFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function getCliOption(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function getCliRequestId(args: string[]): string {
+  return getCliOption(args, "--request-id")?.trim() || `req_${randomUUID()}`;
+}
+
+function getCliCorrelationId(args: string[], requestId: string): string {
+  return getCliOption(args, "--correlation-id")?.trim() || requestId;
+}
+
+function getCliCommand(args: string[]): string | undefined {
+  return args.find((arg) => !arg.startsWith("--"));
+}
+
+function writeCliJson(response: CrossGenJsonResponse): void {
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+function cliSuccess(requestId: string, correlationId: string, data: Record<string, unknown>): CrossGenJsonResponse<Record<string, unknown>> {
+  return {
+    ok: true,
+    schemaVersion: CLI_SCHEMA_VERSION,
+    requestId,
+    correlationId,
+    data
+  };
+}
+
+function cliFailure(
+  requestId: string,
+  correlationId: string,
+  code: CrossGenJsonErrorCode,
+  message: string,
+  nextActions: string[] = []
+): CrossGenJsonFailure {
+  return {
+    ok: false,
+    schemaVersion: CLI_SCHEMA_VERSION,
+    requestId,
+    correlationId,
+    error: {
+      code,
+      message: redactLikelySecrets(message),
+      retryable: false,
+      nextActions
+    }
+  };
+}
+
+async function readExistingStateForCli(): Promise<AppStateFile | null> {
+  try {
+    return normalizeState(await readStateFile(getStatePath()));
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function envApiKeyAvailable(kind: StoredProviderConfig["kind"]): boolean {
+  const providerSpecific = kind === "gemini" ? "CROSSGEN_GEMINI_API_KEY" : kind === "custom" ? "CROSSGEN_CUSTOM_API_KEY" : "CROSSGEN_OPENAI_API_KEY";
+  return Boolean(process.env[providerSpecific]?.trim() || process.env.CROSSGEN_API_KEY?.trim());
+}
+
+function savedApiKeyPresentForCli(config: StoredProviderConfig): boolean {
+  return Boolean(config.encryptedApiKey);
+}
+
+async function runCliCommandMode(args: string[]): Promise<number> {
+  const requestId = getCliRequestId(args);
+  const correlationId = getCliCorrelationId(args, requestId);
+  const json = hasCliFlag(args, "--json");
+  const command = getCliCommand(args);
+
+  try {
+    if (hasCliFlag(args, "--version") || command === "version") {
+      const data = {
+        appName: BRAND_NAME,
+        appVersion: getAppVersion(),
+        schemaVersion: CLI_SCHEMA_VERSION,
+        commandMode: "electron",
+        userDataDir: app.getPath("userData")
+      };
+      if (json) {
+        writeCliJson(cliSuccess(requestId, correlationId, data));
+      } else {
+        process.stdout.write(`${BRAND_NAME} ${getAppVersion()}\n`);
+      }
+      return 0;
+    }
+
+    if (command === "doctor" && hasCliFlag(args, "--agent")) {
+      const state = await readExistingStateForCli();
+      const activeProvider = state ? state.providers.find((provider) => provider.id === state.activeProviderId) ?? state.providers[0] : undefined;
+      const data = {
+        appVersion: getAppVersion(),
+        cliExecutable: process.execPath,
+        packagedExecutable: app.isPackaged ? process.execPath : null,
+        mcpCommand: process.execPath,
+        recommendedArgs: ["--mcp"],
+        dataDir: app.getPath("userData"),
+        statePath: getStatePath(),
+        stateFound: Boolean(state),
+        activeProvider: activeProvider
+          ? {
+              id: activeProvider.id,
+              kind: activeProvider.kind,
+              name: activeProvider.name,
+              enabled: activeProvider.enabled,
+              activeLaunchId: activeProvider.activeLaunchId,
+              activeModelId: activeProvider.activeModelId
+            }
+          : null,
+        apiKeyAvailable: activeProvider ? envApiKeyAvailable(activeProvider.kind) || savedApiKeyPresentForCli(activeProvider) : false,
+        liveWorkerHost: false,
+        permissions: {
+          cliMode: "readonly-spike",
+          mcpDefaultMode: "readonly",
+          writeModeRequiresExplicitEnable: true,
+          generateModeRequiresExplicitEnable: true,
+          paidGenerationRequiresConfirmation: true,
+          pathDisclosureRequiresConfirmation: true
+        },
+        knownLimitations: [
+          "v0.3.1 command mode is in Phase 0 spike state.",
+          "Durable queue, MCP stdio server, Gallery write tools, and generation tools are not implemented yet.",
+          "Use the desktop app for production image generation until the v0.3.1 queue path lands."
+        ]
+      };
+      writeCliJson(cliSuccess(requestId, correlationId, data));
+      return 0;
+    }
+
+    const response = cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Unsupported CrossGen CLI command.", [
+      "Use --cli --version --json.",
+      "Use --cli doctor --agent --json."
+    ]);
+    if (json) {
+      writeCliJson(response);
+    } else {
+      process.stderr.write(`${response.error.message}\n`);
+    }
+    return 2;
+  } catch (error) {
+    writeCliJson(cliFailure(requestId, correlationId, "UNKNOWN_ERROR", normalizeError(error)));
+    return 1;
+  }
+}
+
 function registerIpcHandlers(): void {
   ipcMain.handle("app:getSnapshot", () => runGalleryOperation(handleGetSnapshot));
   ipcMain.handle("config:save", handleSaveConfig);
@@ -3108,6 +3279,12 @@ app.whenReady().then(async () => {
     nativeTheme.themeSource = themeSource;
   }
   preserveLegacyUserDataPath();
+  const cliCommandArgs = getCliCommandArgs();
+  if (cliCommandArgs) {
+    const exitCode = await runCliCommandMode(cliCommandArgs);
+    app.exit(exitCode);
+    return;
+  }
   registerIpcHandlers();
   registerAssetProtocol();
   const performanceResultPath = process.env[PERF_RESULT_PATH_ENV];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,7 +12,38 @@ export type ImageBackground = "auto" | "opaque";
 
 export type ModerationMode = "auto" | "low";
 
-export type JobStatus = "queued" | "running" | "succeeded" | "failed";
+export type JobStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled" | "interrupted";
+
+export type MediaKind = "image" | "animated-gif" | "video";
+
+export type QueueSource = "desktop" | "cli" | "mcp";
+
+export type QueueExecutionKind = "sync-provider" | "remote-poll" | "local-cpu";
+
+export type QueueStage =
+  | "queued"
+  | "claiming"
+  | "calling_provider"
+  | "awaiting_remote"
+  | "downloading"
+  | "postprocessing"
+  | "finalizing";
+
+export type ImageCapabilityContractKind =
+  | "openai-image"
+  | "gemini-generate-content"
+  | "openai-compatible-minimal"
+  | "provider-native"
+  | "local-workflow";
+
+export type ImageCapabilityConfidence = "verified" | "discovered" | "assumed" | "unknown";
+
+export type VideoRouteStrategy =
+  | "openai-videos"
+  | "openai-compatible-video-generations"
+  | "provider-native"
+  | "none"
+  | "unknown";
 
 export interface ImageModelCapabilities {
   generate: boolean;
@@ -27,6 +58,22 @@ export interface ImageModelCapabilities {
   configurableResolution: "openai-size" | "gemini-resolution-aspect" | "none";
   supportsThinking: boolean;
   supportsSearchGrounding: boolean;
+}
+
+export interface ImageModelCapabilityContract extends ImageModelCapabilities {
+  asyncJob: boolean;
+  mediaKinds: MediaKind[];
+  outputAssetKinds: MediaKind[];
+  requiresPublicUrl: boolean;
+  supportsBase64Input: boolean;
+  maxInputImageBytes?: number;
+  estimatedCostSignals: boolean;
+  supportsLocalRuntime: boolean;
+  animatedGif: boolean;
+  video: boolean;
+  videoRouteStrategy: VideoRouteStrategy;
+  contract: ImageCapabilityContractKind;
+  confidence: ImageCapabilityConfidence;
 }
 
 export interface FocusedModelDefinition {
@@ -165,6 +212,7 @@ export interface ImageAsset {
   path: string;
   fileName: string;
   mimeType: string;
+  kind?: MediaKind;
   width?: number;
   height?: number;
   sourceType: "result" | "partial" | "input" | "mask";
@@ -179,6 +227,7 @@ export interface GalleryAsset {
   fileName: string;
   originalName: string;
   mimeType: string;
+  kind?: MediaKind;
   sizeBytes: number;
   width?: number;
   height?: number;
@@ -297,6 +346,88 @@ export interface RunJobRequest {
   maskDataUrl?: string;
   params: ImageParams;
 }
+
+export interface GenerationQueueItem {
+  queueId: string;
+  source: QueueSource;
+  providerId: string;
+  request: RunJobRequest;
+  status: JobStatus;
+  priority: number;
+  attempt: number;
+  maxAttempts: number;
+  createdAt: string;
+  startedAt?: string;
+  updatedAt: string;
+  completedAt?: string;
+  lastError?: string;
+  historyJobId?: string;
+  outputAssetIds: string[];
+  cancelRequested: boolean;
+  costConfirmed: boolean;
+  workerHostId?: string;
+  workerProcessId?: number;
+  workerHeartbeatAt?: string;
+  workerLeaseExpiresAt?: string;
+  executionKind: QueueExecutionKind;
+  stage: QueueStage;
+  remoteJobHandle?: string;
+  remoteProviderStatus?: string;
+  remoteExpiresAt?: string;
+  lastPollAt?: string;
+  localStep?: string;
+  sourceAssetIds: string[];
+  outputMediaKinds: MediaKind[];
+  idempotencyKey?: string;
+  requestId?: string;
+  correlationId?: string;
+}
+
+export interface GenerationQueueFile {
+  schemaVersion: 1;
+  updatedAt: string;
+  items: GenerationQueueItem[];
+}
+
+export type CrossGenJsonErrorCode =
+  | "CONFIG_NOT_FOUND"
+  | "API_KEY_MISSING"
+  | "CONFIRMATION_REQUIRED"
+  | "NO_LIVE_QUEUE_WORKER"
+  | "CAPABILITY_UNSUPPORTED"
+  | "UNSUPPORTED_IN_THIS_VERSION"
+  | "RATE_LIMITED"
+  | "PROVIDER_ERROR"
+  | "LOCK_TIMEOUT"
+  | "PATH_NOT_ALLOWED"
+  | "ASSET_NOT_FOUND"
+  | "INVALID_ARGUMENT"
+  | "UNKNOWN_ERROR";
+
+export interface CrossGenJsonError {
+  code: CrossGenJsonErrorCode;
+  message: string;
+  retryable: boolean;
+  nextActions: string[];
+}
+
+export interface CrossGenJsonSuccess<TData = unknown> {
+  ok: true;
+  schemaVersion: 1;
+  requestId: string;
+  correlationId?: string;
+  data: TData;
+}
+
+export interface CrossGenJsonFailure {
+  ok: false;
+  schemaVersion: 1;
+  requestId: string;
+  correlationId?: string;
+  error: CrossGenJsonError;
+}
+
+export type CrossGenJsonResponse<TData = unknown> = CrossGenJsonSuccess<TData> | CrossGenJsonFailure;
 
 export interface JobProgressEvent {
   jobId: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "jsx": "react-jsx",
     "types": ["vitest/globals"]
   },
-  "include": ["src/renderer", "src/shared", "src/shared/**/*.test.ts", "src/renderer/**/*.test.ts", "src/renderer/**/*.test.tsx"],
+  "include": ["src/core", "src/renderer", "src/shared", "src/core/**/*.test.ts", "src/shared/**/*.test.ts", "src/renderer/**/*.test.ts", "src/renderer/**/*.test.tsx"],
   "references": []
 }

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -14,6 +14,6 @@
     "sourceMap": true,
     "declaration": false
   },
-  "include": ["src/main", "src/preload", "src/shared"],
+  "include": ["src/core", "src/main", "src/preload", "src/shared"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- Adds the v0.3.1 agent-runtime master plan and Phase 0 planning artifacts.
- Adds shared queue, CLI JSON, media, and model capability contract types.
- Adds a conservative core model capability contract mapper with tests.
- Adds an Electron no-window command-mode spike for `--cli --version --json` and `--cli doctor --agent --json`.

## Validation
- `pnpm build`
- `./node_modules/.bin/electron . --cli --version --json`
- `./node_modules/.bin/electron . --cli doctor --agent --json`