### PR TITLE
Add durable generation queue runner

### DIFF
--- a/src/core/generation.ts
+++ b/src/core/generation.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from "node:crypto";
+import type { GenerationQueueItem, MediaKind, QueueSource, RunJobRequest } from "../shared/types.js";
+
+export interface CreateGenerationQueueItemInput {
+  source: QueueSource;
+  providerId: string;
+  request: RunJobRequest;
+  costConfirmed: boolean;
+  priority?: number;
+  maxAttempts?: number;
+  historyJobId?: string;
+  sourceAssetIds?: string[];
+  outputMediaKinds?: MediaKind[];
+  idempotencyKey?: string;
+  requestId?: string;
+  correlationId?: string;
+  now?: () => Date;
+}
+
+export function createGenerationQueueItem(input: CreateGenerationQueueItemInput): GenerationQueueItem {
+  const now = (input.now ?? (() => new Date()))().toISOString();
+  return {
+    queueId: `queue_${randomUUID()}`,
+    source: input.source,
+    providerId: input.providerId,
+    request: input.request,
+    status: "queued",
+    priority: input.priority ?? 0,
+    attempt: 0,
+    maxAttempts: input.maxAttempts ?? 1,
+    createdAt: now,
+    updatedAt: now,
+    historyJobId: input.historyJobId,
+    outputAssetIds: [],
+    cancelRequested: false,
+    costConfirmed: input.costConfirmed,
+    executionKind: "sync-provider",
+    stage: "queued",
+    sourceAssetIds: input.sourceAssetIds ?? [],
+    outputMediaKinds: input.outputMediaKinds ?? ["image"],
+    idempotencyKey: input.idempotencyKey,
+    requestId: input.requestId,
+    correlationId: input.correlationId
+  };
+}

--- a/src/core/generationQueue.test.ts
+++ b/src/core/generationQueue.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createGenerationQueueItem } from "./generation";
+import { requestGenerationQueueItemCancel, runNextGenerationQueueItem } from "./generationQueue";
+import { createQueueStore } from "./queueStore";
+
+function request() {
+  return {
+    mode: "generate" as const,
+    prompt: "hello",
+    inputPaths: [],
+    params: {
+      providerKind: "openai" as const,
+      launchId: "gpt-image-2" as const,
+      model: "gpt-image-2",
+      imageRoute: "auto" as const,
+      size: "1024x1024",
+      quality: "auto" as const,
+      outputFormat: "png" as const,
+      outputCompression: 100,
+      background: "auto" as const,
+      n: 1,
+      stream: false,
+      partialImages: 0,
+      moderation: "auto" as const,
+      timeoutMs: 1000
+    }
+  };
+}
+
+describe("generationQueue", () => {
+  it("claims, executes, and completes an item", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-1"
+    });
+    await store.appendItem(item);
+
+    const result = await runNextGenerationQueueItem({
+      queueStore: store,
+      queueId: item.queueId,
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      maxGlobalRunning: 1,
+      executeItem: async (_item, signal) => {
+        expect(signal.aborted).toBe(false);
+        return {
+          status: "succeeded",
+          historyJobId: "job-1",
+          outputAssetIds: ["asset-1"],
+          value: { ok: true }
+        };
+      }
+    });
+
+    expect(result.claimed).toBe(true);
+    expect(result.execution?.value).toEqual({ ok: true });
+    const queue = await store.read();
+    expect(queue.items[0]).toMatchObject({
+      status: "succeeded",
+      historyJobId: "job-1",
+      outputAssetIds: ["asset-1"],
+      workerHostId: undefined
+    });
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("marks thrown executions as failed", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-1"
+    });
+    await store.appendItem(item);
+
+    const result = await runNextGenerationQueueItem({
+      queueStore: store,
+      queueId: item.queueId,
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      executeItem: async () => {
+        throw new Error("provider failed");
+      }
+    });
+
+    expect(result.execution).toMatchObject({ status: "failed", error: "provider failed" });
+    const queue = await store.read();
+    expect(queue.items[0]).toMatchObject({ status: "failed", lastError: "provider failed" });
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("records queued and running cancel requests", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const queued = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true
+    });
+    await store.appendItem(queued);
+
+    const cancelled = await requestGenerationQueueItemCancel(store, queued.queueId);
+    expect(cancelled?.status).toBe("cancelled");
+    expect(cancelled?.cancelRequested).toBe(true);
+
+    const running = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true
+    });
+    await store.appendItem(running);
+    await store.claimRunnableItems({ host: { hostId: "host-1", kind: "desktop", processId: process.pid }, limit: 1, queueId: running.queueId });
+
+    const requested = await requestGenerationQueueItemCancel(store, running.queueId);
+    expect(requested?.status).toBe("running");
+    expect(requested?.cancelRequested).toBe(true);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+});

--- a/src/core/generationQueue.ts
+++ b/src/core/generationQueue.ts
@@ -1,0 +1,219 @@
+import type { GenerationQueueItem, GenerationQueueWorkerHost, JobStatus } from "../shared/types.js";
+import type { QueueHostIdentity, QueueStore } from "./queueStore.js";
+
+export interface GenerationQueueExecutionResult<TValue = unknown> {
+  status?: Extract<JobStatus, "succeeded" | "failed" | "cancelled">;
+  value?: TValue;
+  historyJobId?: string;
+  outputAssetIds?: string[];
+  error?: string;
+}
+
+export interface RunNextGenerationQueueItemOptions<TValue = unknown> {
+  queueStore: QueueStore;
+  host: QueueHostIdentity;
+  executeItem: (item: GenerationQueueItem, abortSignal: AbortSignal) => Promise<GenerationQueueExecutionResult<TValue>>;
+  queueId?: string;
+  maxGlobalRunning?: number;
+  providerConcurrency?: Record<string, number>;
+  leaseMs?: number;
+  now?: () => number;
+  createAbortController?: () => AbortController;
+  onStarted?: (item: GenerationQueueItem, controller: AbortController) => void;
+  onFinished?: (item: GenerationQueueItem) => void;
+}
+
+export interface GenerationQueueRunResult<TValue = unknown> {
+  claimed: boolean;
+  item?: GenerationQueueItem;
+  execution?: GenerationQueueExecutionResult<TValue>;
+}
+
+export interface RunGenerationQueueItemToCompletionOptions<TValue = unknown> extends RunNextGenerationQueueItemOptions<TValue> {
+  pollIntervalMs?: number;
+  waitTimeoutMs?: number;
+}
+
+const TERMINAL_STATUSES = new Set<JobStatus>(["succeeded", "failed", "cancelled", "interrupted"]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function iso(now: number): string {
+  return new Date(now).toISOString();
+}
+
+function normalizeTerminalStatus(status: GenerationQueueExecutionResult["status"] | undefined): Extract<JobStatus, "succeeded" | "failed" | "cancelled"> {
+  return status === "failed" || status === "cancelled" ? status : "succeeded";
+}
+
+function makeWorkerHost(host: QueueHostIdentity, nowMs: number, leaseMs: number): GenerationQueueWorkerHost {
+  return {
+    hostId: host.hostId,
+    kind: host.kind,
+    processId: host.processId,
+    mode: "generate",
+    heartbeatAt: iso(nowMs),
+    leaseExpiresAt: iso(nowMs + leaseMs)
+  };
+}
+
+async function markClaimedItemStage(queueStore: QueueStore, queueId: string, nowMs: number): Promise<void> {
+  await queueStore.mutate((queue) => ({
+    ...queue,
+    updatedAt: iso(nowMs),
+    items: queue.items.map((item) =>
+      item.queueId === queueId
+        ? {
+            ...item,
+            stage: "calling_provider",
+            updatedAt: iso(nowMs)
+          }
+        : item
+    )
+  }));
+}
+
+async function completeClaimedItem(
+  queueStore: QueueStore,
+  item: GenerationQueueItem,
+  result: GenerationQueueExecutionResult,
+  nowMs: number
+): Promise<GenerationQueueItem> {
+  let completed: GenerationQueueItem | undefined;
+  await queueStore.mutate((queue) => {
+    const next = {
+      ...queue,
+      updatedAt: iso(nowMs),
+      items: queue.items.map((current) => {
+        if (current.queueId !== item.queueId) return current;
+        const status = normalizeTerminalStatus(result.status);
+        completed = {
+          ...current,
+          status,
+          stage: "finalizing",
+          completedAt: iso(nowMs),
+          updatedAt: iso(nowMs),
+          lastError: result.error,
+          historyJobId: result.historyJobId ?? current.historyJobId,
+          outputAssetIds: result.outputAssetIds ?? current.outputAssetIds,
+          cancelRequested: status === "cancelled" ? true : current.cancelRequested,
+          workerHostId: undefined,
+          workerProcessId: undefined,
+          workerHeartbeatAt: undefined,
+          workerLeaseExpiresAt: undefined
+        };
+        return completed;
+      })
+    };
+    return next;
+  });
+  return completed ?? item;
+}
+
+async function failClaimedItem<TValue = unknown>(
+  queueStore: QueueStore,
+  item: GenerationQueueItem,
+  error: unknown,
+  nowMs: number
+): Promise<GenerationQueueExecutionResult<TValue>> {
+  const message = error instanceof Error ? error.message : String(error);
+  await completeClaimedItem(
+    queueStore,
+    item,
+    {
+      status: "failed",
+      error: message,
+      historyJobId: item.historyJobId,
+      outputAssetIds: item.outputAssetIds
+    },
+    nowMs
+  );
+  return { status: "failed", error: message, historyJobId: item.historyJobId, outputAssetIds: item.outputAssetIds };
+}
+
+export async function runNextGenerationQueueItem<TValue = unknown>(
+  options: RunNextGenerationQueueItemOptions<TValue>
+): Promise<GenerationQueueRunResult<TValue>> {
+  const now = options.now ?? Date.now;
+  const leaseMs = options.leaseMs ?? 30000;
+  await options.queueStore.registerWorkerHeartbeat(makeWorkerHost(options.host, now(), leaseMs));
+  const [item] = await options.queueStore.claimRunnableItems({
+    host: options.host,
+    limit: 1,
+    queueId: options.queueId,
+    maxGlobalRunning: options.maxGlobalRunning,
+    providerConcurrency: options.providerConcurrency
+  });
+  if (!item) return { claimed: false };
+
+  const controller = options.createAbortController?.() ?? new AbortController();
+  options.onStarted?.(item, controller);
+  try {
+    await markClaimedItemStage(options.queueStore, item.queueId, now());
+    const execution = await options.executeItem(item, controller.signal);
+    const completed = await completeClaimedItem(options.queueStore, item, execution, now());
+    return { claimed: true, item: completed, execution };
+  } catch (error) {
+    const execution = await failClaimedItem<TValue>(options.queueStore, item, error, now());
+    return { claimed: true, item, execution };
+  } finally {
+    options.onFinished?.(item);
+  }
+}
+
+export async function runGenerationQueueItemToCompletion<TValue = unknown>(
+  options: RunGenerationQueueItemToCompletionOptions<TValue>
+): Promise<GenerationQueueRunResult<TValue>> {
+  const startedAt = (options.now ?? Date.now)();
+  const pollIntervalMs = options.pollIntervalMs ?? 100;
+  while (true) {
+    const result = await runNextGenerationQueueItem(options);
+    if (result.claimed) return result;
+
+    const queue = await options.queueStore.read();
+    const item = queue.items.find((candidate) => candidate.queueId === options.queueId);
+    if (!item) return { claimed: false };
+    if (TERMINAL_STATUSES.has(item.status)) return { claimed: false, item };
+    if (typeof options.waitTimeoutMs === "number" && (options.now ?? Date.now)() - startedAt >= options.waitTimeoutMs) {
+      return { claimed: false, item };
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+export async function requestGenerationQueueItemCancel(queueStore: QueueStore, queueId: string, now = Date.now): Promise<GenerationQueueItem | undefined> {
+  let updated: GenerationQueueItem | undefined;
+  await queueStore.mutate((queue) => {
+    const nowIso = iso(now());
+    return {
+      ...queue,
+      updatedAt: nowIso,
+      items: queue.items.map((item) => {
+        if (item.queueId !== queueId) return item;
+        if (item.status === "queued") {
+          updated = {
+            ...item,
+            status: "cancelled",
+            cancelRequested: true,
+            completedAt: nowIso,
+            updatedAt: nowIso
+          };
+          return updated;
+        }
+        if (item.status === "running") {
+          updated = {
+            ...item,
+            cancelRequested: true,
+            updatedAt: nowIso
+          };
+          return updated;
+        }
+        updated = item;
+        return item;
+      })
+    };
+  });
+  return updated;
+}

--- a/src/core/queueStore.test.ts
+++ b/src/core/queueStore.test.ts
@@ -5,6 +5,50 @@ import { describe, expect, it } from "vitest";
 import { createQueueStore } from "./queueStore";
 import type { GenerationQueueItem } from "../shared/types";
 
+function queueItem(patch: Partial<GenerationQueueItem> = {}): GenerationQueueItem {
+  const now = new Date().toISOString();
+  return {
+    queueId: "queue_1",
+    source: "desktop",
+    providerId: "default",
+    request: {
+      mode: "generate",
+      prompt: "hello",
+      inputPaths: [],
+      params: {
+        providerKind: "openai",
+        launchId: "gpt-image-2",
+        model: "gpt-image-2",
+        imageRoute: "auto",
+        size: "1024x1024",
+        quality: "auto",
+        outputFormat: "png",
+        outputCompression: 100,
+        background: "auto",
+        n: 1,
+        stream: false,
+        partialImages: 0,
+        moderation: "auto",
+        timeoutMs: 1000
+      }
+    },
+    status: "queued",
+    priority: 0,
+    attempt: 0,
+    maxAttempts: 1,
+    createdAt: now,
+    updatedAt: now,
+    outputAssetIds: [],
+    cancelRequested: false,
+    costConfirmed: true,
+    executionKind: "sync-provider",
+    stage: "queued",
+    sourceAssetIds: [],
+    outputMediaKinds: ["image"],
+    ...patch
+  };
+}
+
 describe("queueStore", () => {
   it("round-trips items and recovers stale running items", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
@@ -17,53 +61,81 @@ describe("queueStore", () => {
       leaseMs: 10
     });
 
-    const item: GenerationQueueItem = {
-      queueId: "queue_1",
-      source: "desktop",
-      providerId: "default",
-      request: {
-        mode: "generate",
-        prompt: "hello",
-        inputPaths: [],
-        params: {
-          providerKind: "openai",
-          launchId: "gpt-image-2",
-          model: "gpt-image-2",
-          imageRoute: "auto",
-          size: "1024x1024",
-          quality: "auto",
-          outputFormat: "png",
-          outputCompression: 100,
-          background: "auto",
-          n: 1,
-          stream: false,
-          partialImages: 0,
-          moderation: "auto",
-          timeoutMs: 1000
-        }
-      },
-      status: "queued",
-      priority: 0,
-      attempt: 0,
-      maxAttempts: 1,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      outputAssetIds: [],
-      cancelRequested: false,
-      costConfirmed: true,
-      executionKind: "sync-provider",
-      stage: "queued",
-      sourceAssetIds: [],
-      outputMediaKinds: ["image"]
-    };
+    const item = queueItem();
 
     await store.appendItem(item);
     const claimed = await store.claimRunnableItems({ host: { hostId: "host-1", kind: "desktop", processId: process.pid }, limit: 1 });
     expect(claimed).toHaveLength(1);
+    expect(claimed[0].attempt).toBe(1);
 
     const recovered = await store.recoverStaleRunningItems(Date.now() + 1000);
     expect(recovered.items[0].status).toBe("interrupted");
     expect(recovered.items[0].workerHostId).toBeUndefined();
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("honors global and provider concurrency while claiming", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({
+      queuePath,
+      lockPath: `${queuePath}.lock`,
+      now: () => Date.parse("2026-07-13T00:00:00.000Z"),
+      staleRunningAfterMs: 30000,
+      leaseMs: 30000
+    });
+
+    await store.appendItem(queueItem({
+      queueId: "running-openai",
+      providerId: "openai-provider",
+      status: "running",
+      workerHostId: "other-host",
+      workerHeartbeatAt: "2026-07-13T00:00:00.000Z",
+      workerLeaseExpiresAt: "2026-07-13T00:01:00.000Z"
+    }));
+    await store.appendItem(queueItem({ queueId: "queued-openai", providerId: "openai-provider" }));
+    await store.appendItem(queueItem({ queueId: "queued-gemini", providerId: "gemini-provider" }));
+
+    const none = await store.claimRunnableItems({
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      limit: 1,
+      maxGlobalRunning: 1
+    });
+    expect(none).toHaveLength(0);
+
+    const claimed = await store.claimRunnableItems({
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      limit: 2,
+      maxGlobalRunning: 2,
+      providerConcurrency: { "openai-provider": 1, "gemini-provider": 1 }
+    });
+    expect(claimed.map((item) => item.queueId)).toEqual(["queued-gemini"]);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("can claim a specific queued item by id", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({
+      queuePath,
+      lockPath: `${queuePath}.lock`
+    });
+
+    await store.appendItem(queueItem({ queueId: "queue-old", priority: 0 }));
+    await store.appendItem(queueItem({ queueId: "queue-target", priority: 10 }));
+
+    const claimed = await store.claimRunnableItems({
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      limit: 1,
+      queueId: "queue-target"
+    });
+    expect(claimed.map((item) => item.queueId)).toEqual(["queue-target"]);
+
+    const queue = await store.read();
+    expect(queue.items.find((item) => item.queueId === "queue-old")?.status).toBe("queued");
+    expect(queue.items.find((item) => item.queueId === "queue-target")?.status).toBe("running");
 
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/src/core/queueStore.ts
+++ b/src/core/queueStore.ts
@@ -29,6 +29,9 @@ export interface QueueHostIdentity {
 export interface ClaimRunnableItemsOptions {
   host: QueueHostIdentity;
   limit: number;
+  queueId?: string;
+  maxGlobalRunning?: number;
+  providerConcurrency?: Record<string, number>;
 }
 
 export interface QueueStore {
@@ -177,14 +180,37 @@ function markStaleRunning(queue: GenerationQueueFile, nowMs: number, staleRunnin
   return next;
 }
 
+function activeRunningItems(queue: GenerationQueueFile): GenerationQueueItem[] {
+  return queue.items.filter((item) => item.status === "running");
+}
+
 function claimItems(queue: GenerationQueueFile, options: ClaimRunnableItemsOptions, nowMs: number, leaseMs: number): GenerationQueueItem[] {
+  const runningItems = activeRunningItems(queue);
+  const globalCapacity =
+    typeof options.maxGlobalRunning === "number"
+      ? Math.max(0, options.maxGlobalRunning - runningItems.length)
+      : Number.POSITIVE_INFINITY;
+  const claimLimit = Math.min(Math.max(0, options.limit), globalCapacity);
+  if (claimLimit <= 0) return [];
+
+  const runningByProvider = new Map<string, number>();
+  for (const item of runningItems) {
+    runningByProvider.set(item.providerId, (runningByProvider.get(item.providerId) ?? 0) + 1);
+  }
+
   const eligible = queue.items
-    .filter((item) => item.status === "queued" && !item.cancelRequested)
+    .filter((item) => item.status === "queued" && !item.cancelRequested && (!options.queueId || item.queueId === options.queueId))
     .sort((a, b) => a.priority - b.priority || Date.parse(a.createdAt) - Date.parse(b.createdAt));
 
   const claimed: GenerationQueueItem[] = [];
-  for (const item of eligible.slice(0, Math.max(0, options.limit))) {
+  for (const item of eligible) {
+    if (claimed.length >= claimLimit) break;
+    const providerLimit = options.providerConcurrency?.[item.providerId];
+    const providerRunning = runningByProvider.get(item.providerId) ?? 0;
+    if (typeof providerLimit === "number" && providerRunning >= providerLimit) continue;
+
     item.status = "running";
+    item.attempt += 1;
     item.startedAt = item.startedAt ?? new Date(nowMs).toISOString();
     item.updatedAt = new Date(nowMs).toISOString();
     item.workerHostId = options.host.hostId;
@@ -192,6 +218,7 @@ function claimItems(queue: GenerationQueueFile, options: ClaimRunnableItemsOptio
     item.workerHeartbeatAt = new Date(nowMs).toISOString();
     item.workerLeaseExpiresAt = new Date(nowMs + leaseMs).toISOString();
     item.stage = "claiming";
+    runningByProvider.set(item.providerId, providerRunning + 1);
     claimed.push(structuredClone(item));
   }
   if (claimed.length > 0) {
@@ -266,13 +293,13 @@ export function createQueueStore(options: QueueStoreOptions): QueueStore {
         { timeoutMs, staleLockMs }
       );
     },
-    async claimRunnableItems({ host, limit }: ClaimRunnableItemsOptions): Promise<GenerationQueueItem[]> {
+    async claimRunnableItems(claimOptions: ClaimRunnableItemsOptions): Promise<GenerationQueueItem[]> {
       return withExclusiveFileLock(
         options.lockPath,
         async () => {
           const current = await readQueueFile(options.queuePath);
           const recovered = markStaleRunning(current, now(), staleRunningAfterMs);
-          const claimed = claimItems(recovered, { host, limit }, now(), leaseMs);
+          const claimed = claimItems(recovered, claimOptions, now(), leaseMs);
           await writeQueueFile(options.queuePath, recovered);
           return claimed;
         },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -75,6 +75,9 @@ import {
 } from "../shared/modelCatalog.js";
 import { compareVersions, isAllowedUpdateUrl, parseUpdateManifest, safeUpdateFileName, selectUpdateAsset } from "../shared/updateManifest.js";
 import { resolveDataDirs, resolveUserDataDir } from "../core/dataDirs.js";
+import { createGenerationQueueItem } from "../core/generation.js";
+import { requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion } from "../core/generationQueue.js";
+import { createQueueStore, type QueueStore } from "../core/queueStore.js";
 import { buildEndpoint, fetchWithTimeout } from "./services/openaiImageAdapter.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
@@ -176,7 +179,10 @@ let galleryOperationQueue: Promise<void> = Promise.resolve();
 let galleryWatchNeedsFullSync = false;
 let galleryWatchChangedRelPaths = new Set<string>();
 let stateWriteCount = 0;
+let generationQueueStore: QueueStore | null = null;
+const desktopWorkerHostId = `desktop_${process.pid}_${randomUUID()}`;
 const runningJobControllers = new Map<string, AbortController>();
+const queuedJobIds = new Map<string, string>();
 
 interface AssetProtocolPerfMetrics {
   galleryOriginalRequests: number;
@@ -341,6 +347,14 @@ function getBackupStatePath(): string {
   return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).backupStatePath;
 }
 
+function getQueuePath(): string {
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).queuePath;
+}
+
+function getQueueLockPath(): string {
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).queueLockPath;
+}
+
 function getDefaultImagesDir(): string {
   return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).imagesDir;
 }
@@ -375,6 +389,14 @@ function getHistoryImageRoots(state?: AppStateFile | null): string[] {
     ...dirs.legacyImageRoots
   ];
   return [...new Set(roots.map((root) => path.resolve(root)))];
+}
+
+function getGenerationQueueStore(): QueueStore {
+  generationQueueStore ??= createQueueStore({
+    queuePath: getQueuePath(),
+    lockPath: getQueueLockPath()
+  });
+  return generationQueueStore;
 }
 
 function assertKnownHistoryAssetPath(state: AppStateFile, assetPath: string): string {
@@ -2254,56 +2276,123 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
   const apiKey = await getApiKeyOrThrow();
   const imagesDir = getImagesDir(state);
   const { inputs, mask } = await resolveRequestInputs(normalizedRequest, imagesDir);
-  const startedAt = Date.now();
-  let job: GenerationJob = {
-    ...createJob(normalizedRequest, activeProvider, inputs, mask),
-    status: "running",
+  const queuedAt = Date.now();
+  let job: GenerationJob = createJob(normalizedRequest, activeProvider, inputs, mask);
+  await upsertJob(job);
+  const queueItem = createGenerationQueueItem({
+    source: "desktop",
+    providerId: activeProvider.id,
+    request: normalizedRequest,
+    costConfirmed: true,
+    historyJobId: job.id,
+    sourceAssetIds: [...inputs.map((asset) => asset.id), ...(mask ? [mask.id] : [])],
+    outputMediaKinds: ["image"]
+  });
+  queuedJobIds.set(job.id, queueItem.queueId);
+  await getGenerationQueueStore().appendItem(queueItem);
+
+  const result = await runGenerationQueueItemToCompletion<GenerationJob>({
+    queueStore: getGenerationQueueStore(),
+    queueId: queueItem.queueId,
+    host: { hostId: desktopWorkerHostId, kind: "desktop", processId: process.pid },
+    maxGlobalRunning: 1,
+    waitTimeoutMs: normalizedRequest.params.timeoutMs,
+    executeItem: async (_item, abortSignal) => {
+      const startedAt = Date.now();
+      const sendQueuedJobEvent = (event: JobProgressEvent) => sendJobEvent({ ...event, queueId: queueItem.queueId });
+      job = {
+        ...job,
+        status: "running",
+        updatedAt: new Date().toISOString()
+      };
+      await upsertJob(job);
+      sendQueuedJobEvent({ jobId: job.id, type: "started" });
+
+      try {
+        job = await adapter.runJob(job, apiKey, activeProvider, {
+          fetch,
+          imagesDir,
+          ensureDir,
+          sendJobEvent: sendQueuedJobEvent,
+          abortSignal
+        });
+        job = {
+          ...job,
+          name: job.name.trim() || defaultHistoryJobName(job),
+          durationMs: Date.now() - startedAt,
+          updatedAt: new Date().toISOString()
+        };
+        await upsertJob(job);
+        if (job.status === "succeeded") {
+          sendQueuedJobEvent({ jobId: job.id, type: "completed" });
+        } else {
+          sendQueuedJobEvent({ jobId: job.id, type: "failed", error: job.error });
+        }
+        return {
+          status: job.status === "succeeded" ? "succeeded" : "failed",
+          value: job,
+          historyJobId: job.id,
+          outputAssetIds: job.outputs.map((asset) => asset.id),
+          error: job.status === "failed" ? job.error : undefined
+        };
+      } catch (error) {
+        const message = abortSignal.aborted ? "任务已终止。" : normalizeError(error);
+        job = {
+          ...job,
+          status: "failed",
+          durationMs: Date.now() - startedAt,
+          error: message,
+          updatedAt: new Date().toISOString()
+        };
+        await upsertJob(job);
+        sendQueuedJobEvent({ jobId: job.id, type: "failed", error: message });
+        return {
+          status: "failed",
+          value: job,
+          historyJobId: job.id,
+          outputAssetIds: job.outputs.map((asset) => asset.id),
+          error: message
+        };
+      }
+    },
+    onStarted: (_item, controller) => {
+      runningJobControllers.set(job.id, controller);
+    },
+    onFinished: () => {
+      runningJobControllers.delete(job.id);
+      queuedJobIds.delete(job.id);
+    }
+  });
+
+  if (result.execution?.value) {
+    return result.execution.value;
+  }
+
+  const message = result.item?.status === "cancelled" ? "任务已终止。" : "任务等待超时。";
+  await requestGenerationQueueItemCancel(getGenerationQueueStore(), queueItem.queueId);
+  job = {
+    ...job,
+    status: "failed",
+    durationMs: Date.now() - queuedAt,
+    error: message,
     updatedAt: new Date().toISOString()
   };
   await upsertJob(job);
-  const abortController = new AbortController();
-  runningJobControllers.set(job.id, abortController);
-  sendJobEvent({ jobId: job.id, type: "started" });
-
-  try {
-    job = await adapter.runJob(job, apiKey, activeProvider, {
-      fetch,
-      imagesDir,
-      ensureDir,
-      sendJobEvent,
-      abortSignal: abortController.signal
-    });
-    job = {
-      ...job,
-      name: job.name.trim() || defaultHistoryJobName(job),
-      durationMs: Date.now() - startedAt,
-      updatedAt: new Date().toISOString()
-    };
-    await upsertJob(job);
-    sendJobEvent({ jobId: job.id, type: "completed" });
-    return job;
-  } catch (error) {
-    const message = abortController.signal.aborted ? "任务已终止。" : normalizeError(error);
-    job = {
-      ...job,
-      status: "failed",
-      durationMs: Date.now() - startedAt,
-      error: message,
-      updatedAt: new Date().toISOString()
-    };
-    await upsertJob(job);
-    sendJobEvent({ jobId: job.id, type: "failed", error: message });
-    return job;
-  } finally {
-    runningJobControllers.delete(job.id);
-  }
+  sendJobEvent({ jobId: job.id, queueId: queueItem.queueId, type: "failed", error: message });
+  queuedJobIds.delete(job.id);
+  return job;
 }
 
 function handleCancelJob(jobId: string): boolean {
   if (typeof jobId !== "string" || !jobId.trim()) return false;
   const controller = runningJobControllers.get(jobId);
-  if (!controller) return false;
-  controller.abort();
+  if (controller) {
+    controller.abort();
+    return true;
+  }
+  const queueId = queuedJobIds.get(jobId);
+  if (!queueId) return false;
+  void requestGenerationQueueItemCancel(getGenerationQueueStore(), queueId);
   return true;
 }
 
@@ -3208,9 +3297,9 @@ async function runCliCommandMode(args: string[]): Promise<number> {
           pathDisclosureRequiresConfirmation: true
         },
         knownLimitations: [
-          "v0.3.1 command mode is in Phase 0 spike state.",
-          "Durable queue, MCP stdio server, Gallery write tools, and generation tools are not implemented yet.",
-          "Use the desktop app for production image generation until the v0.3.1 queue path lands."
+          "v0.3.1 command mode is still readonly.",
+          "The desktop generation path uses the durable queue foundation; CLI/MCP generation tools are not implemented yet.",
+          "MCP stdio server, Gallery write tools, and agent generation tools are still in later v0.3.1 phases."
         ]
       };
       writeCliJson(cliSuccess(requestId, correlationId, data));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -441,6 +441,7 @@ export type CrossGenJsonResponse<TData = unknown> = CrossGenJsonSuccess<TData> |
 
 export interface JobProgressEvent {
   jobId: string;
+  queueId?: string;
   type: "started" | "attempt" | "partial" | "completed" | "failed";
   attemptIndex?: number;
   route?: OpenAIImageRoute;


### PR DESCRIPTION
## Summary
- add core generation queue item creation and queue runner helpers
- enforce queue claim caps for global/provider concurrency and queueId-specific claims
- route desktop job:run through durable queue while preserving the existing final GenerationJob facade and job events
- attach queueId to job progress events for future agent/CLI/MCP correlation

## Validation
- pnpm test -- src/core/queueStore.test.ts src/core/generationQueue.test.ts src/shared/validation.test.ts
- pnpm typecheck
- pnpm build
- ./node_modules/.bin/electron . --cli --version --json
- ./node_modules/.bin/electron . --cli doctor --agent --json