### PR TITLE
Add v0.3.1 core state and queue store foundations

### DIFF
--- a/src/core/dataDirs.test.ts
+++ b/src/core/dataDirs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_LEGACY_USER_DATA_NAME, DEFAULT_STATE_FILE_NAME, resolveDataDirs, resolveUserDataDir } from "./dataDirs";
+
+describe("dataDirs", () => {
+  it("resolves user data and queue files from app data", () => {
+    const userDataDir = resolveUserDataDir({ appDataDir: "/tmp/app-data" });
+    expect(userDataDir).toBe("/tmp/app-data/Image2Tools");
+
+    const dirs = resolveDataDirs({ appDataDir: "/tmp/app-data" });
+    expect(dirs.statePath).toBe(`/tmp/app-data/${DEFAULT_LEGACY_USER_DATA_NAME}/${DEFAULT_STATE_FILE_NAME}`);
+    expect(dirs.lockPath).toBe("/tmp/app-data/Image2Tools/.crossgen-state.lock");
+    expect(dirs.queuePath).toBe("/tmp/app-data/Image2Tools/crossgen-queue.v1.json");
+    expect(dirs.queueLockPath).toBe("/tmp/app-data/Image2Tools/.crossgen-queue.lock");
+    expect(dirs.legacyImageRoots).toContain("/tmp/app-data/Image2Tools/images");
+  });
+
+  it("prefers explicit user data directories", () => {
+    const dirs = resolveDataDirs({ appDataDir: "/tmp/app-data", userDataDir: "/tmp/custom-data" });
+    expect(dirs.userDataDir).toBe("/tmp/custom-data");
+    expect(dirs.statePath).toBe("/tmp/custom-data/image2tools-state.v1.json");
+  });
+});

--- a/src/core/dataDirs.test.ts
+++ b/src/core/dataDirs.test.ts
@@ -1,22 +1,25 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_LEGACY_USER_DATA_NAME, DEFAULT_STATE_FILE_NAME, resolveDataDirs, resolveUserDataDir } from "./dataDirs";
 
 describe("dataDirs", () => {
   it("resolves user data and queue files from app data", () => {
     const userDataDir = resolveUserDataDir({ appDataDir: "/tmp/app-data" });
-    expect(userDataDir).toBe("/tmp/app-data/Image2Tools");
+    const expectedUserDataDir = path.join(path.resolve("/tmp/app-data"), "Image2Tools");
+    expect(userDataDir).toBe(expectedUserDataDir);
 
     const dirs = resolveDataDirs({ appDataDir: "/tmp/app-data" });
-    expect(dirs.statePath).toBe(`/tmp/app-data/${DEFAULT_LEGACY_USER_DATA_NAME}/${DEFAULT_STATE_FILE_NAME}`);
-    expect(dirs.lockPath).toBe("/tmp/app-data/Image2Tools/.crossgen-state.lock");
-    expect(dirs.queuePath).toBe("/tmp/app-data/Image2Tools/crossgen-queue.v1.json");
-    expect(dirs.queueLockPath).toBe("/tmp/app-data/Image2Tools/.crossgen-queue.lock");
-    expect(dirs.legacyImageRoots).toContain("/tmp/app-data/Image2Tools/images");
+    expect(dirs.statePath).toBe(path.join(path.resolve("/tmp/app-data"), DEFAULT_LEGACY_USER_DATA_NAME, DEFAULT_STATE_FILE_NAME));
+    expect(dirs.lockPath).toBe(path.join(expectedUserDataDir, ".crossgen-state.lock"));
+    expect(dirs.queuePath).toBe(path.join(expectedUserDataDir, "crossgen-queue.v1.json"));
+    expect(dirs.queueLockPath).toBe(path.join(expectedUserDataDir, ".crossgen-queue.lock"));
+    expect(dirs.legacyImageRoots).toContain(path.join(expectedUserDataDir, "images"));
   });
 
   it("prefers explicit user data directories", () => {
     const dirs = resolveDataDirs({ appDataDir: "/tmp/app-data", userDataDir: "/tmp/custom-data" });
-    expect(dirs.userDataDir).toBe("/tmp/custom-data");
-    expect(dirs.statePath).toBe("/tmp/custom-data/image2tools-state.v1.json");
+    const expectedUserDataDir = path.resolve("/tmp/custom-data");
+    expect(dirs.userDataDir).toBe(expectedUserDataDir);
+    expect(dirs.statePath).toBe(path.join(expectedUserDataDir, "image2tools-state.v1.json"));
   });
 });

--- a/src/core/dataDirs.ts
+++ b/src/core/dataDirs.ts
@@ -1,0 +1,55 @@
+import path from "node:path";
+
+export const DEFAULT_STATE_FILE_NAME = "image2tools-state.v1.json";
+export const DEFAULT_LEGACY_USER_DATA_NAME = "Image2Tools";
+export const DEFAULT_QUEUE_FILE_NAME = "crossgen-queue.v1.json";
+
+export interface DataDirResolutionInput {
+  appDataDir: string;
+  userDataDir?: string | null;
+  legacyUserDataName?: string;
+}
+
+export interface ResolvedDataDirs {
+  appDataDir: string;
+  userDataDir: string;
+  statePath: string;
+  backupStatePath: string;
+  lockPath: string;
+  queuePath: string;
+  queueLockPath: string;
+  imagesDir: string;
+  galleryDir: string;
+  galleryThumbnailCacheDir: string;
+  legacyImageRoots: string[];
+}
+
+export function resolveUserDataDir(input: DataDirResolutionInput): string {
+  if (input.userDataDir?.trim()) return path.resolve(input.userDataDir.trim());
+  return path.join(path.resolve(input.appDataDir), input.legacyUserDataName ?? DEFAULT_LEGACY_USER_DATA_NAME);
+}
+
+export function resolveDataDirs(input: DataDirResolutionInput): ResolvedDataDirs {
+  const appDataDir = path.resolve(input.appDataDir);
+  const legacyUserDataName = input.legacyUserDataName ?? DEFAULT_LEGACY_USER_DATA_NAME;
+  const userDataDir = resolveUserDataDir({ ...input, appDataDir });
+  const statePath = path.join(userDataDir, DEFAULT_STATE_FILE_NAME);
+  const backupStatePath = `${statePath}.bak`;
+  return {
+    appDataDir,
+    userDataDir,
+    statePath,
+    backupStatePath,
+    lockPath: path.join(userDataDir, ".crossgen-state.lock"),
+    queuePath: path.join(userDataDir, DEFAULT_QUEUE_FILE_NAME),
+    queueLockPath: path.join(userDataDir, ".crossgen-queue.lock"),
+    imagesDir: path.join(userDataDir, "images"),
+    galleryDir: path.join(userDataDir, "gallery"),
+    galleryThumbnailCacheDir: path.join(userDataDir, "gallery-thumbnails"),
+    legacyImageRoots: [
+      path.join(userDataDir, "images"),
+      path.join(appDataDir, "image2tools", "images"),
+      path.join(appDataDir, legacyUserDataName, "images")
+    ].map((item) => path.resolve(item))
+  };
+}

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,0 +1,11 @@
+import type { GallerySyncEvent, JobProgressEvent } from "../shared/types.js";
+
+export interface JobEventSink {
+  sendJobEvent(event: JobProgressEvent): void | Promise<void>;
+}
+
+export interface GalleryEventSink {
+  sendGalleryEvent(event: GallerySyncEvent): void | Promise<void>;
+}
+
+export interface CoreEventSink extends JobEventSink, GalleryEventSink {}

--- a/src/core/fileLock.test.ts
+++ b/src/core/fileLock.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withExclusiveFileLock } from "./fileLock";
+
+describe("fileLock", () => {
+  it("serializes access and releases the lock file", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-lock-"));
+    const lockPath = path.join(tempDir, "state.lock");
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    let firstTask: Promise<void>;
+    const firstStarted = new Promise<void>((resolve) => {
+      firstTask = withExclusiveFileLock(
+        lockPath,
+        async () => {
+          events.push("first-start");
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirst = release;
+          });
+          events.push("first-end");
+        },
+        { timeoutMs: 1000, staleLockMs: 1000, pollMs: 10 }
+      );
+    });
+
+    await firstStarted;
+
+    const second = withExclusiveFileLock(
+        lockPath,
+        async () => {
+          events.push("second-start");
+          events.push("second-end");
+        },
+        { timeoutMs: 1000, staleLockMs: 1000, pollMs: 10 }
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    releaseFirst?.();
+    await Promise.all([firstTask!, second]);
+
+    expect(events.indexOf("first-end")).toBeLessThan(events.indexOf("second-start"));
+    await expect(readFile(lockPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await rm(tempDir, { recursive: true, force: true });
+  });
+});

--- a/src/core/fileLock.ts
+++ b/src/core/fileLock.ts
@@ -1,0 +1,94 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface FileLockOptions {
+  timeoutMs?: number;
+  staleLockMs?: number;
+  pollMs?: number;
+  now?: () => number;
+  pid?: number;
+}
+
+export interface FileLockHandle {
+  path: string;
+  acquiredAt: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_STALE_LOCK_MS = 30000;
+const DEFAULT_POLL_MS = 50;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function tryRemoveStaleLock(lockPath: string, staleLockMs: number, now: () => number): Promise<boolean> {
+  try {
+    const stat = await fs.stat(lockPath);
+    if (now() - stat.mtimeMs < staleLockMs) return false;
+    await fs.unlink(lockPath);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return true;
+    return false;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+async function acquireLock(lockPath: string, options: Required<Pick<FileLockOptions, "timeoutMs" | "staleLockMs" | "pollMs">> & Pick<FileLockOptions, "now" | "pid">): Promise<FileLockHandle> {
+  const startedAt = (options.now ?? Date.now)();
+  const now = options.now ?? Date.now;
+  const pid = options.pid ?? process.pid;
+
+  await ensureParentDir(lockPath);
+
+  while (true) {
+    try {
+      const handle = await fs.open(lockPath, "wx");
+      try {
+        await handle.writeFile(
+          `${JSON.stringify({
+            pid,
+            acquiredAt: now(),
+            host: `${pid}:${Math.random().toString(36).slice(2, 8)}`
+          })}\n`,
+          "utf8"
+        );
+      } finally {
+        await handle.close();
+      }
+      return { path: lockPath, acquiredAt: now() };
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== "EEXIST") throw error;
+      const reclaimed = await tryRemoveStaleLock(lockPath, options.staleLockMs, now);
+      if (reclaimed) continue;
+      if (now() - startedAt > options.timeoutMs) {
+        throw new Error(`Timed out acquiring lock: ${lockPath}`);
+      }
+      await sleep(options.pollMs);
+    }
+  }
+}
+
+export async function withExclusiveFileLock<T>(lockPath: string, operation: () => Promise<T>, options: FileLockOptions = {}): Promise<T> {
+  const lock = await acquireLock(lockPath, {
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    staleLockMs: options.staleLockMs ?? DEFAULT_STALE_LOCK_MS,
+    pollMs: options.pollMs ?? DEFAULT_POLL_MS,
+    now: options.now,
+    pid: options.pid
+  });
+
+  try {
+    return await operation();
+  } finally {
+    await fs.unlink(lock.path).catch(() => undefined);
+  }
+}

--- a/src/core/keyring.ts
+++ b/src/core/keyring.ts
@@ -1,0 +1,34 @@
+import type { ProviderKind } from "../shared/types.js";
+
+export type KeySource = "env-provider" | "env-generic" | "saved-safeStorage" | "saved-localFallback" | "none";
+
+export interface ResolvedProviderKey {
+  value: string;
+  source: KeySource;
+}
+
+export interface ProviderKeyResolver {
+  canReadSavedKeys: boolean;
+  resolveProviderKey(providerId: string, providerKind: ProviderKind): Promise<ResolvedProviderKey | null>;
+}
+
+export function getProviderEnvKeyNames(providerKind: ProviderKind): string[] {
+  if (providerKind === "gemini") return ["CROSSGEN_GEMINI_API_KEY", "CROSSGEN_API_KEY"];
+  if (providerKind === "custom") return ["CROSSGEN_CUSTOM_API_KEY", "CROSSGEN_API_KEY"];
+  return ["CROSSGEN_OPENAI_API_KEY", "CROSSGEN_API_KEY"];
+}
+
+export function describeKeySource(source: KeySource): string {
+  switch (source) {
+    case "env-provider":
+      return "provider-env";
+    case "env-generic":
+      return "generic-env";
+    case "saved-safeStorage":
+      return "saved-safeStorage";
+    case "saved-localFallback":
+      return "saved-localFallback";
+    default:
+      return "none";
+  }
+}

--- a/src/core/mediaTypes.test.ts
+++ b/src/core/mediaTypes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { coerceLegacyImageAssetKind, isImageMediaKind, mediaKindsContainImage, normalizeAssetKind, normalizeMediaKind } from "./mediaTypes";
+
+describe("mediaTypes", () => {
+  it("defaults unknown legacy asset kinds to image", () => {
+    expect(normalizeMediaKind(undefined)).toBe("image");
+    expect(normalizeMediaKind(null)).toBe("image");
+    expect(normalizeMediaKind("image")).toBe("image");
+    expect(normalizeMediaKind("animated-gif")).toBe("animated-gif");
+    expect(normalizeMediaKind("video")).toBe("video");
+    expect(normalizeAssetKind(undefined)).toBe("image");
+  });
+
+  it("identifies image kinds and coerces legacy assets", () => {
+    expect(isImageMediaKind("image")).toBe(true);
+    expect(isImageMediaKind("video")).toBe(false);
+
+    expect(coerceLegacyImageAssetKind({ id: "a" }).kind).toBe("image");
+    expect(coerceLegacyImageAssetKind({ id: "b", kind: "video" }).kind).toBe("video");
+  });
+
+  it("detects image presence in kind lists", () => {
+    expect(mediaKindsContainImage(["animated-gif"])).toBe(false);
+    expect(mediaKindsContainImage(["video", "image"])).toBe(true);
+    expect(mediaKindsContainImage(undefined)).toBe(false);
+  });
+});

--- a/src/core/mediaTypes.ts
+++ b/src/core/mediaTypes.ts
@@ -1,0 +1,28 @@
+import type { MediaKind } from "../shared/types.js";
+
+const IMAGE_KINDS = new Set<MediaKind>(["image"]);
+
+export function isImageMediaKind(kind: MediaKind | undefined | null): kind is "image" {
+  return kind === "image";
+}
+
+export function normalizeMediaKind(kind?: MediaKind | null): MediaKind {
+  if (kind === "animated-gif" || kind === "video") return kind;
+  return "image";
+}
+
+export function normalizeAssetKind(kind?: MediaKind | null): MediaKind {
+  return normalizeMediaKind(kind);
+}
+
+export function coerceLegacyImageAssetKind<T extends object>(asset: T & { kind?: MediaKind | null }): T & { kind: MediaKind } {
+  return {
+    ...asset,
+    kind: normalizeMediaKind(asset.kind)
+  };
+}
+
+export function mediaKindsContainImage(kinds: readonly MediaKind[] | undefined | null): boolean {
+  if (!Array.isArray(kinds)) return false;
+  return kinds.some((kind) => IMAGE_KINDS.has(kind));
+}

--- a/src/core/queueStore.test.ts
+++ b/src/core/queueStore.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createQueueStore } from "./queueStore";
+import type { GenerationQueueItem } from "../shared/types";
+
+describe("queueStore", () => {
+  it("round-trips items and recovers stale running items", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({
+      queuePath,
+      lockPath: `${queuePath}.lock`,
+      now: () => Date.now(),
+      staleRunningAfterMs: 10,
+      leaseMs: 10
+    });
+
+    const item: GenerationQueueItem = {
+      queueId: "queue_1",
+      source: "desktop",
+      providerId: "default",
+      request: {
+        mode: "generate",
+        prompt: "hello",
+        inputPaths: [],
+        params: {
+          providerKind: "openai",
+          launchId: "gpt-image-2",
+          model: "gpt-image-2",
+          imageRoute: "auto",
+          size: "1024x1024",
+          quality: "auto",
+          outputFormat: "png",
+          outputCompression: 100,
+          background: "auto",
+          n: 1,
+          stream: false,
+          partialImages: 0,
+          moderation: "auto",
+          timeoutMs: 1000
+        }
+      },
+      status: "queued",
+      priority: 0,
+      attempt: 0,
+      maxAttempts: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      outputAssetIds: [],
+      cancelRequested: false,
+      costConfirmed: true,
+      executionKind: "sync-provider",
+      stage: "queued",
+      sourceAssetIds: [],
+      outputMediaKinds: ["image"]
+    };
+
+    await store.appendItem(item);
+    const claimed = await store.claimRunnableItems({ host: { hostId: "host-1", kind: "desktop", processId: process.pid }, limit: 1 });
+    expect(claimed).toHaveLength(1);
+
+    const recovered = await store.recoverStaleRunningItems(Date.now() + 1000);
+    expect(recovered.items[0].status).toBe("interrupted");
+    expect(recovered.items[0].workerHostId).toBeUndefined();
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+});

--- a/src/core/queueStore.ts
+++ b/src/core/queueStore.ts
@@ -1,0 +1,297 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { withExclusiveFileLock } from "./fileLock.js";
+import type {
+  GenerationQueueFile,
+  GenerationQueueItem,
+  GenerationQueueWorkerHost,
+  JobStatus,
+  QueueExecutionKind,
+  QueueStage
+} from "../shared/types.js";
+
+export interface QueueStoreOptions {
+  queuePath: string;
+  lockPath: string;
+  timeoutMs?: number;
+  staleLockMs?: number;
+  staleRunningAfterMs?: number;
+  leaseMs?: number;
+  now?: () => number;
+}
+
+export interface QueueHostIdentity {
+  hostId: string;
+  kind: GenerationQueueWorkerHost["kind"];
+  processId: number;
+}
+
+export interface ClaimRunnableItemsOptions {
+  host: QueueHostIdentity;
+  limit: number;
+}
+
+export interface QueueStore {
+  read(): Promise<GenerationQueueFile>;
+  write(queue: GenerationQueueFile): Promise<void>;
+  mutate(mutator: (queue: GenerationQueueFile) => GenerationQueueFile | Promise<GenerationQueueFile>): Promise<GenerationQueueFile>;
+  recoverStaleRunningItems(now?: number): Promise<GenerationQueueFile>;
+  registerWorkerHeartbeat(host: GenerationQueueWorkerHost): Promise<GenerationQueueFile>;
+  claimRunnableItems(options: ClaimRunnableItemsOptions): Promise<GenerationQueueItem[]>;
+  appendItem(item: GenerationQueueItem): Promise<GenerationQueueFile>;
+}
+
+const DEFAULT_QUEUE_FILE: GenerationQueueFile = {
+  schemaVersion: 1,
+  updatedAt: new Date(0).toISOString(),
+  items: [],
+  workerHosts: []
+};
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+async function readQueueFile(queuePath: string): Promise<GenerationQueueFile> {
+  try {
+    const raw = JSON.parse(await fs.readFile(queuePath, "utf8")) as Partial<GenerationQueueFile>;
+    return normalizeQueueFile(raw);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return structuredClone(DEFAULT_QUEUE_FILE);
+    }
+    throw error;
+  }
+}
+
+async function writeQueueFile(queuePath: string, queue: GenerationQueueFile): Promise<void> {
+  await fs.mkdir(path.dirname(queuePath), { recursive: true });
+  const tmpPath = `${queuePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(queue, null, 2)}\n`, "utf8");
+  await fs.rename(tmpPath, queuePath);
+}
+
+function normalizeQueueFile(raw: Partial<GenerationQueueFile> | null | undefined): GenerationQueueFile {
+  return {
+    schemaVersion: 1,
+    updatedAt: typeof raw?.updatedAt === "string" ? raw.updatedAt : new Date(0).toISOString(),
+    items: Array.isArray(raw?.items) ? raw!.items.map((item) => normalizeQueueItem(item as Partial<GenerationQueueItem>)) : [],
+    workerHosts: Array.isArray(raw?.workerHosts) ? raw!.workerHosts.map((host) => normalizeQueueWorkerHost(host as Partial<GenerationQueueWorkerHost>)) : []
+  };
+}
+
+function normalizeQueueItem(raw: Partial<GenerationQueueItem>): GenerationQueueItem {
+  const createdAt = typeof raw.createdAt === "string" ? raw.createdAt : new Date(0).toISOString();
+  return {
+    queueId: typeof raw.queueId === "string" ? raw.queueId : `queue_${Math.random().toString(36).slice(2, 10)}`,
+    source: raw.source === "desktop" || raw.source === "cli" || raw.source === "mcp" ? raw.source : "desktop",
+    providerId: typeof raw.providerId === "string" ? raw.providerId : "default",
+    request: raw.request as GenerationQueueItem["request"],
+    status: normalizeJobStatus(raw.status),
+    priority: typeof raw.priority === "number" ? raw.priority : 0,
+    attempt: typeof raw.attempt === "number" ? raw.attempt : 0,
+    maxAttempts: typeof raw.maxAttempts === "number" ? raw.maxAttempts : 1,
+    createdAt,
+    startedAt: typeof raw.startedAt === "string" ? raw.startedAt : undefined,
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : createdAt,
+    completedAt: typeof raw.completedAt === "string" ? raw.completedAt : undefined,
+    lastError: typeof raw.lastError === "string" ? raw.lastError : undefined,
+    historyJobId: typeof raw.historyJobId === "string" ? raw.historyJobId : undefined,
+    outputAssetIds: Array.isArray(raw.outputAssetIds) ? raw.outputAssetIds.filter((value): value is string => typeof value === "string") : [],
+    cancelRequested: Boolean(raw.cancelRequested),
+    costConfirmed: Boolean(raw.costConfirmed),
+    workerHostId: typeof raw.workerHostId === "string" ? raw.workerHostId : undefined,
+    workerProcessId: typeof raw.workerProcessId === "number" ? raw.workerProcessId : undefined,
+    workerHeartbeatAt: typeof raw.workerHeartbeatAt === "string" ? raw.workerHeartbeatAt : undefined,
+    workerLeaseExpiresAt: typeof raw.workerLeaseExpiresAt === "string" ? raw.workerLeaseExpiresAt : undefined,
+    executionKind: normalizeExecutionKind(raw.executionKind),
+    stage: normalizeQueueStage(raw.stage),
+    remoteJobHandle: typeof raw.remoteJobHandle === "string" ? raw.remoteJobHandle : undefined,
+    remoteProviderStatus: typeof raw.remoteProviderStatus === "string" ? raw.remoteProviderStatus : undefined,
+    remoteExpiresAt: typeof raw.remoteExpiresAt === "string" ? raw.remoteExpiresAt : undefined,
+    lastPollAt: typeof raw.lastPollAt === "string" ? raw.lastPollAt : undefined,
+    localStep: typeof raw.localStep === "string" ? raw.localStep : undefined,
+    sourceAssetIds: Array.isArray(raw.sourceAssetIds) ? raw.sourceAssetIds.filter((value): value is string => typeof value === "string") : [],
+    outputMediaKinds: Array.isArray(raw.outputMediaKinds) ? raw.outputMediaKinds.filter(isMediaKind) : ["image"],
+    idempotencyKey: typeof raw.idempotencyKey === "string" ? raw.idempotencyKey : undefined,
+    requestId: typeof raw.requestId === "string" ? raw.requestId : undefined,
+    correlationId: typeof raw.correlationId === "string" ? raw.correlationId : undefined
+  };
+}
+
+function normalizeQueueWorkerHost(raw: Partial<GenerationQueueWorkerHost>): GenerationQueueWorkerHost {
+  const now = new Date().toISOString();
+  return {
+    hostId: typeof raw.hostId === "string" ? raw.hostId : `host_${Math.random().toString(36).slice(2, 10)}`,
+    kind: raw.kind === "desktop" || raw.kind === "mcp" || raw.kind === "cli-worker" ? raw.kind : "desktop",
+    processId: typeof raw.processId === "number" ? raw.processId : process.pid,
+    mode: "generate",
+    heartbeatAt: typeof raw.heartbeatAt === "string" ? raw.heartbeatAt : now,
+    leaseExpiresAt: typeof raw.leaseExpiresAt === "string" ? raw.leaseExpiresAt : now
+  };
+}
+
+function normalizeJobStatus(value: unknown): JobStatus {
+  return value === "queued" || value === "running" || value === "succeeded" || value === "failed" || value === "cancelled" || value === "interrupted"
+    ? value
+    : "queued";
+}
+
+function normalizeExecutionKind(value: unknown): QueueExecutionKind {
+  return value === "remote-poll" || value === "local-cpu" ? value : "sync-provider";
+}
+
+function normalizeQueueStage(value: unknown): QueueStage {
+  return value === "claiming" || value === "calling_provider" || value === "awaiting_remote" || value === "downloading" || value === "postprocessing" || value === "finalizing"
+    ? value
+    : "queued";
+}
+
+function isMediaKind(value: unknown): value is "image" | "animated-gif" | "video" {
+  return value === "image" || value === "animated-gif" || value === "video";
+}
+
+function cloneQueue(queue: GenerationQueueFile): GenerationQueueFile {
+  return structuredClone(queue);
+}
+
+function markStaleRunning(queue: GenerationQueueFile, nowMs: number, staleRunningAfterMs: number): GenerationQueueFile {
+  const next = cloneQueue(queue);
+  for (const item of next.items) {
+    if (item.status !== "running") continue;
+    const leaseExpiresAt = item.workerLeaseExpiresAt ? Date.parse(item.workerLeaseExpiresAt) : Number.NaN;
+    const heartbeatAt = item.workerHeartbeatAt ? Date.parse(item.workerHeartbeatAt) : Number.NaN;
+    const leaseExpired = Number.isFinite(leaseExpiresAt) && leaseExpiresAt <= nowMs;
+    const heartbeatStale = Number.isFinite(heartbeatAt) && nowMs - heartbeatAt >= staleRunningAfterMs;
+    if (leaseExpired || heartbeatStale) {
+      item.status = "interrupted";
+      item.stage = "queued";
+      item.workerHostId = undefined;
+      item.workerHeartbeatAt = undefined;
+      item.workerLeaseExpiresAt = undefined;
+      item.completedAt = item.completedAt ?? new Date(nowMs).toISOString();
+      item.updatedAt = new Date(nowMs).toISOString();
+    }
+  }
+  next.updatedAt = new Date(nowMs).toISOString();
+  return next;
+}
+
+function claimItems(queue: GenerationQueueFile, options: ClaimRunnableItemsOptions, nowMs: number, leaseMs: number): GenerationQueueItem[] {
+  const eligible = queue.items
+    .filter((item) => item.status === "queued" && !item.cancelRequested)
+    .sort((a, b) => a.priority - b.priority || Date.parse(a.createdAt) - Date.parse(b.createdAt));
+
+  const claimed: GenerationQueueItem[] = [];
+  for (const item of eligible.slice(0, Math.max(0, options.limit))) {
+    item.status = "running";
+    item.startedAt = item.startedAt ?? new Date(nowMs).toISOString();
+    item.updatedAt = new Date(nowMs).toISOString();
+    item.workerHostId = options.host.hostId;
+    item.workerProcessId = options.host.processId;
+    item.workerHeartbeatAt = new Date(nowMs).toISOString();
+    item.workerLeaseExpiresAt = new Date(nowMs + leaseMs).toISOString();
+    item.stage = "claiming";
+    claimed.push(structuredClone(item));
+  }
+  if (claimed.length > 0) {
+    queue.updatedAt = new Date(nowMs).toISOString();
+  }
+  return claimed;
+}
+
+export function createQueueStore(options: QueueStoreOptions): QueueStore {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const staleLockMs = options.staleLockMs ?? 30000;
+  const staleRunningAfterMs = options.staleRunningAfterMs ?? 30000;
+  const leaseMs = options.leaseMs ?? 30000;
+  const now = options.now ?? Date.now;
+
+  return {
+    async read(): Promise<GenerationQueueFile> {
+      return readQueueFile(options.queuePath);
+    },
+    async write(queue: GenerationQueueFile): Promise<void> {
+      await withExclusiveFileLock(options.lockPath, async () => writeQueueFile(options.queuePath, normalizeQueueFile(queue)), {
+        timeoutMs,
+        staleLockMs
+      });
+    },
+    async mutate(mutator: (queue: GenerationQueueFile) => GenerationQueueFile | Promise<GenerationQueueFile>): Promise<GenerationQueueFile> {
+      return withExclusiveFileLock(
+        options.lockPath,
+        async () => {
+          const current = await readQueueFile(options.queuePath);
+          const next = normalizeQueueFile(await mutator(current));
+          await writeQueueFile(options.queuePath, next);
+          return next;
+        },
+        { timeoutMs, staleLockMs }
+      );
+    },
+    async recoverStaleRunningItems(nowOverride = now()): Promise<GenerationQueueFile> {
+      return withExclusiveFileLock(
+        options.lockPath,
+        async () => {
+          const current = await readQueueFile(options.queuePath);
+          const next = markStaleRunning(current, nowOverride, staleRunningAfterMs);
+          await writeQueueFile(options.queuePath, next);
+          return next;
+        },
+        { timeoutMs, staleLockMs }
+      );
+    },
+    async registerWorkerHeartbeat(host: GenerationQueueWorkerHost): Promise<GenerationQueueFile> {
+      return withExclusiveFileLock(
+        options.lockPath,
+        async () => {
+          const current = await readQueueFile(options.queuePath);
+          const next = cloneQueue(current);
+          const nowIso = new Date(now()).toISOString();
+          const normalized: GenerationQueueWorkerHost = {
+            hostId: host.hostId,
+            kind: host.kind,
+            processId: host.processId,
+            mode: "generate",
+            heartbeatAt: host.heartbeatAt || nowIso,
+            leaseExpiresAt: host.leaseExpiresAt || nowIso
+          };
+          const index = next.workerHosts.findIndex((item) => item.hostId === normalized.hostId);
+          if (index >= 0) next.workerHosts[index] = normalized;
+          else next.workerHosts.push(normalized);
+          next.updatedAt = nowIso;
+          await writeQueueFile(options.queuePath, next);
+          return next;
+        },
+        { timeoutMs, staleLockMs }
+      );
+    },
+    async claimRunnableItems({ host, limit }: ClaimRunnableItemsOptions): Promise<GenerationQueueItem[]> {
+      return withExclusiveFileLock(
+        options.lockPath,
+        async () => {
+          const current = await readQueueFile(options.queuePath);
+          const recovered = markStaleRunning(current, now(), staleRunningAfterMs);
+          const claimed = claimItems(recovered, { host, limit }, now(), leaseMs);
+          await writeQueueFile(options.queuePath, recovered);
+          return claimed;
+        },
+        { timeoutMs, staleLockMs }
+      );
+    },
+    async appendItem(item: GenerationQueueItem): Promise<GenerationQueueFile> {
+      return withExclusiveFileLock(
+        options.lockPath,
+        async () => {
+          const current = await readQueueFile(options.queuePath);
+          const next = cloneQueue(current);
+          next.items.push(normalizeQueueItem(item));
+          next.updatedAt = new Date(now()).toISOString();
+          await writeQueueFile(options.queuePath, next);
+          return next;
+        },
+        { timeoutMs, staleLockMs }
+      );
+    }
+  };
+}

--- a/src/core/stateStore.test.ts
+++ b/src/core/stateStore.test.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createJsonStateStore } from "./stateStore";
+
+describe("stateStore", () => {
+  it("writes, reads and recovers from backup", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-state-"));
+    const statePath = path.join(tempDir, "state.json");
+    const backupPath = `${statePath}.bak`;
+    const store = createJsonStateStore({
+      statePath,
+      backupPath,
+      lockPath: `${statePath}.lock`,
+      defaultState: { version: 1, value: 0 },
+      normalize: (value) => value as { version: number; value: number }
+    });
+
+    await store.write({ version: 1, value: 42 });
+    expect(await store.read()).toEqual({ version: 1, value: 42 });
+    expect(JSON.parse(await readFile(statePath, "utf8"))).toMatchObject({ version: 1, value: 42 });
+
+    await store.write({ version: 1, value: 7 });
+    await rm(statePath, { force: true });
+    expect(await store.read()).toEqual({ version: 1, value: 42 });
+    await rm(tempDir, { recursive: true, force: true });
+  });
+});

--- a/src/core/stateStore.ts
+++ b/src/core/stateStore.ts
@@ -1,0 +1,97 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { withExclusiveFileLock } from "./fileLock.js";
+
+export interface JsonStateStoreOptions<TState> {
+  statePath: string;
+  backupPath: string;
+  lockPath: string;
+  timeoutMs?: number;
+  staleLockMs?: number;
+  defaultState: TState;
+  normalize: (value: unknown) => TState;
+}
+
+export interface JsonStateStore<TState> {
+  read(): Promise<TState>;
+  write(state: TState, options?: { updateBackup?: boolean }): Promise<void>;
+  mutate(mutator: (state: TState) => TState | Promise<TState>): Promise<TState>;
+  withLock<T>(operation: () => Promise<T>): Promise<T>;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fs.rename(tmpPath, filePath);
+}
+
+export function createJsonStateStore<TState>(options: JsonStateStoreOptions<TState>): JsonStateStore<TState> {
+  const { statePath, backupPath, lockPath, normalize, defaultState } = options;
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const staleLockMs = options.staleLockMs ?? 30000;
+
+  async function readFromDisk(): Promise<TState> {
+    try {
+      return normalize(await readJsonFile(statePath));
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== "ENOENT") {
+        try {
+          return normalize(await readJsonFile(backupPath));
+        } catch {
+          return structuredClone(defaultState);
+        }
+      }
+      try {
+        return normalize(await readJsonFile(backupPath));
+      } catch {
+        return structuredClone(defaultState);
+      }
+    }
+  }
+
+  return {
+    async read(): Promise<TState> {
+      return readFromDisk();
+    },
+    async write(state: TState, writeOptions: { updateBackup?: boolean } = {}): Promise<void> {
+      await withExclusiveFileLock(
+        lockPath,
+        async () => {
+          if (writeOptions.updateBackup !== false) {
+            await fs.copyFile(statePath, backupPath).catch((error: unknown) => {
+              if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+            });
+          }
+          await writeJsonFile(statePath, state);
+        },
+        { timeoutMs, staleLockMs }
+      );
+    },
+    async mutate(mutator: (state: TState) => TState | Promise<TState>): Promise<TState> {
+      return withExclusiveFileLock(
+        lockPath,
+        async () => {
+          const next = await mutator(await readFromDisk());
+          await fs.copyFile(statePath, backupPath).catch((error: unknown) => {
+            if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+          });
+          await writeJsonFile(statePath, next);
+          return next;
+        },
+        { timeoutMs, staleLockMs }
+      );
+    },
+    async withLock<T>(operation: () => Promise<T>): Promise<T> {
+      return withExclusiveFileLock(lockPath, operation, { timeoutMs, staleLockMs });
+    }
+  };
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -74,6 +74,7 @@ import {
   normalizeModelId
 } from "../shared/modelCatalog.js";
 import { compareVersions, isAllowedUpdateUrl, parseUpdateManifest, safeUpdateFileName, selectUpdateAsset } from "../shared/updateManifest.js";
+import { resolveDataDirs, resolveUserDataDir } from "../core/dataDirs.js";
 import { buildEndpoint, fetchWithTimeout } from "./services/openaiImageAdapter.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
@@ -267,7 +268,14 @@ function createWindow(): BrowserWindow {
 
 function preserveLegacyUserDataPath(): void {
   const userDataOverride = process.env[USER_DATA_DIR_ENV] || process.env[LEGACY_USER_DATA_DIR_ENV];
-  app.setPath("userData", userDataOverride ? path.resolve(userDataOverride) : path.join(app.getPath("appData"), LEGACY_USER_DATA_NAME));
+  app.setPath(
+    "userData",
+    resolveUserDataDir({
+      appDataDir: app.getPath("appData"),
+      userDataDir: userDataOverride,
+      legacyUserDataName: LEGACY_USER_DATA_NAME
+    })
+  );
 }
 
 function registerAssetProtocol(): void {
@@ -326,19 +334,19 @@ function registerAssetProtocol(): void {
 }
 
 function getStatePath(): string {
-  return path.join(app.getPath("userData"), "image2tools-state.v1.json");
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).statePath;
 }
 
 function getBackupStatePath(): string {
-  return `${getStatePath()}.bak`;
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).backupStatePath;
 }
 
 function getDefaultImagesDir(): string {
-  return path.join(app.getPath("userData"), "images");
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).imagesDir;
 }
 
 function getDefaultGalleryDir(): string {
-  return path.join(app.getPath("userData"), "gallery");
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).galleryDir;
 }
 
 function getStorageSettings(state?: AppStateFile | null): StorageSettings {
@@ -357,14 +365,14 @@ function getGalleryDir(state?: AppStateFile | null): string {
 }
 
 function getGalleryThumbnailCacheDir(): string {
-  return path.join(app.getPath("userData"), "gallery-thumbnails");
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).galleryThumbnailCacheDir;
 }
 
 function getHistoryImageRoots(state?: AppStateFile | null): string[] {
+  const dirs = resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") });
   const roots = [
     getImagesDir(state),
-    path.join(app.getPath("appData"), "image2tools", "images"),
-    path.join(app.getPath("appData"), LEGACY_USER_DATA_NAME, "images")
+    ...dirs.legacyImageRoots
   ];
   return [...new Set(roots.map((root) => path.resolve(root)))];
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -383,10 +383,20 @@ export interface GenerationQueueItem {
   correlationId?: string;
 }
 
+export interface GenerationQueueWorkerHost {
+  hostId: string;
+  kind: "desktop" | "mcp" | "cli-worker";
+  processId: number;
+  mode: "generate";
+  heartbeatAt: string;
+  leaseExpiresAt: string;
+}
+
 export interface GenerationQueueFile {
   schemaVersion: 1;
   updatedAt: string;
   items: GenerationQueueItem[];
+  workerHosts: GenerationQueueWorkerHost[];
 }
 
 export type CrossGenJsonErrorCode =

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
   "include": ["src/core", "src/renderer", "src/shared", "src/core/**/*.test.ts", "src/shared/**/*.test.ts", "src/renderer/**/*.test.ts", "src/renderer/**/*.test.tsx"],
   "references": []


### PR DESCRIPTION
## Summary
- Adds non-Electron core foundations for data dirs, file locking, state store, queue store, keyring contracts, event sinks, and media kind helpers.
- Extends the queue file contract with durable worker host heartbeat records.
- Moves Electron main path resolution onto the new core data-dir helpers while preserving the legacy Image2Tools userData path.
- Adds focused tests for path resolution, file lock serialization, state backup recovery, stale queue recovery, queue claiming, and media kind compatibility.

## Validation
- `pnpm typecheck`
- `pnpm test -- src/core/dataDirs.test.ts src/core/fileLock.test.ts src/core/stateStore.test.ts src/core/queueStore.test.ts src/core/mediaTypes.test.ts src/core/modelCapabilities.test.ts`
- `pnpm build:main && ./node_modules/.bin/electron . --cli --version --json`
- `pnpm build`