### PR TITLE
Add Gallery write CLI and MCP tools

### DIFF
--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -252,7 +252,7 @@ export function buildCliAssetInspect(state: ReadonlyAppState | null, assetId: st
 
 export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMode; command: string }) {
   const args = ["--mcp"];
-  const effectiveMode: McpMode = "readonly";
+  const effectiveMode: McpMode = options.mode === "generate" ? "write" : options.mode;
   return {
     client: options.client,
     requestedMode: options.mode,
@@ -265,13 +265,15 @@ export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMod
     },
     permissions: {
       readonly: true,
-      write: false,
+      write: effectiveMode === "write",
       generate: false
     },
-    supportedModes: [effectiveMode],
+    supportedModes: ["readonly", "write"],
     unsupportedModeWarning:
-      options.mode === effectiveMode
+      options.mode === "generate"
+        ? "This build currently exposes readonly and Gallery write MCP tools only. Generation MCP tools are reserved for later v0.3.1 phases."
+        : options.mode === effectiveMode
         ? undefined
-        : "This build currently exposes readonly MCP tools only. Write and generation MCP modes are reserved for later v0.3.1 phases."
+        : "This build currently exposes readonly and Gallery write MCP tools only."
   };
 }

--- a/src/core/gallery.test.ts
+++ b/src/core/gallery.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createGalleryFolder,
+  exportGalleryAsset,
+  importGalleryAssets,
+  removeGalleryAsset,
+  resolveGalleryAssetPath,
+  type GalleryMutationContext,
+  type GalleryStateSlice
+} from "./gallery";
+
+function state(patch: Partial<GalleryStateSlice> = {}): GalleryStateSlice {
+  return {
+    galleryFolders: [],
+    galleryAssets: [],
+    ...patch
+  };
+}
+
+async function tempContext(): Promise<{ dir: string; galleryDir: string; context: GalleryMutationContext }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "crossgen-gallery-core-"));
+  const galleryDir = path.join(dir, "gallery");
+  return {
+    dir,
+    galleryDir,
+    context: {
+      galleryDir,
+      now: () => "2026-07-14T00:00:00.000Z",
+      createFolderId: () => "folder_1",
+      createAssetId: () => "asset_1"
+    }
+  };
+}
+
+describe("gallery core mutations", () => {
+  it("rejects illegal and Windows-reserved folder names", async () => {
+    const { context } = await tempContext();
+
+    await expect(createGalleryFolder(state(), context, { name: "../bad" })).rejects.toThrow("不能包含路径分隔符");
+    await expect(createGalleryFolder(state(), context, { name: "CON" })).rejects.toThrow("不可用于托管目录");
+  });
+
+  it("creates folders and imports image assets into managed Gallery paths", async () => {
+    const { dir, galleryDir, context } = await tempContext();
+    const sourcePath = path.join(dir, "source.png");
+    await writeFile(sourcePath, Buffer.from("image-one"));
+
+    const createdFolder = await createGalleryFolder(state(), context, { name: "Campaign" });
+    const imported = await importGalleryAssets(createdFolder.state, context, [sourcePath], createdFolder.folder.id);
+
+    expect(imported.result.assets).toHaveLength(1);
+    expect(imported.result.assets[0]).toMatchObject({
+      id: "asset_1",
+      originalName: "source.png",
+      folderId: "folder_1",
+      source: "import"
+    });
+    const managedPath = path.join(galleryDir, "Campaign", "source.png");
+    await expect(readFile(managedPath, "utf8")).resolves.toBe("image-one");
+  });
+
+  it("handles duplicate imports with cancel, copy, and replace actions", async () => {
+    const { dir, context } = await tempContext();
+    const sourcePath = path.join(dir, "source.png");
+    const replacementPath = path.join(dir, "replacement.png");
+    await writeFile(sourcePath, Buffer.from("same-image"));
+    await writeFile(replacementPath, Buffer.from("same-image"));
+
+    const imported = await importGalleryAssets(state(), context, [sourcePath]);
+    const duplicateCancel = await importGalleryAssets(imported.state, { ...context, duplicateAction: "cancel" }, [replacementPath]);
+    const duplicateCopy = await importGalleryAssets(imported.state, { ...context, duplicateAction: "copy", createAssetId: () => "asset_2" }, [replacementPath]);
+    const duplicateReplace = await importGalleryAssets(imported.state, { ...context, duplicateAction: "replace" }, [replacementPath]);
+
+    expect(duplicateCancel.result.assets).toHaveLength(0);
+    expect(duplicateCancel.result.skipped[0]).toMatchObject({ reason: "duplicate", existingAssetId: "asset_1" });
+    expect(duplicateCopy.result.assets[0]).toMatchObject({ id: "asset_2", originalName: "replacement.png" });
+    expect(duplicateReplace.result.replacedAssetIds).toEqual(["asset_1"]);
+    expect(duplicateReplace.result.assets[0].id).toBe("asset_1");
+  });
+
+  it("requires replace for exporting over an existing file", async () => {
+    const { dir, context } = await tempContext();
+    const sourcePath = path.join(dir, "source.png");
+    const targetPath = path.join(dir, "exported.png");
+    await writeFile(sourcePath, Buffer.from("source-image"));
+    await writeFile(targetPath, Buffer.from("old"));
+    const imported = await importGalleryAssets(state(), context, [sourcePath]);
+
+    await expect(exportGalleryAsset(imported.state, context, "asset_1", targetPath)).rejects.toThrow("--replace");
+    const exported = await exportGalleryAsset(imported.state, context, "asset_1", targetPath, { replace: true });
+
+    expect(exported).toMatchObject({ exportedPath: targetPath, replaced: true });
+    await expect(readFile(targetPath, "utf8")).resolves.toBe("source-image");
+  });
+
+  it("rejects managed asset symlinks that resolve outside the Gallery root", async () => {
+    const { dir, galleryDir, context } = await tempContext();
+    const outsidePath = path.join(dir, "outside.png");
+    await writeFile(outsidePath, Buffer.from("outside"));
+    await writeFile(path.join(dir, "source.png"), Buffer.from("inside"));
+    const imported = await importGalleryAssets(state(), context, [path.join(dir, "source.png")]);
+    await removeGalleryAsset(imported.state, context, "asset_1");
+    await symlink(outsidePath, path.join(galleryDir, "source.png"));
+
+    await expect(resolveGalleryAssetPath(imported.state, context, "asset_1")).rejects.toThrow("不属于 CrossGen 管理目录");
+  });
+});

--- a/src/core/gallery.ts
+++ b/src/core/gallery.ts
@@ -1,0 +1,738 @@
+import { createHash, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { GalleryAsset, GalleryAssetPatch, GalleryFolder, GalleryFolderDeleteResult, GalleryFolderInput } from "../shared/types.js";
+
+export type GalleryDuplicateAction = "cancel" | "replace" | "copy";
+
+export interface GalleryStateSlice {
+  galleryFolders: GalleryFolder[];
+  galleryAssets: GalleryAsset[];
+}
+
+export interface GalleryMutationContext {
+  galleryDir: string;
+  now?: () => string;
+  createFolderId?: () => string;
+  createAssetId?: () => string;
+  duplicateAction?: GalleryDuplicateAction;
+}
+
+export interface GalleryImportResult {
+  assets: GalleryAsset[];
+  skipped: Array<{ path: string; reason: string; existingAssetId?: string }>;
+  replacedAssetIds: string[];
+}
+
+export interface GalleryPathResult {
+  asset: GalleryAsset;
+  path: string;
+}
+
+export interface GalleryExportResult {
+  asset: GalleryAsset;
+  sourcePath: string;
+  exportedPath: string;
+  replaced: boolean;
+}
+
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
+const MAX_GALLERY_FOLDER_NAME_BYTES = 120;
+const MAX_GALLERY_FILE_NAME_BYTES = 180;
+const WINDOWS_RESERVED_FILE_NAMES = new Set([
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  "COM1",
+  "COM2",
+  "COM3",
+  "COM4",
+  "COM5",
+  "COM6",
+  "COM7",
+  "COM8",
+  "COM9",
+  "LPT1",
+  "LPT2",
+  "LPT3",
+  "LPT4",
+  "LPT5",
+  "LPT6",
+  "LPT7",
+  "LPT8",
+  "LPT9"
+]);
+
+function nowIso(context: GalleryMutationContext): string {
+  return context.now?.() ?? new Date().toISOString();
+}
+
+function createFolderId(context: GalleryMutationContext): string {
+  return context.createFolderId?.() ?? `gallery_folder_${randomUUID()}`;
+}
+
+function createAssetId(context: GalleryMutationContext): string {
+  return context.createAssetId?.() ?? `gallery_${randomUUID()}`;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+async function ensureDir(dirPath: string): Promise<void> {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sameResolvedPath(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
+
+async function copyOrMoveFile(sourcePath: string, targetPath: string, removeSource = false): Promise<void> {
+  if (sameResolvedPath(sourcePath, targetPath)) return;
+  await ensureDir(path.dirname(targetPath));
+  if (removeSource) {
+    try {
+      await fs.rename(sourcePath, targetPath);
+      return;
+    } catch (error) {
+      if (!isNodeError(error) || (error.code !== "EXDEV" && error.code !== "EEXIST")) {
+        throw error;
+      }
+    }
+  }
+  await fs.copyFile(sourcePath, targetPath);
+  if (removeSource) {
+    await fs.unlink(sourcePath).catch(() => undefined);
+  }
+}
+
+function isIgnoredGalleryEntryName(name: string): boolean {
+  const normalized = name.trim().toLowerCase();
+  return normalized === ".ds_store" || normalized === "thumbs.db" || normalized === "desktop.ini";
+}
+
+function isReservedWindowsFileName(name: string): boolean {
+  const baseName = name.split(".")[0]?.toUpperCase();
+  return Boolean(baseName && WINDOWS_RESERVED_FILE_NAMES.has(baseName));
+}
+
+function normalizeTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  return value.flatMap((item) => {
+    if (typeof item !== "string") return [];
+    const tag = item.trim();
+    if (!tag || seen.has(tag)) return [];
+    seen.add(tag);
+    return [tag];
+  });
+}
+
+function mergeTags(current: string[], incoming: unknown): string[] {
+  return normalizeTags([...current, ...normalizeTags(incoming)]);
+}
+
+function mimeTypeForFile(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".webp") return "image/webp";
+  return "image/png";
+}
+
+function isImagePath(filePath: string): boolean {
+  return IMAGE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+async function fileContentHash(filePath: string): Promise<string> {
+  const content = await fs.readFile(filePath);
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function filePathHash(filePath: string): string {
+  return createHash("sha256").update(path.resolve(filePath)).digest("hex");
+}
+
+export function normalizeManagedRelativePath(value: string): string {
+  const normalized = value.trim().replace(/\\/g, "/");
+  const segments = normalized.split("/");
+  if (
+    !normalized ||
+    path.isAbsolute(normalized) ||
+    path.win32.isAbsolute(normalized) ||
+    segments.some((segment) => !segment || segment === "." || segment === "..")
+  ) {
+    throw new Error("Gallery 资源路径无效。");
+  }
+  return segments.join("/");
+}
+
+export function resolveManagedGalleryPath(galleryDir: string, fileName: string): string {
+  const normalizedFileName = normalizeManagedRelativePath(fileName);
+  const resolved = path.resolve(galleryDir, ...normalizedFileName.split("/"));
+  const relative = path.relative(path.resolve(galleryDir), resolved);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("无法操作：资源不属于 CrossGen 管理目录。");
+  }
+  return resolved;
+}
+
+export async function assertManagedGalleryFile(galleryDir: string, fileName: string): Promise<string> {
+  const resolved = resolveManagedGalleryPath(galleryDir, fileName);
+  const realGalleryDir = await fs.realpath(galleryDir);
+  const realAssetPath = await fs.realpath(resolved);
+  const relative = path.relative(realGalleryDir, realAssetPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("无法操作：资源不属于 CrossGen 管理目录。");
+  }
+  const stat = await fs.stat(realAssetPath);
+  if (!stat.isFile()) {
+    throw new Error("无法操作：资源不是文件。");
+  }
+  return resolved;
+}
+
+function normalizeGalleryFolderName(value: unknown): string {
+  return typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+}
+
+function normalizeGalleryFolderColor(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed.toUpperCase() : undefined;
+}
+
+function normalizeGalleryFolderInput(input: GalleryFolderInput | undefined): { name: string; color?: string; hasColor: boolean } {
+  const name = normalizeGalleryFolderName(input?.name);
+  if (!name) throw new Error("Gallery 文件夹名称不能为空。");
+  if (name.includes("/") || name.includes("\\")) throw new Error("Gallery 文件夹名称不能包含路径分隔符。");
+  if (/[<>:"|?*\x00-\x1F]/.test(name)) throw new Error("Gallery 文件夹名称包含非法字符。");
+  if (name.endsWith(".") || name.endsWith(" ")) throw new Error("Gallery 文件夹名称不能以空格或句点结尾。");
+  if (isIgnoredGalleryEntryName(name) || isReservedWindowsFileName(name)) throw new Error("Gallery 文件夹名称不可用于托管目录。");
+  if (Buffer.byteLength(name, "utf8") > MAX_GALLERY_FOLDER_NAME_BYTES) throw new Error("Gallery 文件夹名称过长。");
+  return {
+    name,
+    color: normalizeGalleryFolderColor(input?.color),
+    hasColor: Object.prototype.hasOwnProperty.call(input ?? {}, "color")
+  };
+}
+
+function galleryFolderForId(state: GalleryStateSlice, folderId: string | null | undefined): GalleryFolder | undefined {
+  if (!folderId) return undefined;
+  return state.galleryFolders.find((folder) => folder.id === folderId);
+}
+
+function normalizeGalleryFolderId(state: GalleryStateSlice, folderId?: unknown): string | null {
+  if (folderId === undefined || folderId === null || folderId === "" || folderId === "null") return null;
+  if (typeof folderId !== "string") throw new Error("Gallery 文件夹不存在。");
+  const normalized = folderId.trim();
+  if (!normalized) return null;
+  if (!state.galleryFolders.some((folder) => folder.id === normalized)) {
+    throw new Error("Gallery 文件夹不存在。");
+  }
+  return normalized;
+}
+
+function galleryFolderDiskName(folder: GalleryFolder): string {
+  return normalizeGalleryFolderName(folder.name);
+}
+
+function galleryFolderSegments(state: GalleryStateSlice, folder: GalleryFolder): string[] {
+  const byId = new Map(state.galleryFolders.map((item) => [item.id, item]));
+  const segments: string[] = [];
+  const visited = new Set<string>();
+  let current: GalleryFolder | undefined = folder;
+  while (current) {
+    if (visited.has(current.id)) throw new Error("Gallery 文件夹层级存在循环。");
+    visited.add(current.id);
+    segments.unshift(galleryFolderDiskName(current));
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return segments;
+}
+
+function galleryFolderRelativePath(state: GalleryStateSlice, folder: GalleryFolder): string {
+  return galleryFolderSegments(state, folder).join("/");
+}
+
+function galleryFolderRelativePathForId(state: GalleryStateSlice, folderId: string | null | undefined): string {
+  const folder = galleryFolderForId(state, folderId);
+  return folder ? galleryFolderRelativePath(state, folder) : "";
+}
+
+function galleryFolderAbsolutePath(context: GalleryMutationContext, state: GalleryStateSlice, folder: GalleryFolder): string {
+  return resolveManagedGalleryPath(context.galleryDir, galleryFolderRelativePath(state, folder));
+}
+
+function galleryAssetBaseName(asset: GalleryAsset): string {
+  return path.posix.basename(normalizeManagedRelativePath(asset.fileName));
+}
+
+function isGalleryFolderDescendant(state: GalleryStateSlice, folderId: string, maybeAncestorId: string): boolean {
+  const byId = new Map(state.galleryFolders.map((folder) => [folder.id, folder]));
+  const visited = new Set<string>();
+  let current = byId.get(folderId)?.parentId ?? null;
+  while (current) {
+    if (current === maybeAncestorId) return true;
+    if (visited.has(current)) return false;
+    visited.add(current);
+    current = byId.get(current)?.parentId ?? null;
+  }
+  return false;
+}
+
+function galleryFolderSubtreeIds(state: GalleryStateSlice, folderId: string): Set<string> {
+  const result = new Set<string>([folderId]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const folder of state.galleryFolders) {
+      if (folder.parentId && result.has(folder.parentId) && !result.has(folder.id)) {
+        result.add(folder.id);
+        changed = true;
+      }
+    }
+  }
+  return result;
+}
+
+function normalizeGalleryFolderParentId(state: GalleryStateSlice, parentId?: unknown, movingFolderId?: string): string | null {
+  const normalized = normalizeGalleryFolderId(state, parentId);
+  if (movingFolderId && normalized) {
+    if (normalized === movingFolderId || isGalleryFolderDescendant(state, normalized, movingFolderId)) {
+      throw new Error("不能将文件夹移动到自身或其子文件夹。");
+    }
+  }
+  return normalized;
+}
+
+function normalizeGalleryAssetNameInput(value: unknown, currentName: string): string {
+  const rawName = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+  if (!rawName) throw new Error("Gallery 图片名称不能为空。");
+  if (rawName.includes("/") || rawName.includes("\\")) throw new Error("Gallery 图片名称不能包含路径分隔符。");
+  if (/[<>:"|?*\x00-\x1F]/.test(rawName)) throw new Error("Gallery 图片名称包含非法字符。");
+  if (rawName.endsWith(".") || rawName.endsWith(" ")) throw new Error("Gallery 图片名称不能以空格或句点结尾。");
+
+  const currentExt = path.posix.extname(currentName).toLowerCase();
+  const inputExt = path.posix.extname(rawName).toLowerCase();
+  const nextName = inputExt ? rawName : `${rawName}${currentExt || ".png"}`;
+  const nextExt = path.posix.extname(nextName).toLowerCase();
+  if (!IMAGE_EXTENSIONS.has(nextExt)) throw new Error("Gallery 图片名称必须使用 png、jpg、jpeg 或 webp 扩展名。");
+  if (isIgnoredGalleryEntryName(nextName) || isReservedWindowsFileName(nextName)) throw new Error("Gallery 图片名称不可用于托管目录。");
+  if (Buffer.byteLength(nextName, "utf8") > MAX_GALLERY_FILE_NAME_BYTES) throw new Error("Gallery 图片名称过长。");
+  normalizeManagedRelativePath(nextName);
+  return nextName;
+}
+
+async function uniqueGalleryRelativePath(galleryDir: string, desiredRelPath: string, sourcePath?: string): Promise<string> {
+  const normalized = normalizeManagedRelativePath(desiredRelPath);
+  const folderName = path.posix.dirname(normalized) === "." ? "" : path.posix.dirname(normalized);
+  const baseName = path.posix.basename(normalized, path.posix.extname(normalized));
+  const ext = path.posix.extname(normalized);
+
+  for (let index = 0; index < 1000; index += 1) {
+    const fileName = index === 0 ? `${baseName}${ext}` : `${baseName}-${index}${ext}`;
+    const candidate = folderName ? `${folderName}/${fileName}` : fileName;
+    const targetPath = resolveManagedGalleryPath(galleryDir, candidate);
+    if (sourcePath && sameResolvedPath(sourcePath, targetPath)) return candidate;
+    if (!(await pathExists(targetPath))) return candidate;
+  }
+
+  throw new Error("无法创建唯一的 Gallery 文件名。");
+}
+
+async function ensureGalleryFolderDirs(context: GalleryMutationContext, state: GalleryStateSlice): Promise<void> {
+  await ensureDir(context.galleryDir);
+  for (const folder of state.galleryFolders) {
+    await ensureDir(galleryFolderAbsolutePath(context, state, folder));
+  }
+}
+
+async function moveGalleryAssetFileToFolder(context: GalleryMutationContext, state: GalleryStateSlice, asset: GalleryAsset, folderId: string | null): Promise<GalleryAsset> {
+  const currentRelPath = normalizeManagedRelativePath(asset.fileName);
+  const folder = galleryFolderForId(state, folderId);
+  const folderRelPath = folder ? galleryFolderRelativePath(state, folder) : "";
+  const desiredNextRelPath = folderRelPath ? `${folderRelPath}/${galleryAssetBaseName(asset)}` : galleryAssetBaseName(asset);
+  if (currentRelPath === desiredNextRelPath) {
+    return { ...asset, folderId, updatedAt: nowIso(context) };
+  }
+
+  const currentPath = resolveManagedGalleryPath(context.galleryDir, currentRelPath);
+  const nextRelPath = await uniqueGalleryRelativePath(context.galleryDir, desiredNextRelPath, currentPath);
+  const nextPath = resolveManagedGalleryPath(context.galleryDir, nextRelPath);
+  if (await pathExists(currentPath)) {
+    await copyOrMoveFile(currentPath, nextPath, true);
+  }
+  return {
+    ...asset,
+    fileName: nextRelPath,
+    folderId,
+    updatedAt: nowIso(context)
+  };
+}
+
+async function renameGalleryAssetFile(context: GalleryMutationContext, state: GalleryStateSlice, asset: GalleryAsset, originalName: unknown): Promise<GalleryAsset> {
+  const currentRelPath = normalizeManagedRelativePath(asset.fileName);
+  const currentBaseName = galleryAssetBaseName(asset);
+  const nextBaseName = normalizeGalleryAssetNameInput(originalName, currentBaseName);
+  if (nextBaseName.toLowerCase() === currentBaseName.toLowerCase() && nextBaseName === asset.originalName) {
+    return asset;
+  }
+
+  const folderRelPath = path.posix.dirname(currentRelPath) === "." ? "" : path.posix.dirname(currentRelPath);
+  const desiredRelPath = folderRelPath ? `${folderRelPath}/${nextBaseName}` : nextBaseName;
+  const currentPath = resolveManagedGalleryPath(context.galleryDir, currentRelPath);
+  const nextRelPath = await uniqueGalleryRelativePath(context.galleryDir, desiredRelPath, currentPath);
+  const nextPath = resolveManagedGalleryPath(context.galleryDir, nextRelPath);
+  if (await pathExists(currentPath)) {
+    await copyOrMoveFile(currentPath, nextPath, true);
+  }
+  const stat = await fs.stat(nextPath).catch(() => null);
+  return {
+    ...asset,
+    fileName: nextRelPath,
+    originalName: path.posix.basename(nextRelPath),
+    mimeType: mimeTypeForFile(nextPath),
+    sizeBytes: stat?.size ?? asset.sizeBytes,
+    modifiedAt: stat?.mtime.toISOString() ?? asset.modifiedAt
+  };
+}
+
+function sameGalleryFolder(a: string | null | undefined, b: string | null | undefined): boolean {
+  return (a ?? null) === (b ?? null);
+}
+
+async function findDuplicateGalleryAsset(state: GalleryStateSlice, context: GalleryMutationContext, folderId: string | null, contentHash: string, sourcePathHash?: string): Promise<GalleryAsset | undefined> {
+  for (const asset of state.galleryAssets) {
+    if (!sameGalleryFolder(asset.folderId, folderId)) continue;
+    if (sourcePathHash && asset.sourcePathHash === sourcePathHash) return asset;
+    if (asset.contentHash === contentHash) return asset;
+    if (asset.contentHash) continue;
+    const assetPath = resolveManagedGalleryPath(context.galleryDir, normalizeManagedRelativePath(asset.fileName));
+    if (!(await pathExists(assetPath))) continue;
+    try {
+      if ((await fileContentHash(assetPath)) === contentHash) return asset;
+    } catch {
+      // Ignore unreadable stale files while checking duplicates.
+    }
+  }
+  return undefined;
+}
+
+function applyGalleryAssetCreateResult(state: GalleryStateSlice, result: { asset: GalleryAsset | null; replacedAssetId?: string }): GalleryStateSlice {
+  if (!result.asset) return state;
+  if (result.replacedAssetId) {
+    return {
+      ...state,
+      galleryAssets: state.galleryAssets.map((asset) => asset.id === result.replacedAssetId ? result.asset! : asset)
+    };
+  }
+  return {
+    ...state,
+    galleryAssets: [result.asset, ...state.galleryAssets]
+  };
+}
+
+async function createGalleryAssetFromFile(
+  state: GalleryStateSlice,
+  context: GalleryMutationContext,
+  sourcePath: string,
+  folderId: string | null
+): Promise<{ asset: GalleryAsset | null; replacedAssetId?: string; skipped?: { reason: string; existingAssetId?: string } }> {
+  if (!isImagePath(sourcePath)) {
+    return { asset: null, skipped: { reason: "unsupported_file_type" } };
+  }
+  await ensureGalleryFolderDirs(context, state);
+  const stat = await fs.stat(sourcePath);
+  if (!stat.isFile()) throw new Error("Gallery 只能导入图片文件。");
+  const originalName = path.basename(sourcePath);
+  const contentHash = await fileContentHash(sourcePath);
+  const sourcePathHash = filePathHash(sourcePath);
+  const duplicate = await findDuplicateGalleryAsset(state, context, folderId, contentHash, sourcePathHash);
+  if (duplicate) {
+    const duplicateAction = context.duplicateAction ?? "cancel";
+    if (duplicateAction === "cancel") {
+      return { asset: null, skipped: { reason: "duplicate", existingAssetId: duplicate.id } };
+    }
+    if (duplicateAction === "replace") {
+      const targetPath = resolveManagedGalleryPath(context.galleryDir, normalizeManagedRelativePath(duplicate.fileName));
+      await ensureDir(path.dirname(targetPath));
+      if (!sameResolvedPath(sourcePath, targetPath)) await fs.copyFile(sourcePath, targetPath);
+      const nextStat = await fs.stat(targetPath);
+      return {
+        replacedAssetId: duplicate.id,
+        asset: {
+          ...duplicate,
+          originalName,
+          mimeType: mimeTypeForFile(sourcePath),
+          sizeBytes: nextStat.size,
+          source: "import",
+          updatedAt: nowIso(context),
+          contentHash,
+          sourcePathHash,
+          sourceJobId: undefined,
+          sourceAssetId: undefined,
+          modifiedAt: nextStat.mtime.toISOString()
+        }
+      };
+    }
+  }
+
+  const folder = galleryFolderForId(state, folderId);
+  const folderName = folder ? galleryFolderRelativePath(state, folder) : "";
+  const desiredRelPath = folderName ? `${folderName}/${originalName}` : originalName;
+  const fileName = await uniqueGalleryRelativePath(context.galleryDir, desiredRelPath);
+  const targetPath = resolveManagedGalleryPath(context.galleryDir, fileName);
+  await ensureDir(path.dirname(targetPath));
+  await fs.copyFile(sourcePath, targetPath);
+  return {
+    asset: {
+      id: createAssetId(context),
+      fileName,
+      originalName: path.posix.basename(fileName),
+      mimeType: mimeTypeForFile(sourcePath),
+      sizeBytes: stat.size,
+      folderId,
+      tags: [],
+      source: "import",
+      createdAt: nowIso(context),
+      updatedAt: nowIso(context),
+      contentHash,
+      sourcePathHash,
+      modifiedAt: stat.mtime.toISOString()
+    }
+  };
+}
+
+export async function createGalleryFolder(state: GalleryStateSlice, context: GalleryMutationContext, input: GalleryFolderInput): Promise<{ state: GalleryStateSlice; folder: GalleryFolder }> {
+  const { name, color } = normalizeGalleryFolderInput(input);
+  const parentId = normalizeGalleryFolderParentId(state, input?.parentId);
+  if (state.galleryFolders.some((folder) => (folder.parentId ?? null) === parentId && folder.name.toLowerCase() === name.toLowerCase())) {
+    throw new Error("Gallery 文件夹名称已存在。");
+  }
+  const now = nowIso(context);
+  const folder: GalleryFolder = {
+    id: createFolderId(context),
+    name,
+    parentId,
+    color,
+    createdAt: now,
+    updatedAt: now
+  };
+  const nextState = { ...state, galleryFolders: [folder, ...state.galleryFolders] };
+  await ensureDir(galleryFolderAbsolutePath(context, nextState, folder));
+  return { state: nextState, folder };
+}
+
+export async function renameGalleryFolder(state: GalleryStateSlice, context: GalleryMutationContext, id: string, input: GalleryFolderInput): Promise<{ state: GalleryStateSlice; folder: GalleryFolder }> {
+  const folder = state.galleryFolders.find((item) => item.id === id);
+  if (!folder) throw new Error("Gallery 文件夹不存在。");
+  const { name, color, hasColor } = normalizeGalleryFolderInput(input);
+  const parentId = Object.prototype.hasOwnProperty.call(input ?? {}, "parentId")
+    ? normalizeGalleryFolderParentId(state, input?.parentId, id)
+    : folder.parentId ?? null;
+  if (state.galleryFolders.some((item) => item.id !== id && (item.parentId ?? null) === parentId && item.name.toLowerCase() === name.toLowerCase())) {
+    throw new Error("Gallery 文件夹名称已存在。");
+  }
+
+  const updated: GalleryFolder = {
+    ...folder,
+    name,
+    parentId,
+    color: hasColor ? color : folder.color,
+    updatedAt: nowIso(context)
+  };
+  const oldDir = galleryFolderAbsolutePath(context, state, folder);
+  const nextFolders = state.galleryFolders.map((item) => item.id === id ? updated : item);
+  const nextFolderState = { ...state, galleryFolders: nextFolders };
+  const newDir = galleryFolderAbsolutePath(context, nextFolderState, updated);
+  if (!sameResolvedPath(oldDir, newDir)) {
+    await ensureDir(path.dirname(newDir));
+    if (await pathExists(oldDir)) {
+      await fs.rename(oldDir, newDir);
+    } else {
+      await ensureDir(newDir);
+    }
+  }
+
+  const subtreeIds = galleryFolderSubtreeIds(state, id);
+  const galleryAssets = state.galleryAssets.map((asset) => {
+    if (!asset.folderId || !subtreeIds.has(asset.folderId)) return asset;
+    return {
+      ...asset,
+      fileName: normalizeManagedRelativePath(path.posix.join(galleryFolderRelativePathForId(nextFolderState, asset.folderId), galleryAssetBaseName(asset))),
+      updatedAt: updated.updatedAt
+    };
+  });
+  return {
+    state: {
+      ...state,
+      galleryFolders: nextFolders,
+      galleryAssets
+    },
+    folder: updated
+  };
+}
+
+export async function moveGalleryFolder(state: GalleryStateSlice, context: GalleryMutationContext, id: string, parentId: string | null): Promise<{ state: GalleryStateSlice; folder: GalleryFolder }> {
+  const folder = state.galleryFolders.find((item) => item.id === id);
+  if (!folder) throw new Error("Gallery 文件夹不存在。");
+  return renameGalleryFolder(state, context, id, { name: folder.name, color: folder.color, parentId });
+}
+
+export async function deleteGalleryFolder(state: GalleryStateSlice, context: GalleryMutationContext, id: string): Promise<{ state: GalleryStateSlice; result: GalleryFolderDeleteResult }> {
+  const folder = state.galleryFolders.find((item) => item.id === id);
+  if (!folder) throw new Error("Gallery 文件夹不存在。");
+  const subtreeIds = galleryFolderSubtreeIds(state, id);
+  const movedAssets: GalleryAsset[] = [];
+  for (const asset of state.galleryAssets) {
+    movedAssets.push(asset.folderId && subtreeIds.has(asset.folderId) ? await moveGalleryAssetFileToFolder(context, state, asset, null) : asset);
+  }
+  const nextState: GalleryStateSlice = {
+    ...state,
+    galleryFolders: state.galleryFolders.filter((candidate) => !subtreeIds.has(candidate.id)),
+    galleryAssets: movedAssets.map((asset) => asset.folderId && subtreeIds.has(asset.folderId) ? { ...asset, folderId: null, updatedAt: nowIso(context) } : asset)
+  };
+  await fs.rm(galleryFolderAbsolutePath(context, state, folder), { recursive: true, force: true }).catch(() => undefined);
+  return {
+    state: nextState,
+    result: {
+      folders: nextState.galleryFolders,
+      assets: nextState.galleryAssets
+    }
+  };
+}
+
+export async function importGalleryAssets(state: GalleryStateSlice, context: GalleryMutationContext, sourcePaths: string[], folderId?: string | null): Promise<{ state: GalleryStateSlice; result: GalleryImportResult }> {
+  let nextState = state;
+  const targetFolderId = normalizeGalleryFolderId(state, folderId);
+  const result: GalleryImportResult = {
+    assets: [],
+    skipped: [],
+    replacedAssetIds: []
+  };
+
+  for (const sourcePath of sourcePaths) {
+    if (typeof sourcePath !== "string" || !sourcePath.trim()) continue;
+    const created = await createGalleryAssetFromFile(nextState, context, path.resolve(sourcePath), targetFolderId);
+    if (created.skipped) {
+      result.skipped.push({ path: sourcePath, reason: created.skipped.reason, existingAssetId: created.skipped.existingAssetId });
+      continue;
+    }
+    if (!created.asset) continue;
+    result.assets.push(created.asset);
+    if (created.replacedAssetId) result.replacedAssetIds.push(created.replacedAssetId);
+    nextState = applyGalleryAssetCreateResult(nextState, created);
+  }
+
+  return { state: nextState, result };
+}
+
+export async function updateGalleryAsset(state: GalleryStateSlice, context: GalleryMutationContext, id: string, patch: GalleryAssetPatch = {}): Promise<{ state: GalleryStateSlice; asset: GalleryAsset }> {
+  const normalizedPatch = patch && typeof patch === "object" ? patch : {};
+  const asset = state.galleryAssets.find((item) => item.id === id);
+  if (!asset) throw new Error("Gallery 资源不存在。");
+  const hasTagsPatch = Object.prototype.hasOwnProperty.call(normalizedPatch, "tags");
+  const hasFolderPatch = Object.prototype.hasOwnProperty.call(normalizedPatch, "folderId");
+  const hasNamePatch = Object.prototype.hasOwnProperty.call(normalizedPatch, "originalName");
+  const movedAsset = hasFolderPatch
+    ? await moveGalleryAssetFileToFolder(context, state, asset, normalizeGalleryFolderId(state, normalizedPatch.folderId))
+    : asset;
+  const renamedAsset = hasNamePatch
+    ? await renameGalleryAssetFile(context, state, movedAsset, normalizedPatch.originalName)
+    : movedAsset;
+  const updated: GalleryAsset = {
+    ...renamedAsset,
+    tags: hasTagsPatch ? normalizeTags(normalizedPatch.tags) : renamedAsset.tags,
+    updatedAt: nowIso(context)
+  };
+  return {
+    state: { ...state, galleryAssets: state.galleryAssets.map((item) => item.id === id ? updated : item) },
+    asset: updated
+  };
+}
+
+export async function removeGalleryAsset(state: GalleryStateSlice, context: GalleryMutationContext, id: string): Promise<{ state: GalleryStateSlice; assets: GalleryAsset[]; removed?: GalleryAsset }> {
+  const asset = state.galleryAssets.find((item) => item.id === id);
+  const galleryAssets = state.galleryAssets.filter((item) => item.id !== id);
+  if (asset) {
+    const filePath = resolveManagedGalleryPath(context.galleryDir, asset.fileName);
+    await fs.unlink(filePath).catch(() => undefined);
+  }
+  return {
+    state: { ...state, galleryAssets },
+    assets: galleryAssets,
+    removed: asset
+  };
+}
+
+export async function resolveGalleryAssetPath(state: GalleryStateSlice, context: GalleryMutationContext, id: string): Promise<GalleryPathResult> {
+  const asset = state.galleryAssets.find((item) => item.id === id);
+  if (!asset) throw new Error("Gallery 资源不存在。");
+  return {
+    asset,
+    path: await assertManagedGalleryFile(context.galleryDir, asset.fileName)
+  };
+}
+
+export async function exportGalleryAsset(
+  state: GalleryStateSlice,
+  context: GalleryMutationContext,
+  id: string,
+  targetPath: string,
+  options: { replace?: boolean } = {}
+): Promise<GalleryExportResult> {
+  if (typeof targetPath !== "string" || !targetPath.trim()) {
+    throw new Error("导出路径不能为空。");
+  }
+  const { asset, path: sourcePath } = await resolveGalleryAssetPath(state, context, id);
+  const resolvedTarget = path.resolve(targetPath);
+  const targetStat = await fs.stat(resolvedTarget).catch(() => null);
+  const finalTarget = targetStat?.isDirectory() ? path.join(resolvedTarget, asset.originalName) : resolvedTarget;
+  if (sameResolvedPath(sourcePath, finalTarget)) {
+    throw new Error("导出路径不能与原文件相同。");
+  }
+  const exists = await pathExists(finalTarget);
+  if (exists && !options.replace) {
+    throw new Error("导出目标已存在，请使用 --replace 明确覆盖。");
+  }
+  await ensureDir(path.dirname(finalTarget));
+  await fs.copyFile(sourcePath, finalTarget);
+  return {
+    asset,
+    sourcePath,
+    exportedPath: finalTarget,
+    replaced: exists
+  };
+}
+
+export function getGalleryAssetPublicMetadata(asset: GalleryAsset) {
+  return {
+    id: asset.id,
+    originalName: asset.originalName,
+    mimeType: asset.mimeType,
+    kind: asset.kind ?? "image",
+    sizeBytes: asset.sizeBytes,
+    width: asset.width,
+    height: asset.height,
+    folderId: asset.folderId ?? null,
+    tags: asset.tags,
+    source: asset.source,
+    sourceJobId: asset.sourceJobId,
+    sourceAssetId: asset.sourceAssetId,
+    createdAt: asset.createdAt,
+    updatedAt: asset.updatedAt,
+    modifiedAt: asset.modifiedAt,
+    hasContentHash: Boolean(asset.contentHash),
+    hasSourcePathHash: Boolean(asset.sourcePathHash)
+  };
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -76,8 +76,23 @@ import {
 import { compareVersions, isAllowedUpdateUrl, parseUpdateManifest, safeUpdateFileName, selectUpdateAsset } from "../shared/updateManifest.js";
 import { resolveDataDirs, resolveUserDataDir } from "../core/dataDirs.js";
 import { createGenerationQueueItem } from "../core/generation.js";
+import {
+  createGalleryFolder as createCoreGalleryFolder,
+  deleteGalleryFolder as deleteCoreGalleryFolder,
+  exportGalleryAsset as exportCoreGalleryAsset,
+  getGalleryAssetPublicMetadata,
+  importGalleryAssets as importCoreGalleryAssets,
+  moveGalleryFolder as moveCoreGalleryFolder,
+  removeGalleryAsset as removeCoreGalleryAsset,
+  renameGalleryFolder as renameCoreGalleryFolder,
+  resolveGalleryAssetPath as resolveCoreGalleryAssetPath,
+  updateGalleryAsset as updateCoreGalleryAsset,
+  type GalleryDuplicateAction,
+  type GalleryMutationContext
+} from "../core/gallery.js";
 import { recordGenerationQueuePartialOutput, requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion } from "../core/generationQueue.js";
 import { createQueueStore, type QueueStore } from "../core/queueStore.js";
+import { createJsonStateStore, type JsonStateStore } from "../core/stateStore.js";
 import {
   buildCliAssetInspect,
   buildCliConfigStatus,
@@ -193,6 +208,7 @@ let galleryOperationQueue: Promise<void> = Promise.resolve();
 let galleryWatchNeedsFullSync = false;
 let galleryWatchChangedRelPaths = new Set<string>();
 let stateWriteCount = 0;
+let appStateStore: JsonStateStore<AppStateFile> | null = null;
 let generationQueueStore: QueueStore | null = null;
 const desktopWorkerHostId = `desktop_${process.pid}_${randomUUID()}`;
 const runningJobControllers = new Map<string, AbortController>();
@@ -361,6 +377,10 @@ function getBackupStatePath(): string {
   return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).backupStatePath;
 }
 
+function getStateLockPath(): string {
+  return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).lockPath;
+}
+
 function getQueuePath(): string {
   return resolveDataDirs({ appDataDir: app.getPath("appData"), userDataDir: app.getPath("userData") }).queuePath;
 }
@@ -411,6 +431,17 @@ function getGenerationQueueStore(): QueueStore {
     lockPath: getQueueLockPath()
   });
   return generationQueueStore;
+}
+
+function getAppStateStore(): JsonStateStore<AppStateFile> {
+  appStateStore ??= createJsonStateStore({
+    statePath: getStatePath(),
+    backupPath: getBackupStatePath(),
+    lockPath: getStateLockPath(),
+    defaultState: getDefaultState(),
+    normalize: normalizeState
+  });
+  return appStateStore;
 }
 
 function assertKnownHistoryAssetPath(state: AppStateFile, assetPath: string): string {
@@ -513,20 +544,7 @@ async function writeState(state: AppStateFile, options: WriteStateOptions = {}):
     storage: state.storage,
     draft: state.draft
   };
-  const statePath = getStatePath();
-  const backupPath = getBackupStatePath();
-  const tmpPath = `${statePath}.tmp`;
-  if (options.updateBackup !== false) {
-    try {
-      await fs.copyFile(statePath, backupPath);
-    } catch (error) {
-      if (!isNodeError(error) || error.code !== "ENOENT") {
-        console.warn("[CrossGen] Failed to update state backup.", sanitizeError(error));
-      }
-    }
-  }
-  await fs.writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-  await fs.rename(tmpPath, statePath);
+  await getAppStateStore().write(payload, options);
   stateWriteCount += 1;
   stateCache = payload;
 }
@@ -1112,7 +1130,8 @@ function sendGalleryEvent(state: AppStateFile, reason: "disk" | "mutation"): voi
 }
 
 async function readGalleryMutationState(): Promise<AppStateFile> {
-  return syncGalleryWithDisk(await readState());
+  stateCache = applyStartupRecovery(await getAppStateStore().read());
+  return syncGalleryWithDisk(stateCache);
 }
 
 async function commitGalleryMutationState<TResult>(state: AppStateFile, result: TResult): Promise<TResult> {
@@ -3239,6 +3258,32 @@ function getCliPositionalAfter(args: string[], token: string): string | undefine
   return args.slice(index + 1).find((arg) => !arg.startsWith("--"));
 }
 
+function getCliPositionalsAfter(args: string[], token: string): string[] {
+  const index = args.indexOf(token);
+  if (index < 0) return [];
+  const valueFlags = new Set(["--asset-id", "--client", "--correlation-id", "--duplicate", "--folder", "--mode", "--name", "--parent", "--request-id", "--tag", "--to"]);
+  const result: string[] = [];
+  for (let cursor = index + 1; cursor < args.length; cursor += 1) {
+    const arg = args[cursor];
+    if (arg.startsWith("--")) {
+      if (valueFlags.has(arg) && args[cursor + 1] && !args[cursor + 1].startsWith("--")) cursor += 1;
+      continue;
+    }
+    result.push(arg);
+  }
+  return result;
+}
+
+function getCliOptions(args: string[], name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] !== name) continue;
+    const value = args[index + 1];
+    if (value && !value.startsWith("--")) values.push(value);
+  }
+  return values;
+}
+
 function writeCliJson(response: CrossGenJsonResponse): void {
   process.stdout.write(`${JSON.stringify(response)}\n`);
 }
@@ -3287,6 +3332,46 @@ async function readExistingQueueForCli() {
   return getGenerationQueueStore().read();
 }
 
+function normalizeCliDuplicateAction(value: string | undefined): GalleryDuplicateAction {
+  return value === "replace" || value === "copy" ? value : "cancel";
+}
+
+function galleryMutationContext(state: AppStateFile, options: { duplicateAction?: GalleryDuplicateAction } = {}): GalleryMutationContext {
+  return {
+    galleryDir: getGalleryDir(state),
+    duplicateAction: options.duplicateAction
+  };
+}
+
+function mergeGalleryState(state: AppStateFile, galleryState: { galleryFolders: GalleryFolder[]; galleryAssets: GalleryAsset[] }): AppStateFile {
+  return {
+    ...state,
+    galleryFolders: galleryState.galleryFolders,
+    galleryAssets: galleryState.galleryAssets
+  };
+}
+
+async function mutateGalleryStateForCli<TResult>(
+  operation: (state: AppStateFile, context: GalleryMutationContext) => Promise<{ state: { galleryFolders: GalleryFolder[]; galleryAssets: GalleryAsset[] }; result: TResult }>,
+  options: { duplicateAction?: GalleryDuplicateAction } = {}
+): Promise<TResult> {
+  let result: TResult | undefined;
+  const nextState = await getAppStateStore().mutate(async (state) => {
+    const outcome = await operation(state, galleryMutationContext(state, options));
+    result = outcome.result;
+    return mergeGalleryState(state, outcome.state);
+  });
+  stateCache = nextState;
+  if (result === undefined) throw new Error("Gallery 操作没有返回结果。");
+  return result;
+}
+
+async function readGalleryStateForCli(): Promise<AppStateFile> {
+  const state = await getAppStateStore().read();
+  stateCache = state;
+  return state;
+}
+
 async function runMcpCommandMode(args: string[]): Promise<number> {
   const requestedMode = normalizeCliMcpMode(getCliOption(args, "--mode") ?? process.env.CROSSGEN_MCP_MODE);
   return runReadonlyMcpStdioServer({
@@ -3301,6 +3386,90 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
       folderList: async () => buildCliFolderList(await readExistingStateForCli()),
       galleryList: async () => buildCliGalleryList(await readExistingStateForCli()),
       assetInspect: async (assetId) => buildCliAssetInspect(await readExistingStateForCli(), assetId)
+    },
+    writers: requestedMode === "readonly" ? undefined : {
+      folderCreate: async ({ name, parentId }) => {
+        const folder = await mutateGalleryStateForCli(async (state, context) => {
+          const outcome = await createCoreGalleryFolder(state, context, { name, parentId });
+          return { state: outcome.state, result: outcome.folder };
+        });
+        return { folder };
+      },
+      folderRename: async ({ folderId, name, parentId }) => {
+        const folder = await mutateGalleryStateForCli(async (state, context) => {
+          const outcome = await renameCoreGalleryFolder(state, context, folderId, { name, parentId });
+          return { state: outcome.state, result: outcome.folder };
+        });
+        return { folder };
+      },
+      folderMove: async ({ folderId, parentId }) => {
+        const folder = await mutateGalleryStateForCli(async (state, context) => {
+          const outcome = await moveCoreGalleryFolder(state, context, folderId, parentId);
+          return { state: outcome.state, result: outcome.folder };
+        });
+        return { folder };
+      },
+      folderDelete: async ({ folderId }) => mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await deleteCoreGalleryFolder(state, context, folderId);
+        return { state: outcome.state, result: outcome.result };
+      }),
+      assetImport: async ({ paths, folderId, duplicateAction }) => {
+        const result = await mutateGalleryStateForCli(
+          async (state, context) => {
+            const outcome = await importCoreGalleryAssets(state, context, paths, folderId ?? null);
+            return { state: outcome.state, result: outcome.result };
+          },
+          { duplicateAction: normalizeCliDuplicateAction(duplicateAction) }
+        );
+        return {
+          imported: result.assets.map(getGalleryAssetPublicMetadata),
+          skipped: result.skipped,
+          replacedAssetIds: result.replacedAssetIds
+        };
+      },
+      assetMove: async ({ assetId, folderId }) => {
+        const asset = await mutateGalleryStateForCli(async (state, context) => {
+          const outcome = await updateCoreGalleryAsset(state, context, assetId, { folderId });
+          return { state: outcome.state, result: outcome.asset };
+        });
+        return { asset: getGalleryAssetPublicMetadata(asset) };
+      },
+      assetUpdate: async ({ assetId, originalName, tags, folderId }) => {
+        const patch: GalleryAssetPatch = {};
+        if (originalName) patch.originalName = originalName;
+        if (tags) patch.tags = tags;
+        if (folderId !== undefined) patch.folderId = folderId;
+        if (!Object.keys(patch).length) throw new Error("No asset update fields were provided.");
+        const asset = await mutateGalleryStateForCli(async (state, context) => {
+          const outcome = await updateCoreGalleryAsset(state, context, assetId, patch);
+          return { state: outcome.state, result: outcome.asset };
+        });
+        return { asset: getGalleryAssetPublicMetadata(asset) };
+      },
+      assetRemove: async ({ assetId }) => mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await removeCoreGalleryAsset(state, context, assetId);
+        return {
+          state: outcome.state,
+          result: {
+            assets: outcome.assets.map(getGalleryAssetPublicMetadata),
+            removed: outcome.removed ? getGalleryAssetPublicMetadata(outcome.removed) : null
+          }
+        };
+      }),
+      assetPath: async ({ assetId }) => {
+        const state = await readGalleryStateForCli();
+        const result = await resolveCoreGalleryAssetPath(state, galleryMutationContext(state), assetId);
+        return { asset: getGalleryAssetPublicMetadata(result.asset), path: result.path };
+      },
+      assetExport: async ({ assetId, to, replace }) => {
+        const state = await readGalleryStateForCli();
+        const result = await exportCoreGalleryAsset(state, galleryMutationContext(state), assetId, to, { replace });
+        return {
+          asset: getGalleryAssetPublicMetadata(result.asset),
+          exportedPath: result.exportedPath,
+          replaced: result.replaced
+        };
+      }
     },
     sanitizeError: (error) => redactLikelySecrets(normalizeError(error))
   });
@@ -3390,9 +3559,9 @@ async function runCliCommandMode(args: string[]): Promise<number> {
           pathDisclosureRequiresConfirmation: true
         },
         knownLimitations: [
-          "v0.3.1 CLI/MCP command mode currently exposes readonly discovery tools.",
+          "v0.3.1 CLI/MCP command mode currently exposes readonly discovery and Gallery asset management tools.",
           "The desktop generation path uses the durable queue foundation; CLI/MCP generation tools are not implemented yet.",
-          "Gallery write tools and agent generation tools are still in later v0.3.1 phases."
+          "Agent generation tools are still in later v0.3.1 phases."
         ]
       };
       writeCliJson(cliSuccess(requestId, correlationId, data));
@@ -3449,6 +3618,199 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       return 0;
     }
 
+    if (command === "folder" && subcommand === "create") {
+      const [name] = getCliPositionalsAfter(args, subcommand);
+      if (!name) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing folder name.", ["Use folder create <name>."]));
+        return 2;
+      }
+      const folder = await mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await createCoreGalleryFolder(state, context, {
+          name,
+          parentId: getCliOption(args, "--parent") ?? undefined
+        });
+        return { state: outcome.state, result: outcome.folder };
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, { folder }));
+      return 0;
+    }
+
+    if (command === "folder" && subcommand === "rename") {
+      const [folderId, name] = getCliPositionalsAfter(args, subcommand);
+      if (!folderId || !name) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing folder id or name.", ["Use folder rename <id> <name>."]));
+        return 2;
+      }
+      const folder = await mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await renameCoreGalleryFolder(state, context, folderId, {
+          name,
+          parentId: getCliOption(args, "--parent") ?? undefined
+        });
+        return { state: outcome.state, result: outcome.folder };
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, { folder }));
+      return 0;
+    }
+
+    if (command === "folder" && subcommand === "move") {
+      const [folderId] = getCliPositionalsAfter(args, subcommand);
+      if (!folderId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing folder id.", ["Use folder move <id> --parent <id|null>."]));
+        return 2;
+      }
+      const folder = await mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await moveCoreGalleryFolder(state, context, folderId, getCliOption(args, "--parent") ?? null);
+        return { state: outcome.state, result: outcome.folder };
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, { folder }));
+      return 0;
+    }
+
+    if (command === "folder" && subcommand === "delete") {
+      const [folderId] = getCliPositionalsAfter(args, subcommand);
+      if (!folderId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing folder id.", ["Use folder delete <id> --yes."]));
+        return 2;
+      }
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Folder deletion requires --yes.", ["Re-run with --yes if you intend to delete this Gallery folder."]));
+        return 3;
+      }
+      const result = await mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await deleteCoreGalleryFolder(state, context, folderId);
+        return { state: outcome.state, result: outcome.result };
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, { folders: result.folders, assets: result.assets }));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "import") {
+      const paths = getCliPositionalsAfter(args, subcommand);
+      if (paths.length === 0) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing image path for asset import.", ["Use asset import <path...> [--folder <id>] [--duplicate cancel|replace|copy]."]));
+        return 2;
+      }
+      const result = await mutateGalleryStateForCli(
+        async (state, context) => {
+          const outcome = await importCoreGalleryAssets(state, context, paths, getCliOption(args, "--folder") ?? null);
+          return { state: outcome.state, result: outcome.result };
+        },
+        { duplicateAction: normalizeCliDuplicateAction(getCliOption(args, "--duplicate")) }
+      );
+      writeCliJson(cliSuccess(requestId, correlationId, {
+        imported: result.assets.map(getGalleryAssetPublicMetadata),
+        skipped: result.skipped,
+        replacedAssetIds: result.replacedAssetIds
+      }));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "move") {
+      const [assetId] = getCliPositionalsAfter(args, subcommand);
+      if (!assetId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing asset id.", ["Use asset move <id> --folder <id|null>."]));
+        return 2;
+      }
+      const asset = await mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await updateCoreGalleryAsset(state, context, assetId, { folderId: getCliOption(args, "--folder") ?? null });
+        return { state: outcome.state, result: outcome.asset };
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, { asset: getGalleryAssetPublicMetadata(asset) }));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "update") {
+      const [assetId] = getCliPositionalsAfter(args, subcommand);
+      if (!assetId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing asset id.", ["Use asset update <id> [--name <name>] [--tag <tag>] [--folder <id|null>]."]));
+        return 2;
+      }
+      const patch: GalleryAssetPatch = {};
+      const name = getCliOption(args, "--name");
+      if (name) patch.originalName = name;
+      const tags = getCliOptions(args, "--tag");
+      if (tags.length > 0) patch.tags = tags;
+      if (args.includes("--folder")) patch.folderId = getCliOption(args, "--folder") ?? null;
+      if (!Object.keys(patch).length) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "No asset update fields were provided.", ["Use --name, --tag, or --folder."]));
+        return 2;
+      }
+      const asset = await mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await updateCoreGalleryAsset(state, context, assetId, patch);
+        return { state: outcome.state, result: outcome.asset };
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, { asset: getGalleryAssetPublicMetadata(asset) }));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "remove") {
+      const [assetId] = getCliPositionalsAfter(args, subcommand);
+      if (!assetId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing asset id.", ["Use asset remove <id> --yes."]));
+        return 2;
+      }
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Asset removal requires --yes.", ["Re-run with --yes if you intend to remove this Gallery asset."]));
+        return 3;
+      }
+      const result = await mutateGalleryStateForCli(async (state, context) => {
+        const outcome = await removeCoreGalleryAsset(state, context, assetId);
+        return { state: outcome.state, result: { assets: outcome.assets.map(getGalleryAssetPublicMetadata), removed: outcome.removed ? getGalleryAssetPublicMetadata(outcome.removed) : null } };
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, result));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "path") {
+      const [assetId] = getCliPositionalsAfter(args, subcommand);
+      if (!assetId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing asset id.", ["Use asset path <id> --yes."]));
+        return 2;
+      }
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Absolute asset path disclosure requires --yes.", ["Re-run with --yes if you intend to expose the local absolute path."]));
+        return 3;
+      }
+      const state = await readGalleryStateForCli();
+      const result = await resolveCoreGalleryAssetPath(state, galleryMutationContext(state), assetId);
+      writeCliJson(cliSuccess(requestId, correlationId, { asset: getGalleryAssetPublicMetadata(result.asset), path: result.path }));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "export") {
+      const [assetId] = getCliPositionalsAfter(args, subcommand);
+      const targetPath = getCliOption(args, "--to");
+      if (!assetId || !targetPath) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing asset id or --to path.", ["Use asset export <id> --to <path> --yes."]));
+        return 2;
+      }
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Asset export requires --yes.", ["Re-run with --yes if you intend to copy this asset to the target path."]));
+        return 3;
+      }
+      const state = await readGalleryStateForCli();
+      const result = await exportCoreGalleryAsset(state, galleryMutationContext(state), assetId, targetPath, { replace: hasCliFlag(args, "--replace") });
+      writeCliJson(cliSuccess(requestId, correlationId, {
+        asset: getGalleryAssetPublicMetadata(result.asset),
+        exportedPath: result.exportedPath,
+        replaced: result.replaced
+      }));
+      return 0;
+    }
+
+    if (command === "asset" && subcommand === "open") {
+      const [assetId] = getCliPositionalsAfter(args, subcommand);
+      if (!assetId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing asset id.", ["Use asset open <id>."]));
+        return 2;
+      }
+      const state = await readGalleryStateForCli();
+      const result = await resolveCoreGalleryAssetPath(state, galleryMutationContext(state), assetId);
+      shell.showItemInFolder(result.path);
+      writeCliJson(cliSuccess(requestId, correlationId, { asset: getGalleryAssetPublicMetadata(result.asset), opened: true }));
+      return 0;
+    }
+
     const response = cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Unsupported CrossGen CLI command.", [
       "Use --cli --version --json.",
       "Use --cli doctor --agent --json.",
@@ -3458,6 +3820,9 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli queue status --json.",
       "Use --cli job list --json.",
       "Use --cli gallery list --json.",
+      "Use --cli folder create <name> --json.",
+      "Use --cli asset import <path...> --json.",
+      "Use --cli asset export <id> --to <path> --yes --json.",
       "Use --cli mcp config --client codex --mode readonly --json."
     ]);
     if (json) {

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -1,6 +1,6 @@
 import { PassThrough, Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
-import { runReadonlyMcpStdioServer, type ReadonlyMcpReaders } from "./stdioServer";
+import { runReadonlyMcpStdioServer, type GalleryMcpWriters, type ReadonlyMcpMode, type ReadonlyMcpReaders } from "./stdioServer";
 
 function captureOutput() {
   const chunks: Buffer[] = [];
@@ -29,13 +29,29 @@ function readers(): ReadonlyMcpReaders {
   };
 }
 
-async function runServer(inputText: string) {
+function writers(): GalleryMcpWriters {
+  return {
+    folderCreate: async ({ name }) => ({ folder: { id: "folder-1", name } }),
+    folderRename: async ({ folderId, name }) => ({ folder: { id: folderId, name } }),
+    folderMove: async ({ folderId, parentId }) => ({ folder: { id: folderId, parentId } }),
+    folderDelete: async ({ folderId }) => ({ folderId }),
+    assetImport: async ({ paths }) => ({ imported: paths.map((path) => ({ path })) }),
+    assetMove: async ({ assetId, folderId }) => ({ asset: { id: assetId, folderId } }),
+    assetUpdate: async ({ assetId, originalName }) => ({ asset: { id: assetId, originalName } }),
+    assetRemove: async ({ assetId }) => ({ removed: { id: assetId } }),
+    assetPath: async ({ assetId }) => ({ asset: { id: assetId }, path: "/tmp/sample.png" }),
+    assetExport: async ({ assetId, to }) => ({ asset: { id: assetId }, exportedPath: to, replaced: false })
+  };
+}
+
+async function runServer(inputText: string, options: { mode?: ReadonlyMcpMode; withWriters?: boolean } = {}) {
   const input = new PassThrough();
   const captured = captureOutput();
   const run = runReadonlyMcpStdioServer({
-    mode: "readonly",
+    mode: options.mode ?? "readonly",
     serverVersion: "0.3.0-test",
     readers: readers(),
+    writers: options.withWriters ? writers() : undefined,
     input,
     output: captured.output
   });
@@ -77,7 +93,9 @@ describe("readonly MCP stdio server", () => {
       }
     });
     expect(responses[1]).toMatchObject({ id: 2 });
-    expect((responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain("crossgen_config_status");
+    const toolNames = (responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
+    expect(toolNames).toContain("crossgen_config_status");
+    expect(toolNames).not.toContain("crossgen_folder_create");
   });
 
   it("returns structured content for tool calls and tool errors", async () => {
@@ -92,14 +110,58 @@ describe("readonly MCP stdio server", () => {
     expect(responses[0]).toMatchObject({
       id: 1,
       result: {
-        structuredContent: { stateFound: true, providerCount: 1 }
+        structuredContent: {
+          schemaVersion: 1,
+          data: { stateFound: true, providerCount: 1 }
+        }
       }
     });
     expect(responses[1]).toMatchObject({
       id: 2,
       result: {
         isError: true,
-        structuredContent: { code: "INVALID_ARGUMENT" }
+        structuredContent: {
+          schemaVersion: 1,
+          error: { code: "INVALID_ARGUMENT" }
+        }
+      }
+    });
+  });
+
+  it("registers Gallery write tools only in write mode", async () => {
+    const { output } = await runServer(
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_folder_create", arguments: { name: "Campaign" } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "crossgen_asset_remove", arguments: { assetId: "asset-1" } } })
+      ].join("\n"),
+      { mode: "write", withWriters: true }
+    );
+
+    const responses = lineResponses(output);
+    expect(responses[0]).toMatchObject({
+      result: {
+        crossgen: {
+          effectiveMode: "write",
+          permissions: { readonly: true, write: true, generate: false }
+        }
+      }
+    });
+    expect((responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain("crossgen_folder_create");
+    expect(responses[2]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: { folder: { id: "folder-1", name: "Campaign" } }
+        }
+      }
+    });
+    expect(responses[3]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "CONFIRMATION_REQUIRED" }
+        }
       }
     });
   });

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
 
 export type ReadonlyMcpMode = "readonly" | "write" | "generate";
@@ -23,7 +24,8 @@ interface ReadonlyMcpTool {
   title: string;
   description: string;
   inputSchema: JsonRpcObject;
-  handler: (args: JsonRpcObject) => Promise<unknown>;
+  annotations: JsonRpcObject;
+  handler: (args: JsonRpcObject) => unknown | Promise<unknown>;
 }
 
 export interface ReadonlyMcpReaders {
@@ -37,10 +39,24 @@ export interface ReadonlyMcpReaders {
   assetInspect(assetId: string): Promise<unknown | null>;
 }
 
+export interface GalleryMcpWriters {
+  folderCreate(args: { name: string; parentId?: string | null }): Promise<unknown>;
+  folderRename(args: { folderId: string; name: string; parentId?: string | null }): Promise<unknown>;
+  folderMove(args: { folderId: string; parentId: string | null }): Promise<unknown>;
+  folderDelete(args: { folderId: string; confirm: boolean }): Promise<unknown>;
+  assetImport(args: { paths: string[]; folderId?: string | null; duplicateAction?: "cancel" | "replace" | "copy" }): Promise<unknown>;
+  assetMove(args: { assetId: string; folderId: string | null }): Promise<unknown>;
+  assetUpdate(args: { assetId: string; originalName?: string; tags?: string[]; folderId?: string | null }): Promise<unknown>;
+  assetRemove(args: { assetId: string; confirm: boolean }): Promise<unknown>;
+  assetPath(args: { assetId: string; confirm: boolean }): Promise<unknown>;
+  assetExport(args: { assetId: string; to: string; replace?: boolean; confirm: boolean }): Promise<unknown>;
+}
+
 export interface ReadonlyMcpStdioServerOptions {
   mode: ReadonlyMcpMode;
   serverVersion: string;
   readers: ReadonlyMcpReaders;
+  writers?: GalleryMcpWriters;
   input?: Readable;
   output?: Writable;
   sanitizeError?: (error: unknown) => string;
@@ -93,13 +109,74 @@ function assetInspectSchema(): JsonRpcObject {
   };
 }
 
-function readonlyAnnotations() {
+function readonlyAnnotations(): JsonRpcObject {
   return {
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: false
   };
+}
+
+function writeAnnotations(destructive = false): JsonRpcObject {
+  return {
+    readOnlyHint: false,
+    destructiveHint: destructive,
+    idempotentHint: false,
+    openWorldHint: false
+  };
+}
+
+function stringProperty(description: string): JsonRpcObject {
+  return { type: "string", description };
+}
+
+function nullableStringProperty(description: string): JsonRpcObject {
+  return { type: ["string", "null"], description };
+}
+
+function confirmProperty(description: string): JsonRpcObject {
+  return { type: "boolean", description };
+}
+
+function objectSchema(properties: JsonRpcObject, required: string[] = []): JsonRpcObject {
+  return {
+    type: "object",
+    properties,
+    required,
+    additionalProperties: false
+  };
+}
+
+function requiredString(args: JsonRpcObject, name: string): string | ToolCallResult {
+  const value = args[name];
+  if (typeof value !== "string" || !value.trim()) {
+    return toolError("INVALID_ARGUMENT", `Missing required string argument ${name}.`);
+  }
+  return value.trim();
+}
+
+function optionalStringOrNull(args: JsonRpcObject, name: string): string | null | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function stringArray(args: JsonRpcObject, name: string): string[] | ToolCallResult {
+  const value = args[name];
+  if (!Array.isArray(value)) {
+    return toolError("INVALID_ARGUMENT", `Missing required string array argument ${name}.`);
+  }
+  const strings = value.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).map((item) => item.trim());
+  if (strings.length === 0) {
+    return toolError("INVALID_ARGUMENT", `Argument ${name} must contain at least one path.`);
+  }
+  return strings;
+}
+
+function requireConfirmed(args: JsonRpcObject, message: string): ToolCallResult | null {
+  return args.confirm === true ? null : toolError("CONFIRMATION_REQUIRED", message, ["Call this tool again with confirm: true if you intend to perform this operation."]);
 }
 
 function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
@@ -109,6 +186,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Config Status",
       description: "Read current CrossGen provider, storage, history, Gallery, and queue status without exposing local asset paths.",
       inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
       handler: () => readers.configStatus()
     },
     {
@@ -116,6 +194,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Provider List",
       description: "List configured CrossGen providers and the active provider selection.",
       inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
       handler: () => readers.providerList()
     },
     {
@@ -123,6 +202,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Models List",
       description: "List configured provider models and machine-readable CrossGen capability summaries.",
       inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
       handler: () => readers.modelsList()
     },
     {
@@ -130,6 +210,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Queue Status",
       description: "Read durable generation queue counts and live worker host metadata.",
       inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
       handler: () => readers.queueStatus()
     },
     {
@@ -137,6 +218,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Job List",
       description: "List durable generation queue items, attempts, retry metadata, partial outputs, and completion status.",
       inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
       handler: () => readers.jobList()
     },
     {
@@ -144,6 +226,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Folder List",
       description: "List CrossGen Gallery folders by id and display metadata.",
       inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
       handler: () => readers.folderList()
     },
     {
@@ -151,6 +234,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Gallery List",
       description: "List Gallery folders and assets without disclosing local absolute file paths.",
       inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
       handler: () => readers.galleryList()
     },
     {
@@ -158,6 +242,7 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       title: "CrossGen Asset Inspect",
       description: "Inspect one Gallery asset by id without disclosing the local absolute file path.",
       inputSchema: assetInspectSchema(),
+      annotations: readonlyAnnotations(),
       handler: async (args) => {
         const assetId = typeof args.assetId === "string" ? args.assetId.trim() : "";
         if (!assetId) {
@@ -173,13 +258,192 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
   ];
 }
 
+function makeWriteTools(writers: GalleryMcpWriters): ReadonlyMcpTool[] {
+  return [
+    {
+      name: "crossgen_folder_create",
+      title: "CrossGen Folder Create",
+      description: "Create a CrossGen Gallery folder.",
+      inputSchema: objectSchema({
+        name: stringProperty("Folder display name."),
+        parentId: nullableStringProperty("Optional parent folder id.")
+      }, ["name"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const name = requiredString(args, "name");
+        if (typeof name !== "string") return name;
+        return writers.folderCreate({ name, parentId: optionalStringOrNull(args, "parentId") });
+      }
+    },
+    {
+      name: "crossgen_folder_rename",
+      title: "CrossGen Folder Rename",
+      description: "Rename a CrossGen Gallery folder, optionally moving it under a new parent.",
+      inputSchema: objectSchema({
+        folderId: stringProperty("Folder id."),
+        name: stringProperty("New folder display name."),
+        parentId: nullableStringProperty("Optional new parent folder id.")
+      }, ["folderId", "name"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const folderId = requiredString(args, "folderId");
+        if (typeof folderId !== "string") return folderId;
+        const name = requiredString(args, "name");
+        if (typeof name !== "string") return name;
+        return writers.folderRename({ folderId, name, parentId: optionalStringOrNull(args, "parentId") });
+      }
+    },
+    {
+      name: "crossgen_folder_move",
+      title: "CrossGen Folder Move",
+      description: "Move a CrossGen Gallery folder under another folder or to the root.",
+      inputSchema: objectSchema({
+        folderId: stringProperty("Folder id."),
+        parentId: nullableStringProperty("New parent folder id, or null for root.")
+      }, ["folderId", "parentId"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const folderId = requiredString(args, "folderId");
+        if (typeof folderId !== "string") return folderId;
+        return writers.folderMove({ folderId, parentId: optionalStringOrNull(args, "parentId") ?? null });
+      }
+    },
+    {
+      name: "crossgen_folder_delete",
+      title: "CrossGen Folder Delete",
+      description: "Delete a Gallery folder and move contained assets back to uncategorized.",
+      inputSchema: objectSchema({
+        folderId: stringProperty("Folder id."),
+        confirm: confirmProperty("Must be true to delete a folder.")
+      }, ["folderId", "confirm"]),
+      annotations: writeAnnotations(true),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Folder deletion requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const folderId = requiredString(args, "folderId");
+        if (typeof folderId !== "string") return folderId;
+        return writers.folderDelete({ folderId, confirm: true });
+      }
+    },
+    {
+      name: "crossgen_asset_import",
+      title: "CrossGen Asset Import",
+      description: "Import local image files into CrossGen Gallery.",
+      inputSchema: objectSchema({
+        paths: { type: "array", items: { type: "string" }, description: "Local image paths to import." },
+        folderId: nullableStringProperty("Optional target folder id."),
+        duplicateAction: { type: "string", enum: ["cancel", "replace", "copy"], description: "How duplicate files should be handled." }
+      }, ["paths"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const paths = stringArray(args, "paths");
+        if (!Array.isArray(paths)) return paths;
+        const duplicateAction = args.duplicateAction === "replace" || args.duplicateAction === "copy" ? args.duplicateAction : "cancel";
+        return writers.assetImport({ paths, folderId: optionalStringOrNull(args, "folderId"), duplicateAction });
+      }
+    },
+    {
+      name: "crossgen_asset_move",
+      title: "CrossGen Asset Move",
+      description: "Move a Gallery asset to another folder or uncategorized.",
+      inputSchema: objectSchema({
+        assetId: stringProperty("Gallery asset id."),
+        folderId: nullableStringProperty("Target folder id, or null for uncategorized.")
+      }, ["assetId", "folderId"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const assetId = requiredString(args, "assetId");
+        if (typeof assetId !== "string") return assetId;
+        return writers.assetMove({ assetId, folderId: optionalStringOrNull(args, "folderId") ?? null });
+      }
+    },
+    {
+      name: "crossgen_asset_update",
+      title: "CrossGen Asset Update",
+      description: "Update Gallery asset display name, tags, or folder.",
+      inputSchema: objectSchema({
+        assetId: stringProperty("Gallery asset id."),
+        originalName: stringProperty("Optional new file/display name."),
+        tags: { type: "array", items: { type: "string" }, description: "Optional replacement tag list." },
+        folderId: nullableStringProperty("Optional target folder id.")
+      }, ["assetId"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const assetId = requiredString(args, "assetId");
+        if (typeof assetId !== "string") return assetId;
+        return writers.assetUpdate({
+          assetId,
+          originalName: typeof args.originalName === "string" ? args.originalName : undefined,
+          tags: Array.isArray(args.tags) ? args.tags.filter((tag): tag is string => typeof tag === "string") : undefined,
+          folderId: optionalStringOrNull(args, "folderId")
+        });
+      }
+    },
+    {
+      name: "crossgen_asset_remove",
+      title: "CrossGen Asset Remove",
+      description: "Remove a Gallery asset from CrossGen and delete its managed file.",
+      inputSchema: objectSchema({
+        assetId: stringProperty("Gallery asset id."),
+        confirm: confirmProperty("Must be true to remove the asset.")
+      }, ["assetId", "confirm"]),
+      annotations: writeAnnotations(true),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Asset removal requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const assetId = requiredString(args, "assetId");
+        if (typeof assetId !== "string") return assetId;
+        return writers.assetRemove({ assetId, confirm: true });
+      }
+    },
+    {
+      name: "crossgen_asset_path",
+      title: "CrossGen Asset Path",
+      description: "Return the local absolute path for a Gallery asset after explicit confirmation.",
+      inputSchema: objectSchema({
+        assetId: stringProperty("Gallery asset id."),
+        confirm: confirmProperty("Must be true to disclose a local absolute path.")
+      }, ["assetId", "confirm"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Absolute asset path disclosure requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const assetId = requiredString(args, "assetId");
+        if (typeof assetId !== "string") return assetId;
+        return writers.assetPath({ assetId, confirm: true });
+      }
+    },
+    {
+      name: "crossgen_asset_export",
+      title: "CrossGen Asset Export",
+      description: "Copy a Gallery asset to a target project path after explicit confirmation.",
+      inputSchema: objectSchema({
+        assetId: stringProperty("Gallery asset id."),
+        to: stringProperty("Target file path or directory."),
+        replace: { type: "boolean", description: "Whether to replace an existing target file." },
+        confirm: confirmProperty("Must be true to export the asset.")
+      }, ["assetId", "to", "confirm"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Asset export requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const assetId = requiredString(args, "assetId");
+        if (typeof assetId !== "string") return assetId;
+        const to = requiredString(args, "to");
+        if (typeof to !== "string") return to;
+        return writers.assetExport({ assetId, to, replace: args.replace === true, confirm: true });
+      }
+    }
+  ];
+}
+
 function publicTool(tool: ReadonlyMcpTool): JsonRpcObject {
   return {
     name: tool.name,
     title: tool.title,
     description: tool.description,
     inputSchema: tool.inputSchema,
-    annotations: readonlyAnnotations()
+    annotations: tool.annotations
   };
 }
 
@@ -266,7 +530,11 @@ function extractJsonMessages(pending: Buffer): { messages: string[]; rest: Buffe
 export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerOptions): Promise<number> {
   const input = options.input ?? process.stdin;
   const output = options.output ?? process.stdout;
-  const tools = makeReadonlyTools(options.readers);
+  const effectiveMode = options.mode === "readonly" || !options.writers ? "readonly" : "write";
+  const tools = [
+    ...makeReadonlyTools(options.readers),
+    ...(effectiveMode === "write" && options.writers ? makeWriteTools(options.writers) : [])
+  ];
   const toolMap = new Map(tools.map((tool) => [tool.name, tool]));
   const sanitizeError = options.sanitizeError ?? ((error: unknown) => (error instanceof Error ? error.message : String(error)));
   let pending: Buffer = Buffer.alloc(0);
@@ -290,7 +558,16 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
       return toolError("INVALID_ARGUMENT", "Unknown CrossGen MCP tool.", [`Use tools/list to inspect available tools before calling ${name || "a tool"}.`]);
     }
     try {
-      return normalizeToolResult(await tool.handler(asRecord(call.arguments)));
+      const requestId = typeof call.requestId === "string" && call.requestId.trim() ? call.requestId.trim() : `mcp_${randomUUID()}`;
+      const result = normalizeToolResult(await tool.handler(asRecord(call.arguments)));
+      if (result.structuredContent && typeof result.structuredContent === "object" && !Array.isArray(result.structuredContent)) {
+        result.structuredContent = {
+          schemaVersion: 1,
+          requestId,
+          ...(result.isError ? { error: result.structuredContent } : { data: result.structuredContent })
+        };
+      }
+      return result;
     } catch (error) {
       return toolError("UNKNOWN_ERROR", sanitizeError(error));
     }
@@ -327,17 +604,21 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
             version: options.serverVersion
           },
           instructions:
-            options.mode === "readonly"
+            effectiveMode === "readonly"
               ? "CrossGen MCP is running in readonly mode. It can inspect configuration, providers, models, queue state, and Gallery metadata without exposing local asset paths."
-              : "CrossGen MCP currently exposes readonly tools only. Write and generation MCP tools are reserved for later v0.3.1 phases.",
+              : "CrossGen MCP is running in write mode. It can inspect CrossGen state and manage Gallery folders/assets. Generation tools are reserved for later v0.3.1 phases.",
           crossgen: {
             requestedMode: options.mode,
-            effectiveMode: "readonly",
+            effectiveMode,
             permissions: {
               readonly: true,
-              write: false,
+              write: effectiveMode === "write",
               generate: false
-            }
+            },
+            generateModeWarning:
+              options.mode === "generate"
+                ? "Generation MCP tools are not implemented yet; this process exposes write-mode Gallery tools only."
+                : undefined
           }
         })
       );


### PR DESCRIPTION
## Summary
- add a core Gallery mutation layer for folder CRUD, asset import/move/update/remove/path/export
- route CLI Gallery write commands through the shared state file lock, with --yes required for delete/path/export
- enable MCP write mode for Gallery tools while keeping generation tools disabled
- update MCP structured tool results with schemaVersion/requestId wrapping
- make desktop state writes use the cross-process state lock and refresh Gallery mutation state from disk

## Verification
- pnpm typecheck
- pnpm test -- src/core/gallery.test.ts
- pnpm test -- src/mcp/stdioServer.test.ts
- pnpm build
- pnpm package:dir
- CLI Gallery smoke with temporary CROSSGEN_USER_DATA_DIR
- packaged MCP write-mode smoke
