### PR TITLE
Add readonly CLI discovery commands

### DIFF
--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -1,0 +1,270 @@
+import { listProviderModelCapabilitySummaries } from "../core/modelCapabilities.js";
+import type {
+  GalleryAsset,
+  GalleryFolder,
+  GenerationJob,
+  GenerationQueueFile,
+  ImageQuality,
+  OpenAIImageRouting,
+  ProviderConfig,
+  ProviderKind,
+  StorageSettings
+} from "../shared/types.js";
+import type { FocusedLaunchId } from "../shared/types.js";
+
+interface ReadonlyProviderConfig {
+  id: string;
+  kind: ProviderKind;
+  name: string;
+  baseURL: string;
+  enabled: boolean;
+  defaultModel: string;
+  defaultSize: string;
+  defaultQuality: ImageQuality;
+  timeoutMs: number;
+  streamingPartialsEnabled: boolean;
+  discoveredModels: ProviderConfig["discoveredModels"];
+  lastModelDiscoveryAt?: string;
+  lastModelDiscoveryError?: string;
+  activeLaunchId: FocusedLaunchId;
+  activeModelId: string;
+  openAIImageRouting?: OpenAIImageRouting;
+  updatedAt: string;
+  encryptedApiKey?: string;
+}
+
+interface ReadonlyAppState {
+  providers: ReadonlyProviderConfig[];
+  activeProviderId: string;
+  history: GenerationJob[];
+  galleryFolders: GalleryFolder[];
+  galleryAssets: GalleryAsset[];
+  storage?: StorageSettings;
+}
+
+export type McpClientName = "codex" | "claude-code" | "cursor";
+
+export type McpMode = "readonly" | "write" | "generate";
+
+function activeProvider(state: ReadonlyAppState): ReadonlyProviderConfig | undefined {
+  return state.providers.find((provider) => provider.id === state.activeProviderId) ?? state.providers[0];
+}
+
+function publicProvider(provider: ReadonlyProviderConfig) {
+  return {
+    id: provider.id,
+    kind: provider.kind,
+    name: provider.name,
+    enabled: provider.enabled,
+    activeLaunchId: provider.activeLaunchId,
+    activeModelId: provider.activeModelId,
+    defaultModel: provider.defaultModel,
+    defaultSize: provider.defaultSize,
+    defaultQuality: provider.defaultQuality,
+    timeoutMs: provider.timeoutMs,
+    streamingPartialsEnabled: provider.streamingPartialsEnabled,
+    discoveredModelCount: provider.discoveredModels.length,
+    lastModelDiscoveryAt: provider.lastModelDiscoveryAt,
+    lastModelDiscoveryError: provider.lastModelDiscoveryError,
+    apiKeySaved: Boolean(provider.encryptedApiKey),
+    openAIImageRouting: provider.openAIImageRouting
+  };
+}
+
+function capabilityProvider(provider: ReadonlyProviderConfig): ProviderConfig {
+  return {
+    ...provider,
+    apiKeySaved: Boolean(provider.encryptedApiKey),
+    discoveredModels: provider.discoveredModels
+  };
+}
+
+function queueStatusCounts(queue: GenerationQueueFile): Record<string, number> {
+  return queue.items.reduce<Record<string, number>>((counts, item) => {
+    counts[item.status] = (counts[item.status] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function promptPreview(prompt: string, maxLength = 180): string {
+  const trimmed = prompt.replace(/\s+/g, " ").trim();
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength - 1)}...` : trimmed;
+}
+
+function liveWorkerHosts(queue: GenerationQueueFile, now = Date.now()): number {
+  return queue.workerHosts.filter((host) => Date.parse(host.leaseExpiresAt) > now).length;
+}
+
+export function buildCliConfigStatus(state: ReadonlyAppState | null, queue: GenerationQueueFile) {
+  const provider = state ? activeProvider(state) : undefined;
+  return {
+    stateFound: Boolean(state),
+    activeProvider: provider ? publicProvider(provider) : null,
+    providerCount: state?.providers.length ?? 0,
+    historyCount: state?.history.length ?? 0,
+    galleryFolderCount: state?.galleryFolders.length ?? 0,
+    galleryAssetCount: state?.galleryAssets.length ?? 0,
+    queueItemCount: queue.items.length,
+    queueStatusCounts: queueStatusCounts(queue),
+    liveWorkerHosts: liveWorkerHosts(queue),
+    storageConfigured: {
+      historyDir: Boolean(state?.storage?.historyDir),
+      galleryDir: Boolean(state?.storage?.galleryDir)
+    }
+  };
+}
+
+export function buildCliProviderList(state: ReadonlyAppState | null) {
+  return {
+    activeProviderId: state?.activeProviderId ?? null,
+    providers: state?.providers.map(publicProvider) ?? []
+  };
+}
+
+export function buildCliModelsList(state: ReadonlyAppState | null) {
+  return {
+    providers: state?.providers.map((provider) => ({
+      provider: publicProvider(provider),
+      models: listProviderModelCapabilitySummaries(capabilityProvider(provider))
+    })) ?? []
+  };
+}
+
+export function buildCliQueueStatus(queue: GenerationQueueFile) {
+  return {
+    schemaVersion: queue.schemaVersion,
+    updatedAt: queue.updatedAt,
+    totalItems: queue.items.length,
+    statusCounts: queueStatusCounts(queue),
+    liveWorkerHosts: liveWorkerHosts(queue),
+    workerHosts: queue.workerHosts.map((host) => ({
+      hostId: host.hostId,
+      kind: host.kind,
+      processId: host.processId,
+      mode: host.mode,
+      heartbeatAt: host.heartbeatAt,
+      leaseExpiresAt: host.leaseExpiresAt
+    }))
+  };
+}
+
+export function buildCliJobList(queue: GenerationQueueFile) {
+  return {
+    jobs: queue.items.map((item) => ({
+      queueId: item.queueId,
+      source: item.source,
+      providerId: item.providerId,
+      status: item.status,
+      priority: item.priority,
+      attempt: item.attempt,
+      maxAttempts: item.maxAttempts,
+      mode: item.request.mode,
+      promptPreview: promptPreview(item.request.prompt),
+      createdAt: item.createdAt,
+      startedAt: item.startedAt,
+      updatedAt: item.updatedAt,
+      completedAt: item.completedAt,
+      nextRunAt: item.nextRunAt,
+      lastError: item.lastError,
+      lastErrorCategory: item.lastErrorCategory,
+      lastErrorRetryable: item.lastErrorRetryable,
+      historyJobId: item.historyJobId,
+      outputAssetIds: item.outputAssetIds,
+      partialAssetIds: item.partialAssetIds,
+      cancelRequested: item.cancelRequested,
+      workerHostId: item.workerHostId,
+      executionKind: item.executionKind,
+      stage: item.stage,
+      outputMediaKinds: item.outputMediaKinds,
+      requestId: item.requestId,
+      correlationId: item.correlationId
+    }))
+  };
+}
+
+export function buildCliGalleryList(state: ReadonlyAppState | null) {
+  return {
+    folders: state?.galleryFolders.map((folder) => ({
+      id: folder.id,
+      name: folder.name,
+      parentId: folder.parentId ?? null,
+      color: folder.color,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt
+    })) ?? [],
+    assets: state?.galleryAssets.map((asset) => ({
+      id: asset.id,
+      originalName: asset.originalName,
+      mimeType: asset.mimeType,
+      kind: asset.kind ?? "image",
+      sizeBytes: asset.sizeBytes,
+      width: asset.width,
+      height: asset.height,
+      folderId: asset.folderId ?? null,
+      tags: asset.tags,
+      source: asset.source,
+      sourceJobId: asset.sourceJobId,
+      sourceAssetId: asset.sourceAssetId,
+      createdAt: asset.createdAt,
+      updatedAt: asset.updatedAt,
+      modifiedAt: asset.modifiedAt,
+      hasContentHash: Boolean(asset.contentHash)
+    })) ?? []
+  };
+}
+
+export function buildCliFolderList(state: ReadonlyAppState | null) {
+  return {
+    folders: state?.galleryFolders.map((folder) => ({
+      id: folder.id,
+      name: folder.name,
+      parentId: folder.parentId ?? null,
+      color: folder.color,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt
+    })) ?? []
+  };
+}
+
+export function buildCliAssetInspect(state: ReadonlyAppState | null, assetId: string) {
+  const asset = state?.galleryAssets.find((candidate) => candidate.id === assetId);
+  if (!asset) return null;
+  return {
+    id: asset.id,
+    originalName: asset.originalName,
+    mimeType: asset.mimeType,
+    kind: asset.kind ?? "image",
+    sizeBytes: asset.sizeBytes,
+    width: asset.width,
+    height: asset.height,
+    folderId: asset.folderId ?? null,
+    tags: asset.tags,
+    source: asset.source,
+    sourceJobId: asset.sourceJobId,
+    sourceAssetId: asset.sourceAssetId,
+    createdAt: asset.createdAt,
+    updatedAt: asset.updatedAt,
+    modifiedAt: asset.modifiedAt,
+    hasContentHash: Boolean(asset.contentHash),
+    hasSourcePathHash: Boolean(asset.sourcePathHash)
+  };
+}
+
+export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMode; command: string }) {
+  const args = ["--mcp"];
+  return {
+    client: options.client,
+    mode: options.mode,
+    transport: "stdio",
+    command: options.command,
+    args,
+    env: {
+      CROSSGEN_MCP_MODE: options.mode
+    },
+    permissions: {
+      readonly: true,
+      write: options.mode === "write" || options.mode === "generate",
+      generate: options.mode === "generate"
+    }
+  };
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -78,6 +78,19 @@ import { resolveDataDirs, resolveUserDataDir } from "../core/dataDirs.js";
 import { createGenerationQueueItem } from "../core/generation.js";
 import { recordGenerationQueuePartialOutput, requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion } from "../core/generationQueue.js";
 import { createQueueStore, type QueueStore } from "../core/queueStore.js";
+import {
+  buildCliAssetInspect,
+  buildCliConfigStatus,
+  buildCliFolderList,
+  buildCliGalleryList,
+  buildCliJobList,
+  buildCliMcpConfig,
+  buildCliModelsList,
+  buildCliProviderList,
+  buildCliQueueStatus,
+  type McpClientName,
+  type McpMode
+} from "../cli/readonly.js";
 import { buildEndpoint, fetchWithTimeout } from "./services/openaiImageAdapter.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
@@ -3206,6 +3219,19 @@ function getCliCommand(args: string[]): string | undefined {
   return args.find((arg) => !arg.startsWith("--"));
 }
 
+function getCliSubcommand(args: string[], command: string | undefined): string | undefined {
+  if (!command) return undefined;
+  const commandIndex = args.indexOf(command);
+  if (commandIndex < 0) return undefined;
+  return args.slice(commandIndex + 1).find((arg) => !arg.startsWith("--"));
+}
+
+function getCliPositionalAfter(args: string[], token: string): string | undefined {
+  const index = args.indexOf(token);
+  if (index < 0) return undefined;
+  return args.slice(index + 1).find((arg) => !arg.startsWith("--"));
+}
+
 function writeCliJson(response: CrossGenJsonResponse): void {
   process.stdout.write(`${JSON.stringify(response)}\n`);
 }
@@ -3250,6 +3276,18 @@ async function readExistingStateForCli(): Promise<AppStateFile | null> {
   }
 }
 
+async function readExistingQueueForCli() {
+  return getGenerationQueueStore().read();
+}
+
+function normalizeCliMcpClient(value: string | undefined): McpClientName {
+  return value === "claude-code" || value === "cursor" ? value : "codex";
+}
+
+function normalizeCliMcpMode(value: string | undefined): McpMode {
+  return value === "write" || value === "generate" ? value : "readonly";
+}
+
 function envApiKeyAvailable(kind: StoredProviderConfig["kind"]): boolean {
   const providerSpecific = kind === "gemini" ? "CROSSGEN_GEMINI_API_KEY" : kind === "custom" ? "CROSSGEN_CUSTOM_API_KEY" : "CROSSGEN_OPENAI_API_KEY";
   return Boolean(process.env[providerSpecific]?.trim() || process.env.CROSSGEN_API_KEY?.trim());
@@ -3264,6 +3302,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
   const correlationId = getCliCorrelationId(args, requestId);
   const json = hasCliFlag(args, "--json");
   const command = getCliCommand(args);
+  const subcommand = getCliSubcommand(args, command);
 
   try {
     if (hasCliFlag(args, "--version") || command === "version") {
@@ -3279,6 +3318,16 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       } else {
         process.stdout.write(`${BRAND_NAME} ${getAppVersion()}\n`);
       }
+      return 0;
+    }
+
+    if (command === "mcp" && subcommand === "config") {
+      const data = buildCliMcpConfig({
+        client: normalizeCliMcpClient(getCliOption(args, "--client")),
+        mode: normalizeCliMcpMode(getCliOption(args, "--mode")),
+        command: process.execPath
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, data));
       return 0;
     }
 
@@ -3324,9 +3373,66 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       return 0;
     }
 
+    if (command === "config" && subcommand === "status") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliConfigStatus(await readExistingStateForCli(), await readExistingQueueForCli())));
+      return 0;
+    }
+
+    if (command === "provider" && subcommand === "list") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliProviderList(await readExistingStateForCli())));
+      return 0;
+    }
+
+    if (command === "models" && subcommand === "list") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliModelsList(await readExistingStateForCli())));
+      return 0;
+    }
+
+    if (command === "queue" && subcommand === "status") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliQueueStatus(await readExistingQueueForCli())));
+      return 0;
+    }
+
+    if (command === "job" && subcommand === "list") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliJobList(await readExistingQueueForCli())));
+      return 0;
+    }
+
+    if (command === "folder" && subcommand === "list") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliFolderList(await readExistingStateForCli())));
+      return 0;
+    }
+
+    if (command === "gallery" && subcommand === "list") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliGalleryList(await readExistingStateForCli())));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "inspect") {
+      const assetId = getCliOption(args, "--asset-id")?.trim() || getCliPositionalAfter(args, subcommand)?.trim();
+      if (!assetId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing --asset-id for asset inspect.", ["Use --asset-id <gallery asset id>."]));
+        return 2;
+      }
+      const asset = buildCliAssetInspect(await readExistingStateForCli(), assetId);
+      if (!asset) {
+        writeCliJson(cliFailure(requestId, correlationId, "ASSET_NOT_FOUND", "Gallery asset not found.", ["Run crossgen --cli gallery list --json to find asset ids."]));
+        return 4;
+      }
+      writeCliJson(cliSuccess(requestId, correlationId, { asset }));
+      return 0;
+    }
+
     const response = cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Unsupported CrossGen CLI command.", [
       "Use --cli --version --json.",
-      "Use --cli doctor --agent --json."
+      "Use --cli doctor --agent --json.",
+      "Use --cli config status --json.",
+      "Use --cli provider list --json.",
+      "Use --cli models list --json.",
+      "Use --cli queue status --json.",
+      "Use --cli job list --json.",
+      "Use --cli gallery list --json.",
+      "Use --cli mcp config --client codex --mode readonly --json."
     ]);
     if (json) {
       writeCliJson(response);

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -14,6 +14,6 @@
     "sourceMap": true,
     "declaration": false
   },
-  "include": ["src/core", "src/main", "src/preload", "src/shared"],
+  "include": ["src/cli", "src/core", "src/main", "src/preload", "src/shared"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- add reusable readonly CLI summary builders under src/cli
- add command-mode JSON commands for config/provider/models/queue/job/folder/gallery/asset readonly discovery
- add mcp config snippet generation for codex/claude-code/cursor and readonly/write/generate modes
- include src/cli in main-process TypeScript build

## Validation
- pnpm typecheck
- pnpm test -- src/core/modelCapabilities.test.ts src/core/queueStore.test.ts src/core/generationQueue.test.ts
- pnpm build
- ./node_modules/.bin/electron . --cli config status --json
- ./node_modules/.bin/electron . --cli provider list --json
- ./node_modules/.bin/electron . --cli models list --json
- ./node_modules/.bin/electron . --cli queue status --json
- ./node_modules/.bin/electron . --cli job list --json
- ./node_modules/.bin/electron . --cli folder list --json
- ./node_modules/.bin/electron . --cli gallery list --json
- ./node_modules/.bin/electron . --cli asset inspect --asset-id <existing-id> --json
- ./node_modules/.bin/electron . --cli asset inspect --json
- ./node_modules/.bin/electron . --cli mcp config --client codex --mode readonly --json