### PR TITLE
Add job status and cancel command surfaces

### DIFF
--- a/src/cli/readonly.test.ts
+++ b/src/cli/readonly.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { buildCliJobStatus, buildCliMcpConfig } from "./readonly";
+
+function request() {
+  return {
+    mode: "edit" as const,
+    prompt: "make it brighter",
+    inputPaths: ["/private/input.png"],
+    params: {
+      providerKind: "openai" as const,
+      launchId: "gpt-image-2" as const,
+      model: "gpt-image-2",
+      imageRoute: "auto" as const,
+      size: "1024x1024",
+      quality: "auto" as const,
+      outputFormat: "png" as const,
+      outputCompression: 100,
+      background: "auto" as const,
+      n: 1,
+      stream: false,
+      partialImages: 0,
+      moderation: "auto" as const,
+      timeoutMs: 1000
+    }
+  };
+}
+
+describe("readonly CLI builders", () => {
+  it("builds job status without disclosing local output paths", () => {
+    const queue = {
+      schemaVersion: 1 as const,
+      updatedAt: "2026-07-14T00:00:00.000Z",
+      workerHosts: [],
+      items: [
+        {
+          queueId: "queue-1",
+          source: "cli" as const,
+          providerId: "provider-1",
+          request: request(),
+          status: "running" as const,
+          priority: 0,
+          attempt: 1,
+          maxAttempts: 2,
+          createdAt: "2026-07-14T00:00:00.000Z",
+          updatedAt: "2026-07-14T00:00:01.000Z",
+          historyJobId: "history-1",
+          outputAssetIds: ["asset-1"],
+          partialAssetIds: ["asset-partial"],
+          cancelRequested: false,
+          costConfirmed: true,
+          executionKind: "sync-provider" as const,
+          stage: "calling_provider" as const,
+          sourceAssetIds: ["source-1"],
+          outputMediaKinds: ["image" as const]
+        }
+      ]
+    };
+    const state = {
+      providers: [],
+      activeProviderId: "",
+      galleryFolders: [],
+      galleryAssets: [],
+      history: [
+        {
+          id: "history-1",
+          name: "Result",
+          tags: ["test"],
+          providerKind: "openai" as const,
+          providerId: "provider-1",
+          launchId: "gpt-image-2" as const,
+          modelId: "gpt-image-2",
+          modelDisplayName: "GPT Image 2",
+          mode: "edit" as const,
+          prompt: "make it brighter",
+          inputAssets: [],
+          params: request().params,
+          status: "succeeded" as const,
+          durationMs: 1200,
+          createdAt: "2026-07-14T00:00:00.000Z",
+          updatedAt: "2026-07-14T00:00:02.000Z",
+          outputs: [
+            {
+              id: "asset-1",
+              jobId: "history-1",
+              path: "/private/result.png",
+              fileName: "result.png",
+              mimeType: "image/png",
+              sourceType: "result" as const,
+              createdAt: "2026-07-14T00:00:02.000Z"
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = buildCliJobStatus(queue, state, "queue-1");
+
+    expect(result).toMatchObject({
+      lookupId: "queue-1",
+      source: "queue",
+      canCancel: true,
+      terminal: false,
+      queueItem: {
+        queueId: "queue-1",
+        historyJobId: "history-1",
+        status: "running",
+        inputCount: 1,
+        outputAssetIds: ["asset-1"]
+      },
+      historyJob: {
+        id: "history-1",
+        outputCount: 1,
+        outputs: [{ id: "asset-1", fileName: "result.png" }]
+      }
+    });
+    expect(result?.historyJob?.outputs[0]).not.toHaveProperty("path");
+  });
+
+  it("reports generate MCP mode without downgrading to write", () => {
+    expect(buildCliMcpConfig({ client: "codex", mode: "generate", command: "/Applications/CrossGen.app" })).toMatchObject({
+      requestedMode: "generate",
+      mode: "generate",
+      env: { CROSSGEN_MCP_MODE: "generate" },
+      permissions: { readonly: true, write: true, generate: true },
+      supportedModes: ["readonly", "write", "generate"]
+    });
+  });
+});

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -3,8 +3,10 @@ import type {
   GalleryAsset,
   GalleryFolder,
   GenerationJob,
+  GenerationQueueItem,
   GenerationQueueFile,
   ImageQuality,
+  JobStatus,
   OpenAIImageRouting,
   ProviderConfig,
   ProviderKind,
@@ -95,6 +97,86 @@ function liveWorkerHosts(queue: GenerationQueueFile, now = Date.now()): number {
   return queue.workerHosts.filter((host) => Date.parse(host.leaseExpiresAt) > now).length;
 }
 
+function publicQueueJob(item: GenerationQueueItem) {
+  return {
+    queueId: item.queueId,
+    source: item.source,
+    providerId: item.providerId,
+    status: item.status,
+    priority: item.priority,
+    attempt: item.attempt,
+    maxAttempts: item.maxAttempts,
+    mode: item.request.mode,
+    promptPreview: promptPreview(item.request.prompt),
+    inputCount: item.request.inputPaths.length,
+    hasMask: Boolean(item.request.maskPath || item.request.maskDataUrl),
+    createdAt: item.createdAt,
+    startedAt: item.startedAt,
+    updatedAt: item.updatedAt,
+    completedAt: item.completedAt,
+    nextRunAt: item.nextRunAt,
+    lastError: item.lastError,
+    lastErrorCategory: item.lastErrorCategory,
+    lastErrorRetryable: item.lastErrorRetryable,
+    historyJobId: item.historyJobId,
+    outputAssetIds: item.outputAssetIds,
+    partialAssetIds: item.partialAssetIds,
+    cancelRequested: item.cancelRequested,
+    workerHostId: item.workerHostId,
+    workerProcessId: item.workerProcessId,
+    workerHeartbeatAt: item.workerHeartbeatAt,
+    workerLeaseExpiresAt: item.workerLeaseExpiresAt,
+    executionKind: item.executionKind,
+    stage: item.stage,
+    remoteProviderStatus: item.remoteProviderStatus,
+    lastPollAt: item.lastPollAt,
+    localStep: item.localStep,
+    outputMediaKinds: item.outputMediaKinds,
+    sourceAssetIds: item.sourceAssetIds,
+    requestId: item.requestId,
+    correlationId: item.correlationId
+  };
+}
+
+function publicHistoryJob(job: GenerationJob) {
+  return {
+    id: job.id,
+    name: job.name,
+    tags: job.tags,
+    providerKind: job.providerKind,
+    providerId: job.providerId,
+    launchId: job.launchId,
+    modelId: job.modelId,
+    modelDisplayName: job.modelDisplayName,
+    mode: job.mode,
+    promptPreview: promptPreview(job.prompt),
+    inputCount: job.inputAssets.length,
+    hasMask: Boolean(job.maskAsset),
+    status: job.status,
+    durationMs: job.durationMs,
+    error: job.error,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    outputCount: job.outputs.length,
+    outputs: job.outputs.map((output) => ({
+      id: output.id,
+      fileName: output.fileName,
+      mimeType: output.mimeType,
+      kind: output.kind ?? "image",
+      width: output.width,
+      height: output.height,
+      sourceType: output.sourceType,
+      createdAt: output.createdAt
+    })),
+    usage: job.usage,
+    hasProviderMetadata: Boolean(job.providerMetadata)
+  };
+}
+
+function isTerminalStatus(status: JobStatus): boolean {
+  return status === "succeeded" || status === "failed" || status === "cancelled" || status === "interrupted";
+}
+
 export function buildCliConfigStatus(state: ReadonlyAppState | null, queue: GenerationQueueFile) {
   const provider = state ? activeProvider(state) : undefined;
   return {
@@ -150,35 +232,22 @@ export function buildCliQueueStatus(queue: GenerationQueueFile) {
 
 export function buildCliJobList(queue: GenerationQueueFile) {
   return {
-    jobs: queue.items.map((item) => ({
-      queueId: item.queueId,
-      source: item.source,
-      providerId: item.providerId,
-      status: item.status,
-      priority: item.priority,
-      attempt: item.attempt,
-      maxAttempts: item.maxAttempts,
-      mode: item.request.mode,
-      promptPreview: promptPreview(item.request.prompt),
-      createdAt: item.createdAt,
-      startedAt: item.startedAt,
-      updatedAt: item.updatedAt,
-      completedAt: item.completedAt,
-      nextRunAt: item.nextRunAt,
-      lastError: item.lastError,
-      lastErrorCategory: item.lastErrorCategory,
-      lastErrorRetryable: item.lastErrorRetryable,
-      historyJobId: item.historyJobId,
-      outputAssetIds: item.outputAssetIds,
-      partialAssetIds: item.partialAssetIds,
-      cancelRequested: item.cancelRequested,
-      workerHostId: item.workerHostId,
-      executionKind: item.executionKind,
-      stage: item.stage,
-      outputMediaKinds: item.outputMediaKinds,
-      requestId: item.requestId,
-      correlationId: item.correlationId
-    }))
+    jobs: queue.items.map(publicQueueJob)
+  };
+}
+
+export function buildCliJobStatus(queue: GenerationQueueFile, state: ReadonlyAppState | null, jobId: string) {
+  const lookupId = jobId.trim();
+  const queueItem = queue.items.find((item) => item.queueId === lookupId || item.historyJobId === lookupId);
+  const historyJob = state?.history.find((job) => job.id === lookupId || job.id === queueItem?.historyJobId);
+  if (!queueItem && !historyJob) return null;
+  return {
+    lookupId,
+    source: queueItem ? "queue" : "history",
+    queueItem: queueItem ? publicQueueJob(queueItem) : null,
+    historyJob: historyJob ? publicHistoryJob(historyJob) : null,
+    canCancel: queueItem ? queueItem.status === "queued" || queueItem.status === "running" : false,
+    terminal: queueItem ? isTerminalStatus(queueItem.status) : historyJob ? isTerminalStatus(historyJob.status) : false
   };
 }
 
@@ -252,7 +321,7 @@ export function buildCliAssetInspect(state: ReadonlyAppState | null, assetId: st
 
 export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMode; command: string }) {
   const args = ["--mcp"];
-  const effectiveMode: McpMode = options.mode === "generate" ? "write" : options.mode;
+  const effectiveMode: McpMode = options.mode;
   return {
     client: options.client,
     requestedMode: options.mode,
@@ -265,15 +334,13 @@ export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMod
     },
     permissions: {
       readonly: true,
-      write: effectiveMode === "write",
-      generate: false
+      write: effectiveMode === "write" || effectiveMode === "generate",
+      generate: effectiveMode === "generate"
     },
-    supportedModes: ["readonly", "write"],
-    unsupportedModeWarning:
+    supportedModes: ["readonly", "write", "generate"],
+    generateModeWarning:
       options.mode === "generate"
-        ? "This build currently exposes readonly and Gallery write MCP tools only. Generation MCP tools are reserved for later v0.3.1 phases."
-        : options.mode === effectiveMode
-        ? undefined
-        : "This build currently exposes readonly and Gallery write MCP tools only."
+        ? "Generate mode currently exposes queue status and cancellation controls. Image generation submission tools are reserved for later v0.3.1 phases."
+        : undefined
   };
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -99,6 +99,7 @@ import {
   buildCliFolderList,
   buildCliGalleryList,
   buildCliJobList,
+  buildCliJobStatus,
   buildCliMcpConfig,
   buildCliModelsList,
   buildCliProviderList,
@@ -3332,6 +3333,37 @@ async function readExistingQueueForCli() {
   return getGenerationQueueStore().read();
 }
 
+async function cancelGenerationQueueItemForCli(queueId: string) {
+  const queue = await readExistingQueueForCli();
+  const before = queue.items.find((item) => item.queueId === queueId);
+  if (!before) return null;
+
+  await requestGenerationQueueItemCancel(getGenerationQueueStore(), queueId);
+  const afterQueue = await readExistingQueueForCli();
+  const job = buildCliJobStatus(afterQueue, await readExistingStateForCli(), queueId);
+  if (!job) return null;
+
+  const action =
+    before.status === "queued"
+      ? "cancelled"
+      : before.status === "running"
+      ? "cancel_requested"
+      : "already_terminal";
+
+  return {
+    action,
+    queueId,
+    status: job.queueItem?.status ?? before.status,
+    cancelRequested: job.queueItem?.cancelRequested ?? before.cancelRequested,
+    providerRequestAborted: false,
+    note:
+      action === "cancel_requested"
+        ? "Cancel was recorded in the durable queue. A running provider request may continue until the active worker observes cancellation or returns."
+        : undefined,
+    job
+  };
+}
+
 function normalizeCliDuplicateAction(value: string | undefined): GalleryDuplicateAction {
   return value === "replace" || value === "copy" ? value : "cancel";
 }
@@ -3383,6 +3415,7 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
       modelsList: async () => buildCliModelsList(await readExistingStateForCli()),
       queueStatus: async () => buildCliQueueStatus(await readExistingQueueForCli()),
       jobList: async () => buildCliJobList(await readExistingQueueForCli()),
+      jobStatus: async (jobId) => buildCliJobStatus(await readExistingQueueForCli(), await readExistingStateForCli(), jobId),
       folderList: async () => buildCliFolderList(await readExistingStateForCli()),
       galleryList: async () => buildCliGalleryList(await readExistingStateForCli()),
       assetInspect: async (assetId) => buildCliAssetInspect(await readExistingStateForCli(), assetId)
@@ -3471,6 +3504,9 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
         };
       }
     },
+    jobControllers: requestedMode === "generate" ? {
+      jobCancel: async ({ queueId }) => cancelGenerationQueueItemForCli(queueId)
+    } : undefined,
     sanitizeError: (error) => redactLikelySecrets(normalizeError(error))
   });
 }
@@ -3559,9 +3595,9 @@ async function runCliCommandMode(args: string[]): Promise<number> {
           pathDisclosureRequiresConfirmation: true
         },
         knownLimitations: [
-          "v0.3.1 CLI/MCP command mode currently exposes readonly discovery and Gallery asset management tools.",
-          "The desktop generation path uses the durable queue foundation; CLI/MCP generation tools are not implemented yet.",
-          "Agent generation tools are still in later v0.3.1 phases."
+          "v0.3.1 CLI/MCP command mode currently exposes readonly discovery, queue inspection/cancellation, and Gallery asset management tools.",
+          "The desktop generation path uses the durable queue foundation; CLI/MCP generation submission tools are not implemented yet.",
+          "Agent generation submit/edit tools are still in later v0.3.1 phases."
         ]
       };
       writeCliJson(cliSuccess(requestId, correlationId, data));
@@ -3590,6 +3626,40 @@ async function runCliCommandMode(args: string[]): Promise<number> {
 
     if (command === "job" && subcommand === "list") {
       writeCliJson(cliSuccess(requestId, correlationId, buildCliJobList(await readExistingQueueForCli())));
+      return 0;
+    }
+
+    if (command === "job" && subcommand === "status") {
+      const [jobId] = getCliPositionalsAfter(args, subcommand);
+      if (!jobId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing job id.", ["Use job status <queue-id-or-history-job-id>."]));
+        return 2;
+      }
+      const job = buildCliJobStatus(await readExistingQueueForCli(), await readExistingStateForCli(), jobId);
+      if (!job) {
+        writeCliJson(cliFailure(requestId, correlationId, "JOB_NOT_FOUND", "Generation job not found.", ["Run crossgen --cli job list --json to find queue ids."]));
+        return 4;
+      }
+      writeCliJson(cliSuccess(requestId, correlationId, { job }));
+      return 0;
+    }
+
+    if (command === "job" && subcommand === "cancel") {
+      const [queueId] = getCliPositionalsAfter(args, subcommand);
+      if (!queueId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing queue id.", ["Use job cancel <queue-id> --yes."]));
+        return 2;
+      }
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Job cancellation requires --yes.", ["Re-run with --yes if you intend to cancel this queued or running generation job."]));
+        return 3;
+      }
+      const result = await cancelGenerationQueueItemForCli(queueId);
+      if (!result) {
+        writeCliJson(cliFailure(requestId, correlationId, "JOB_NOT_FOUND", "Generation queue item not found.", ["Run crossgen --cli job list --json to find queue ids."]));
+        return 4;
+      }
+      writeCliJson(cliSuccess(requestId, correlationId, result));
       return 0;
     }
 
@@ -3819,6 +3889,8 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli models list --json.",
       "Use --cli queue status --json.",
       "Use --cli job list --json.",
+      "Use --cli job status <queue-id-or-history-job-id> --json.",
+      "Use --cli job cancel <queue-id> --yes --json.",
       "Use --cli gallery list --json.",
       "Use --cli folder create <name> --json.",
       "Use --cli asset import <path...> --json.",

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -1,6 +1,12 @@
 import { PassThrough, Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
-import { runReadonlyMcpStdioServer, type GalleryMcpWriters, type ReadonlyMcpMode, type ReadonlyMcpReaders } from "./stdioServer";
+import {
+  runReadonlyMcpStdioServer,
+  type GalleryMcpWriters,
+  type GenerationMcpControllers,
+  type ReadonlyMcpMode,
+  type ReadonlyMcpReaders
+} from "./stdioServer";
 
 function captureOutput() {
   const chunks: Buffer[] = [];
@@ -23,6 +29,7 @@ function readers(): ReadonlyMcpReaders {
     modelsList: async () => ({ providers: [] }),
     queueStatus: async () => ({ totalItems: 0 }),
     jobList: async () => ({ jobs: [] }),
+    jobStatus: async (jobId) => (jobId === "queue-1" ? { lookupId: "queue-1", queueItem: { queueId: "queue-1", status: "running" } } : null),
     folderList: async () => ({ folders: [] }),
     galleryList: async () => ({ assets: [] }),
     assetInspect: async (assetId) => (assetId === "asset-1" ? { id: "asset-1", originalName: "sample.png" } : null)
@@ -44,7 +51,13 @@ function writers(): GalleryMcpWriters {
   };
 }
 
-async function runServer(inputText: string, options: { mode?: ReadonlyMcpMode; withWriters?: boolean } = {}) {
+function controllers(): GenerationMcpControllers {
+  return {
+    jobCancel: async ({ queueId }) => (queueId === "missing" ? null : { action: "cancel_requested", queueId, status: "running", cancelRequested: true })
+  };
+}
+
+async function runServer(inputText: string, options: { mode?: ReadonlyMcpMode; withWriters?: boolean; withControllers?: boolean } = {}) {
   const input = new PassThrough();
   const captured = captureOutput();
   const run = runReadonlyMcpStdioServer({
@@ -52,6 +65,7 @@ async function runServer(inputText: string, options: { mode?: ReadonlyMcpMode; w
     serverVersion: "0.3.0-test",
     readers: readers(),
     writers: options.withWriters ? writers() : undefined,
+    jobControllers: options.withControllers ? controllers() : undefined,
     input,
     output: captured.output
   });
@@ -95,14 +109,17 @@ describe("readonly MCP stdio server", () => {
     expect(responses[1]).toMatchObject({ id: 2 });
     const toolNames = (responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
     expect(toolNames).toContain("crossgen_config_status");
+    expect(toolNames).toContain("crossgen_job_status");
     expect(toolNames).not.toContain("crossgen_folder_create");
+    expect(toolNames).not.toContain("crossgen_job_cancel");
   });
 
   it("returns structured content for tool calls and tool errors", async () => {
     const { output } = await runServer(
       [
         JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "crossgen_config_status", arguments: {} } }),
-        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_asset_inspect", arguments: {} } })
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_asset_inspect", arguments: {} } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_job_status", arguments: { jobId: "queue-1" } } })
       ].join("\n")
     );
 
@@ -123,6 +140,20 @@ describe("readonly MCP stdio server", () => {
         structuredContent: {
           schemaVersion: 1,
           error: { code: "INVALID_ARGUMENT" }
+        }
+      }
+    });
+    expect(responses[2]).toMatchObject({
+      id: 3,
+      result: {
+        structuredContent: {
+          schemaVersion: 1,
+          data: {
+            job: {
+              lookupId: "queue-1",
+              queueItem: { queueId: "queue-1", status: "running" }
+            }
+          }
         }
       }
     });
@@ -149,6 +180,7 @@ describe("readonly MCP stdio server", () => {
       }
     });
     expect((responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain("crossgen_folder_create");
+    expect((responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).not.toContain("crossgen_job_cancel");
     expect(responses[2]).toMatchObject({
       result: {
         structuredContent: {
@@ -161,6 +193,59 @@ describe("readonly MCP stdio server", () => {
         isError: true,
         structuredContent: {
           error: { code: "CONFIRMATION_REQUIRED" }
+        }
+      }
+    });
+  });
+
+  it("registers job cancellation only in generate mode", async () => {
+    const { output } = await runServer(
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_job_cancel", arguments: { queueId: "queue-1" } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "crossgen_job_cancel", arguments: { queueId: "queue-1", confirm: true } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "crossgen_job_cancel", arguments: { queueId: "missing", confirm: true } } })
+      ].join("\n"),
+      { mode: "generate", withWriters: true, withControllers: true }
+    );
+
+    const responses = lineResponses(output);
+    expect(responses[0]).toMatchObject({
+      result: {
+        crossgen: {
+          effectiveMode: "generate",
+          permissions: { readonly: true, write: true, generate: true }
+        }
+      }
+    });
+    const toolNames = (responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
+    expect(toolNames).toContain("crossgen_folder_create");
+    expect(toolNames).toContain("crossgen_job_cancel");
+    expect(responses[2]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "CONFIRMATION_REQUIRED" }
+        }
+      }
+    });
+    expect(responses[3]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: {
+            action: "cancel_requested",
+            queueId: "queue-1",
+            cancelRequested: true
+          }
+        }
+      }
+    });
+    expect(responses[4]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "JOB_NOT_FOUND" }
         }
       }
     });

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -34,9 +34,14 @@ export interface ReadonlyMcpReaders {
   modelsList(): Promise<unknown>;
   queueStatus(): Promise<unknown>;
   jobList(): Promise<unknown>;
+  jobStatus(jobId: string): Promise<unknown | null>;
   folderList(): Promise<unknown>;
   galleryList(): Promise<unknown>;
   assetInspect(assetId: string): Promise<unknown | null>;
+}
+
+export interface GenerationMcpControllers {
+  jobCancel(args: { queueId: string; confirm: boolean }): Promise<unknown | null>;
 }
 
 export interface GalleryMcpWriters {
@@ -57,6 +62,7 @@ export interface ReadonlyMcpStdioServerOptions {
   serverVersion: string;
   readers: ReadonlyMcpReaders;
   writers?: GalleryMcpWriters;
+  jobControllers?: GenerationMcpControllers;
   input?: Readable;
   output?: Writable;
   sanitizeError?: (error: unknown) => string;
@@ -105,6 +111,20 @@ function assetInspectSchema(): JsonRpcObject {
       }
     },
     required: ["assetId"],
+    additionalProperties: false
+  };
+}
+
+function jobStatusSchema(): JsonRpcObject {
+  return {
+    type: "object",
+    properties: {
+      jobId: {
+        type: "string",
+        description: "Generation queue id or completed history job id from crossgen_job_list or crossgen_job_status."
+      }
+    },
+    required: ["jobId"],
     additionalProperties: false
   };
 }
@@ -222,6 +242,24 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       handler: () => readers.jobList()
     },
     {
+      name: "crossgen_job_status",
+      title: "CrossGen Job Status",
+      description: "Inspect one durable queue item or completed history job without exposing local output paths.",
+      inputSchema: jobStatusSchema(),
+      annotations: readonlyAnnotations(),
+      handler: async (args) => {
+        const jobId = typeof args.jobId === "string" ? args.jobId.trim() : "";
+        if (!jobId) {
+          return toolError("INVALID_ARGUMENT", "Missing required string argument jobId.", ["Call crossgen_job_list first to find queue ids."]);
+        }
+        const job = await readers.jobStatus(jobId);
+        if (!job) {
+          return toolError("JOB_NOT_FOUND", "Generation job not found.", ["Call crossgen_job_list first to find current queue ids."]);
+        }
+        return { job };
+      }
+    },
+    {
       name: "crossgen_folder_list",
       title: "CrossGen Folder List",
       description: "List CrossGen Gallery folders by id and display metadata.",
@@ -253,6 +291,33 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
           return toolError("ASSET_NOT_FOUND", "Gallery asset not found.", ["Call crossgen_gallery_list first to find current asset ids."]);
         }
         return { asset };
+      }
+    }
+  ];
+}
+
+function makeGenerationControlTools(controllers: GenerationMcpControllers): ReadonlyMcpTool[] {
+  return [
+    {
+      name: "crossgen_job_cancel",
+      title: "CrossGen Job Cancel",
+      description: "Request cancellation for a queued or running durable generation queue item.",
+      inputSchema: objectSchema({
+        queueId: stringProperty("Durable generation queue id."),
+        confirm: confirmProperty("Must be true to request cancellation.")
+      }, ["queueId", "confirm"]),
+      annotations: writeAnnotations(true),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Job cancellation requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const queueId = requiredString(args, "queueId");
+        if (typeof queueId !== "string") return queueId;
+        return controllers.jobCancel({ queueId, confirm: true }).then((result) => {
+          if (!result) {
+            return toolError("JOB_NOT_FOUND", "Generation queue item not found.", ["Call crossgen_job_list first to find current queue ids."]);
+          }
+          return result;
+        });
       }
     }
   ];
@@ -530,10 +595,16 @@ function extractJsonMessages(pending: Buffer): { messages: string[]; rest: Buffe
 export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerOptions): Promise<number> {
   const input = options.input ?? process.stdin;
   const output = options.output ?? process.stdout;
-  const effectiveMode = options.mode === "readonly" || !options.writers ? "readonly" : "write";
+  const effectiveMode: ReadonlyMcpMode =
+    options.mode === "generate" && options.jobControllers
+      ? "generate"
+      : options.mode !== "readonly" && options.writers
+      ? "write"
+      : "readonly";
   const tools = [
     ...makeReadonlyTools(options.readers),
-    ...(effectiveMode === "write" && options.writers ? makeWriteTools(options.writers) : [])
+    ...(effectiveMode !== "readonly" && options.writers ? makeWriteTools(options.writers) : []),
+    ...(effectiveMode === "generate" && options.jobControllers ? makeGenerationControlTools(options.jobControllers) : [])
   ];
   const toolMap = new Map(tools.map((tool) => [tool.name, tool]));
   const sanitizeError = options.sanitizeError ?? ((error: unknown) => (error instanceof Error ? error.message : String(error)));
@@ -606,18 +677,22 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
           instructions:
             effectiveMode === "readonly"
               ? "CrossGen MCP is running in readonly mode. It can inspect configuration, providers, models, queue state, and Gallery metadata without exposing local asset paths."
-              : "CrossGen MCP is running in write mode. It can inspect CrossGen state and manage Gallery folders/assets. Generation tools are reserved for later v0.3.1 phases.",
+              : effectiveMode === "write"
+              ? "CrossGen MCP is running in write mode. It can inspect CrossGen state and manage Gallery folders/assets. Generation tools are reserved for later v0.3.1 phases."
+              : "CrossGen MCP is running in generate mode. It can inspect CrossGen state, manage Gallery folders/assets, and request durable queue cancellation. Image generation submission tools are reserved for later v0.3.1 phases.",
           crossgen: {
             requestedMode: options.mode,
             effectiveMode,
             permissions: {
               readonly: true,
-              write: effectiveMode === "write",
-              generate: false
+              write: effectiveMode === "write" || effectiveMode === "generate",
+              generate: effectiveMode === "generate"
             },
             generateModeWarning:
-              options.mode === "generate"
-                ? "Generation MCP tools are not implemented yet; this process exposes write-mode Gallery tools only."
+              effectiveMode === "generate"
+                ? "Image generation submit/edit tools are not implemented yet; generate mode currently exposes queue cancellation controls."
+                : options.mode === "generate"
+                ? "Generate mode was requested, but queue cancellation controls were not available in this process."
                 : undefined
           }
         })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -417,6 +417,7 @@ export type CrossGenJsonErrorCode =
   | "LOCK_TIMEOUT"
   | "PATH_NOT_ALLOWED"
   | "ASSET_NOT_FOUND"
+  | "JOB_NOT_FOUND"
   | "INVALID_ARGUMENT"
   | "UNKNOWN_ERROR";
 


### PR DESCRIPTION
## Summary
- add CLI job status and job cancel commands for durable queue inspection/control
- expose readonly MCP crossgen_job_status and generate-mode crossgen_job_cancel with confirm gating
- keep job status path-safe by returning output metadata/asset ids without local file paths
- stop downgrading mcp config --mode generate to write; document current generate-mode limitation as queue cancellation only

## Validation
- pnpm typecheck
- pnpm test -- src/cli/readonly.test.ts src/mcp/stdioServer.test.ts src/core/generationQueue.test.ts
- pnpm build
- pnpm package:dir
- Electron command-mode smoke: job status + job cancel against temp CROSSGEN_USER_DATA_DIR
- MCP stdio smoke: generate mode lists job cancel, requires confirm, returns JOB_NOT_FOUND for missing queue id
- Packaged app smoke: mcp config --mode generate and MCP JOB_NOT_FOUND path via release/mac-arm64/CrossGen.app

## Notes
- This does not implement CLI/MCP image generation submission yet; it advances the queue control surface required before Phase 5 submit/edit tools.
