### PR TITLE
Add queue retry and partial retention

### DIFF
--- a/src/core/generation.ts
+++ b/src/core/generation.ts
@@ -32,6 +32,7 @@ export function createGenerationQueueItem(input: CreateGenerationQueueItemInput)
     updatedAt: now,
     historyJobId: input.historyJobId,
     outputAssetIds: [],
+    partialAssetIds: [],
     cancelRequested: false,
     costConfirmed: input.costConfirmed,
     executionKind: "sync-provider",

--- a/src/core/generationQueue.test.ts
+++ b/src/core/generationQueue.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createGenerationQueueItem } from "./generation";
-import { requestGenerationQueueItemCancel, runNextGenerationQueueItem } from "./generationQueue";
+import { recordGenerationQueuePartialOutput, requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion, runNextGenerationQueueItem } from "./generationQueue";
 import { createQueueStore } from "./queueStore";
 
 function request() {
@@ -130,6 +130,101 @@ describe("generationQueue", () => {
     const requested = await requestGenerationQueueItemCancel(store, running.queueId);
     expect(requested?.status).toBe("running");
     expect(requested?.cancelRequested).toBe(true);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("requeues retryable failures until maxAttempts is reached", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-1",
+      maxAttempts: 2
+    });
+    await store.appendItem(item);
+
+    let calls = 0;
+    const result = await runGenerationQueueItemToCompletion({
+      queueStore: store,
+      queueId: item.queueId,
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      pollIntervalMs: 0,
+      classifyFailure: () => ({ category: "transient", retryable: true }),
+      retryBackoffMs: () => 0,
+      executeItem: async () => {
+        calls += 1;
+        if (calls === 1) return { status: "failed", error: "rate limited" };
+        return { status: "succeeded", historyJobId: "job-1", outputAssetIds: ["asset-final"], value: { ok: true } };
+      }
+    });
+
+    expect(result.item?.status).toBe("succeeded");
+    expect(calls).toBe(2);
+    const queue = await store.read();
+    expect(queue.items[0]).toMatchObject({
+      status: "succeeded",
+      attempt: 2,
+      outputAssetIds: ["asset-final"]
+    });
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not retry non-retryable failures", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      maxAttempts: 3
+    });
+    await store.appendItem(item);
+
+    const result = await runNextGenerationQueueItem({
+      queueStore: store,
+      queueId: item.queueId,
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      classifyFailure: () => ({ category: "auth", retryable: false }),
+      executeItem: async () => ({ status: "failed", error: "unauthorized" })
+    });
+
+    expect(result.item?.status).toBe("failed");
+    const queue = await store.read();
+    expect(queue.items[0]).toMatchObject({
+      status: "failed",
+      attempt: 1,
+      lastError: "unauthorized",
+      lastErrorCategory: "auth",
+      lastErrorRetryable: false
+    });
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("records partial outputs without duplicating asset ids", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true
+    });
+    await store.appendItem(item);
+
+    await recordGenerationQueuePartialOutput(store, item.queueId, ["partial-1", "partial-1", "partial-2"]);
+    const queue = await store.read();
+    expect(queue.items[0].partialAssetIds).toEqual(["partial-1", "partial-2"]);
+    expect(queue.items[0].outputAssetIds).toEqual(["partial-1", "partial-2"]);
 
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/src/core/generationQueue.ts
+++ b/src/core/generationQueue.ts
@@ -1,12 +1,26 @@
-import type { GenerationQueueItem, GenerationQueueWorkerHost, JobStatus } from "../shared/types.js";
+import type { GenerationQueueItem, GenerationQueueWorkerHost, JobStatus, QueueErrorCategory } from "../shared/types.js";
 import type { QueueHostIdentity, QueueStore } from "./queueStore.js";
+
+export interface GenerationQueueFailureClassification {
+  category: QueueErrorCategory;
+  retryable: boolean;
+}
 
 export interface GenerationQueueExecutionResult<TValue = unknown> {
   status?: Extract<JobStatus, "succeeded" | "failed" | "cancelled">;
   value?: TValue;
   historyJobId?: string;
   outputAssetIds?: string[];
+  partialAssetIds?: string[];
   error?: string;
+  errorCategory?: QueueErrorCategory;
+  retryable?: boolean;
+}
+
+export interface ClassifyGenerationQueueFailureInput {
+  item: GenerationQueueItem;
+  error?: unknown;
+  result?: GenerationQueueExecutionResult;
 }
 
 export interface RunNextGenerationQueueItemOptions<TValue = unknown> {
@@ -18,6 +32,8 @@ export interface RunNextGenerationQueueItemOptions<TValue = unknown> {
   providerConcurrency?: Record<string, number>;
   leaseMs?: number;
   now?: () => number;
+  classifyFailure?: (input: ClassifyGenerationQueueFailureInput) => GenerationQueueFailureClassification;
+  retryBackoffMs?: (item: GenerationQueueItem, classification: GenerationQueueFailureClassification) => number;
   createAbortController?: () => AbortController;
   onStarted?: (item: GenerationQueueItem, controller: AbortController) => void;
   onFinished?: (item: GenerationQueueItem) => void;
@@ -46,6 +62,18 @@ function iso(now: number): string {
 
 function normalizeTerminalStatus(status: GenerationQueueExecutionResult["status"] | undefined): Extract<JobStatus, "succeeded" | "failed" | "cancelled"> {
   return status === "failed" || status === "cancelled" ? status : "succeeded";
+}
+
+function defaultFailureClassification(): GenerationQueueFailureClassification {
+  return { category: "unknown", retryable: false };
+}
+
+function defaultRetryBackoffMs(item: GenerationQueueItem): number {
+  return Math.min(30000, 1000 * 2 ** Math.max(0, item.attempt - 1));
+}
+
+function mergeUnique(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
 }
 
 function makeWorkerHost(host: QueueHostIdentity, nowMs: number, leaseMs: number): GenerationQueueWorkerHost {
@@ -94,10 +122,14 @@ async function completeClaimedItem(
           status,
           stage: "finalizing",
           completedAt: iso(nowMs),
+          nextRunAt: undefined,
           updatedAt: iso(nowMs),
           lastError: result.error,
+          lastErrorCategory: result.errorCategory,
+          lastErrorRetryable: result.retryable,
           historyJobId: result.historyJobId ?? current.historyJobId,
           outputAssetIds: result.outputAssetIds ?? current.outputAssetIds,
+          partialAssetIds: result.partialAssetIds ?? current.partialAssetIds,
           cancelRequested: status === "cancelled" ? true : current.cancelRequested,
           workerHostId: undefined,
           workerProcessId: undefined,
@@ -112,11 +144,48 @@ async function completeClaimedItem(
   return completed ?? item;
 }
 
+async function scheduleRetry(
+  queueStore: QueueStore,
+  item: GenerationQueueItem,
+  message: string,
+  classification: GenerationQueueFailureClassification,
+  retryBackoffMs: number,
+  nowMs: number
+): Promise<GenerationQueueItem | undefined> {
+  if (!classification.retryable || item.cancelRequested || item.attempt >= item.maxAttempts) return undefined;
+  let requeued: GenerationQueueItem | undefined;
+  await queueStore.mutate((queue) => ({
+    ...queue,
+    updatedAt: iso(nowMs),
+    items: queue.items.map((current) => {
+      if (current.queueId !== item.queueId) return current;
+      requeued = {
+        ...current,
+        status: "queued",
+        stage: "queued",
+        nextRunAt: iso(nowMs + Math.max(0, retryBackoffMs)),
+        updatedAt: iso(nowMs),
+        lastError: message,
+        lastErrorCategory: classification.category,
+        lastErrorRetryable: classification.retryable,
+        completedAt: undefined,
+        workerHostId: undefined,
+        workerProcessId: undefined,
+        workerHeartbeatAt: undefined,
+        workerLeaseExpiresAt: undefined
+      };
+      return requeued;
+    })
+  }));
+  return requeued;
+}
+
 async function failClaimedItem<TValue = unknown>(
   queueStore: QueueStore,
   item: GenerationQueueItem,
   error: unknown,
-  nowMs: number
+  nowMs: number,
+  classification: GenerationQueueFailureClassification
 ): Promise<GenerationQueueExecutionResult<TValue>> {
   const message = error instanceof Error ? error.message : String(error);
   await completeClaimedItem(
@@ -125,12 +194,23 @@ async function failClaimedItem<TValue = unknown>(
     {
       status: "failed",
       error: message,
+      errorCategory: classification.category,
+      retryable: classification.retryable,
       historyJobId: item.historyJobId,
-      outputAssetIds: item.outputAssetIds
+      outputAssetIds: item.outputAssetIds,
+      partialAssetIds: item.partialAssetIds
     },
     nowMs
   );
-  return { status: "failed", error: message, historyJobId: item.historyJobId, outputAssetIds: item.outputAssetIds };
+  return {
+    status: "failed",
+    error: message,
+    errorCategory: classification.category,
+    retryable: classification.retryable,
+    historyJobId: item.historyJobId,
+    outputAssetIds: item.outputAssetIds,
+    partialAssetIds: item.partialAssetIds
+  };
 }
 
 export async function runNextGenerationQueueItem<TValue = unknown>(
@@ -153,10 +233,59 @@ export async function runNextGenerationQueueItem<TValue = unknown>(
   try {
     await markClaimedItemStage(options.queueStore, item.queueId, now());
     const execution = await options.executeItem(item, controller.signal);
+    if (execution.status === "failed") {
+      const classification = options.classifyFailure?.({ item, result: execution }) ?? defaultFailureClassification();
+      const retryItem = await scheduleRetry(
+        options.queueStore,
+        item,
+        execution.error ?? "Generation failed.",
+        classification,
+        (options.retryBackoffMs ?? defaultRetryBackoffMs)(item, classification),
+        now()
+      );
+      if (retryItem) {
+        return {
+          claimed: true,
+          item: retryItem,
+          execution: {
+            ...execution,
+            errorCategory: classification.category,
+            retryable: classification.retryable
+          }
+        };
+      }
+      execution.errorCategory = execution.errorCategory ?? classification.category;
+      execution.retryable = execution.retryable ?? classification.retryable;
+    }
     const completed = await completeClaimedItem(options.queueStore, item, execution, now());
     return { claimed: true, item: completed, execution };
   } catch (error) {
-    const execution = await failClaimedItem<TValue>(options.queueStore, item, error, now());
+    const classification = options.classifyFailure?.({ item, error }) ?? defaultFailureClassification();
+    const message = error instanceof Error ? error.message : String(error);
+    const retryItem = await scheduleRetry(
+      options.queueStore,
+      item,
+      message,
+      classification,
+      (options.retryBackoffMs ?? defaultRetryBackoffMs)(item, classification),
+      now()
+    );
+    if (retryItem) {
+      return {
+        claimed: true,
+        item: retryItem,
+        execution: {
+          status: "failed",
+          error: message,
+          errorCategory: classification.category,
+          retryable: classification.retryable,
+          historyJobId: item.historyJobId,
+          outputAssetIds: item.outputAssetIds,
+          partialAssetIds: item.partialAssetIds
+        }
+      };
+    }
+    const execution = await failClaimedItem<TValue>(options.queueStore, item, error, now(), classification);
     return { claimed: true, item, execution };
   } finally {
     options.onFinished?.(item);
@@ -170,6 +299,10 @@ export async function runGenerationQueueItemToCompletion<TValue = unknown>(
   const pollIntervalMs = options.pollIntervalMs ?? 100;
   while (true) {
     const result = await runNextGenerationQueueItem(options);
+    if (result.claimed && result.item && !TERMINAL_STATUSES.has(result.item.status)) {
+      await sleep(pollIntervalMs);
+      continue;
+    }
     if (result.claimed) return result;
 
     const queue = await options.queueStore.read();
@@ -181,6 +314,30 @@ export async function runGenerationQueueItemToCompletion<TValue = unknown>(
     }
     await sleep(pollIntervalMs);
   }
+}
+
+export async function recordGenerationQueuePartialOutput(queueStore: QueueStore, queueId: string, assetIds: string[], now = Date.now): Promise<GenerationQueueItem | undefined> {
+  const incoming = mergeUnique(assetIds);
+  if (incoming.length === 0) return undefined;
+  let updated: GenerationQueueItem | undefined;
+  await queueStore.mutate((queue) => {
+    const nowIso = iso(now());
+    return {
+      ...queue,
+      updatedAt: nowIso,
+      items: queue.items.map((item) => {
+        if (item.queueId !== queueId) return item;
+        updated = {
+          ...item,
+          updatedAt: nowIso,
+          partialAssetIds: mergeUnique([...item.partialAssetIds, ...incoming]),
+          outputAssetIds: mergeUnique([...item.outputAssetIds, ...incoming])
+        };
+        return updated;
+      })
+    };
+  });
+  return updated;
 }
 
 export async function requestGenerationQueueItemCancel(queueStore: QueueStore, queueId: string, now = Date.now): Promise<GenerationQueueItem | undefined> {

--- a/src/core/queueStore.test.ts
+++ b/src/core/queueStore.test.ts
@@ -39,6 +39,7 @@ function queueItem(patch: Partial<GenerationQueueItem> = {}): GenerationQueueIte
     createdAt: now,
     updatedAt: now,
     outputAssetIds: [],
+    partialAssetIds: [],
     cancelRequested: false,
     costConfirmed: true,
     executionKind: "sync-provider",
@@ -136,6 +137,30 @@ describe("queueStore", () => {
     const queue = await store.read();
     expect(queue.items.find((item) => item.queueId === "queue-old")?.status).toBe("queued");
     expect(queue.items.find((item) => item.queueId === "queue-target")?.status).toBe("running");
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not claim items before nextRunAt", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({
+      queuePath,
+      lockPath: `${queuePath}.lock`,
+      now: () => Date.parse("2026-07-13T00:00:00.000Z")
+    });
+
+    await store.appendItem(queueItem({
+      queueId: "queue-later",
+      nextRunAt: "2026-07-13T00:01:00.000Z"
+    }));
+    await store.appendItem(queueItem({ queueId: "queue-now" }));
+
+    const claimed = await store.claimRunnableItems({
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      limit: 2
+    });
+    expect(claimed.map((item) => item.queueId)).toEqual(["queue-now"]);
 
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/src/core/queueStore.ts
+++ b/src/core/queueStore.ts
@@ -5,6 +5,7 @@ import type {
   GenerationQueueFile,
   GenerationQueueItem,
   GenerationQueueWorkerHost,
+  QueueErrorCategory,
   JobStatus,
   QueueExecutionKind,
   QueueStage
@@ -98,9 +99,13 @@ function normalizeQueueItem(raw: Partial<GenerationQueueItem>): GenerationQueueI
     startedAt: typeof raw.startedAt === "string" ? raw.startedAt : undefined,
     updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : createdAt,
     completedAt: typeof raw.completedAt === "string" ? raw.completedAt : undefined,
+    nextRunAt: typeof raw.nextRunAt === "string" ? raw.nextRunAt : undefined,
     lastError: typeof raw.lastError === "string" ? raw.lastError : undefined,
+    lastErrorCategory: normalizeQueueErrorCategory(raw.lastErrorCategory),
+    lastErrorRetryable: typeof raw.lastErrorRetryable === "boolean" ? raw.lastErrorRetryable : undefined,
     historyJobId: typeof raw.historyJobId === "string" ? raw.historyJobId : undefined,
     outputAssetIds: Array.isArray(raw.outputAssetIds) ? raw.outputAssetIds.filter((value): value is string => typeof value === "string") : [],
+    partialAssetIds: Array.isArray(raw.partialAssetIds) ? raw.partialAssetIds.filter((value): value is string => typeof value === "string") : [],
     cancelRequested: Boolean(raw.cancelRequested),
     costConfirmed: Boolean(raw.costConfirmed),
     workerHostId: typeof raw.workerHostId === "string" ? raw.workerHostId : undefined,
@@ -148,6 +153,18 @@ function normalizeQueueStage(value: unknown): QueueStage {
   return value === "claiming" || value === "calling_provider" || value === "awaiting_remote" || value === "downloading" || value === "postprocessing" || value === "finalizing"
     ? value
     : "queued";
+}
+
+function normalizeQueueErrorCategory(value: unknown): QueueErrorCategory | undefined {
+  return value === "transient" ||
+    value === "auth" ||
+    value === "quota" ||
+    value === "safety" ||
+    value === "cancelled" ||
+    value === "unsupported" ||
+    value === "unknown"
+    ? value
+    : undefined;
 }
 
 function isMediaKind(value: unknown): value is "image" | "animated-gif" | "video" {
@@ -199,7 +216,12 @@ function claimItems(queue: GenerationQueueFile, options: ClaimRunnableItemsOptio
   }
 
   const eligible = queue.items
-    .filter((item) => item.status === "queued" && !item.cancelRequested && (!options.queueId || item.queueId === options.queueId))
+    .filter((item) => {
+      if (item.status !== "queued" || item.cancelRequested) return false;
+      if (options.queueId && item.queueId !== options.queueId) return false;
+      const nextRunAt = item.nextRunAt ? Date.parse(item.nextRunAt) : Number.NaN;
+      return !Number.isFinite(nextRunAt) || nextRunAt <= nowMs;
+    })
     .sort((a, b) => a.priority - b.priority || Date.parse(a.createdAt) - Date.parse(b.createdAt));
 
   const claimed: GenerationQueueItem[] = [];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -76,7 +76,7 @@ import {
 import { compareVersions, isAllowedUpdateUrl, parseUpdateManifest, safeUpdateFileName, selectUpdateAsset } from "../shared/updateManifest.js";
 import { resolveDataDirs, resolveUserDataDir } from "../core/dataDirs.js";
 import { createGenerationQueueItem } from "../core/generation.js";
-import { requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion } from "../core/generationQueue.js";
+import { recordGenerationQueuePartialOutput, requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion } from "../core/generationQueue.js";
 import { createQueueStore, type QueueStore } from "../core/queueStore.js";
 import { buildEndpoint, fetchWithTimeout } from "./services/openaiImageAdapter.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
@@ -1059,6 +1059,14 @@ function createJob(request: RunJobRequest, config: StoredProviderConfig, inputAs
 function defaultHistoryJobName(job: GenerationJob): string {
   const result = job.outputs.find((asset) => asset.sourceType === "result") ?? job.outputs[job.outputs.length - 1];
   return result?.fileName ? path.basename(result.fileName) : job.name.trim() || `${job.modelDisplayName || job.modelId || "image"}-${job.id.slice(-8)}.png`;
+}
+
+function mergeImageAssets(...groups: ImageAsset[][]): ImageAsset[] {
+  const byId = new Map<string, ImageAsset>();
+  for (const asset of groups.flat()) {
+    byId.set(asset.id, asset);
+  }
+  return [...byId.values()];
 }
 
 async function upsertJob(job: GenerationJob): Promise<void> {
@@ -2299,7 +2307,14 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
     waitTimeoutMs: normalizedRequest.params.timeoutMs,
     executeItem: async (_item, abortSignal) => {
       const startedAt = Date.now();
-      const sendQueuedJobEvent = (event: JobProgressEvent) => sendJobEvent({ ...event, queueId: queueItem.queueId });
+      const partialAssets: ImageAsset[] = [];
+      const sendQueuedJobEvent = (event: JobProgressEvent) => {
+        if (event.type === "partial" && event.image) {
+          partialAssets.push(event.image);
+          void recordGenerationQueuePartialOutput(getGenerationQueueStore(), queueItem.queueId, [event.image.id]);
+        }
+        sendJobEvent({ ...event, queueId: queueItem.queueId });
+      };
       job = {
         ...job,
         status: "running",
@@ -2333,6 +2348,7 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
           value: job,
           historyJobId: job.id,
           outputAssetIds: job.outputs.map((asset) => asset.id),
+          partialAssetIds: job.outputs.filter((asset) => asset.sourceType === "partial").map((asset) => asset.id),
           error: job.status === "failed" ? job.error : undefined
         };
       } catch (error) {
@@ -2342,6 +2358,7 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
           status: "failed",
           durationMs: Date.now() - startedAt,
           error: message,
+          outputs: mergeImageAssets(job.outputs, partialAssets),
           updatedAt: new Date().toISOString()
         };
         await upsertJob(job);
@@ -2351,6 +2368,7 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
           value: job,
           historyJobId: job.id,
           outputAssetIds: job.outputs.map((asset) => asset.id),
+          partialAssetIds: partialAssets.map((asset) => asset.id),
           error: message
         };
       }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,6 +20,8 @@ export type QueueSource = "desktop" | "cli" | "mcp";
 
 export type QueueExecutionKind = "sync-provider" | "remote-poll" | "local-cpu";
 
+export type QueueErrorCategory = "transient" | "auth" | "quota" | "safety" | "cancelled" | "unsupported" | "unknown";
+
 export type QueueStage =
   | "queued"
   | "claiming"
@@ -360,9 +362,13 @@ export interface GenerationQueueItem {
   startedAt?: string;
   updatedAt: string;
   completedAt?: string;
+  nextRunAt?: string;
   lastError?: string;
+  lastErrorCategory?: QueueErrorCategory;
+  lastErrorRetryable?: boolean;
   historyJobId?: string;
   outputAssetIds: string[];
+  partialAssetIds: string[];
   cancelRequested: boolean;
   costConfirmed: boolean;
   workerHostId?: string;


### PR DESCRIPTION
## Summary
- add queue retry metadata: nextRunAt, error category/retryable flags, partial asset ids
- make queue claim respect nextRunAt so backoff jobs are not claimed early
- add generation queue retry scheduling for injected retryable failures without changing desktop default maxAttempts
- record partial output ids in queue and preserve partial assets on desktop generation failure

## Validation
- pnpm test -- src/core/queueStore.test.ts src/core/generationQueue.test.ts
- pnpm typecheck
- pnpm build
- ./node_modules/.bin/electron . --cli --version --json
- ./node_modules/.bin/electron . --cli doctor --agent --json