### PR TITLE
Add CLI and MCP generation enqueue tools

### DIFF
--- a/src/cli/readonly.test.ts
+++ b/src/cli/readonly.test.ts
@@ -122,7 +122,8 @@ describe("readonly CLI builders", () => {
       mode: "generate",
       env: { CROSSGEN_MCP_MODE: "generate" },
       permissions: { readonly: true, write: true, generate: true },
-      supportedModes: ["readonly", "write", "generate"]
+      supportedModes: ["readonly", "write", "generate"],
+      generateModeWarning: "Generate mode currently enqueues image generation/edit requests. Worker execution and wait-mode completion are reserved for later v0.3.1 phases."
     });
   });
 });

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -340,7 +340,7 @@ export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMod
     supportedModes: ["readonly", "write", "generate"],
     generateModeWarning:
       options.mode === "generate"
-        ? "Generate mode currently exposes queue status and cancellation controls. Image generation submission tools are reserved for later v0.3.1 phases."
+        ? "Generate mode currently enqueues image generation/edit requests. Worker execution and wait-mode completion are reserved for later v0.3.1 phases."
         : undefined
   };
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -29,10 +29,14 @@ import type {
   GalleryFolder,
   GalleryFolderDeleteResult,
   GalleryFolderInput,
+  GeminiAspectRatio,
+  GeminiResolution,
   GenerationJob,
   HistoryJobPatch,
   ImageAsset,
   InputAsset,
+  ImageParams,
+  ImageQuality,
   JobProgressEvent,
   OpenAIImageRoute,
   OpenAIImageRouteProbe,
@@ -41,6 +45,7 @@ import type {
   PromptTemplateInput,
   ProviderConfig,
   ProviderConfigInput,
+  QueueSource,
   RunJobRequest,
   StorageKind,
   StorageFolderOptions,
@@ -53,6 +58,8 @@ import type {
 } from "../shared/types.js";
 import {
   DEFAULT_IMAGE_PARAMS,
+  DEFAULT_GEMINI_IMAGE_PARAMS,
+  DEFAULT_GENERAL_IMAGE_PARAMS,
   dataUrlToBase64,
   defaultStreamingPartialsEnabled,
   getValidationError,
@@ -3262,7 +3269,32 @@ function getCliPositionalAfter(args: string[], token: string): string | undefine
 function getCliPositionalsAfter(args: string[], token: string): string[] {
   const index = args.indexOf(token);
   if (index < 0) return [];
-  const valueFlags = new Set(["--asset-id", "--client", "--correlation-id", "--duplicate", "--folder", "--mode", "--name", "--parent", "--request-id", "--tag", "--to"]);
+  const valueFlags = new Set([
+    "--asset-id",
+    "--aspect-ratio",
+    "--client",
+    "--correlation-id",
+    "--duplicate",
+    "--folder",
+    "--idempotency-key",
+    "--input",
+    "--mask",
+    "--max-attempts",
+    "--mode",
+    "--model",
+    "--name",
+    "--parent",
+    "--prompt",
+    "--prompt-file",
+    "--provider",
+    "--quality",
+    "--request-id",
+    "--resolution",
+    "--size",
+    "--tag",
+    "--timeout-ms",
+    "--to"
+  ]);
   const result: string[] = [];
   for (let cursor = index + 1; cursor < args.length; cursor += 1) {
     const arg = args[cursor];
@@ -3320,6 +3352,34 @@ function cliFailure(
   };
 }
 
+class CliCommandModeError extends Error {
+  constructor(
+    readonly code: CrossGenJsonErrorCode,
+    message: string,
+    readonly nextActions: string[] = [],
+    readonly exitCode = 2
+  ) {
+    super(message);
+  }
+}
+
+function throwCliCommandError(code: CrossGenJsonErrorCode, message: string, nextActions: string[] = [], exitCode = 2): never {
+  throw new CliCommandModeError(code, message, nextActions, exitCode);
+}
+
+function mcpToolErrorFromCli(error: CliCommandModeError) {
+  const message = redactLikelySecrets(error.message);
+  return {
+    isError: true,
+    content: [{ type: "text", text: `${error.code}: ${message}` }],
+    structuredContent: {
+      code: error.code,
+      message,
+      nextActions: error.nextActions
+    }
+  };
+}
+
 async function readExistingStateForCli(): Promise<AppStateFile | null> {
   try {
     return normalizeState(await readStateFile(getStatePath()));
@@ -3362,6 +3422,195 @@ async function cancelGenerationQueueItemForCli(queueId: string) {
         : undefined,
     job
   };
+}
+
+interface AgentGenerationEnqueueInput {
+  source: QueueSource;
+  mode: "generate" | "edit";
+  prompt: string;
+  inputPaths: string[];
+  maskPath?: string;
+  providerId?: string;
+  model?: string;
+  costConfirmed: boolean;
+  idempotencyKey?: string;
+  requestId?: string;
+  correlationId?: string;
+  maxAttempts?: number;
+  timeoutMs?: number;
+  size?: string;
+  quality?: string;
+  aspectRatio?: string;
+  resolution?: string;
+}
+
+function parsePositiveIntegerOption(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throwCliCommandError("INVALID_ARGUMENT", `${name} must be a positive integer.`, [`Use ${name} <number>.`]);
+  }
+  return parsed;
+}
+
+function selectProviderForAgent(state: AppStateFile, providerId?: string): StoredProviderConfig {
+  const requestedId = providerId?.trim() || state.activeProviderId;
+  const provider = state.providers.find((candidate) => candidate.id === requestedId);
+  if (!provider) {
+    throwCliCommandError("CONFIG_NOT_FOUND", "Provider configuration not found.", ["Run crossgen --cli provider list --json to find provider ids."], 4);
+  }
+  if (!provider.enabled) {
+    throwCliCommandError("CONFIG_NOT_FOUND", "Provider configuration is disabled.", ["Enable or switch provider in CrossGen before submitting generation jobs."], 4);
+  }
+  return provider;
+}
+
+function activeProviderModel(provider: StoredProviderConfig, override?: string): string {
+  return override?.trim() || provider.activeModelId || provider.defaultModel;
+}
+
+function buildAgentImageParams(provider: StoredProviderConfig, input: AgentGenerationEnqueueInput): ImageParams {
+  const model = activeProviderModel(provider, input.model);
+  const timeoutMs = input.timeoutMs ?? provider.timeoutMs;
+  if (provider.activeLaunchId === GENERAL_LAUNCH_ID) {
+    return {
+      ...DEFAULT_GENERAL_IMAGE_PARAMS,
+      providerKind: provider.kind,
+      model,
+      timeoutMs
+    };
+  }
+  if (provider.kind === "gemini" || provider.activeLaunchId === NANO_BANANA_3_LAUNCH_ID) {
+    return {
+      ...DEFAULT_GEMINI_IMAGE_PARAMS,
+      providerKind: "gemini",
+      model,
+      aspectRatio: (input.aspectRatio as GeminiAspectRatio | undefined) ?? DEFAULT_GEMINI_IMAGE_PARAMS.aspectRatio,
+      resolution: (input.resolution as GeminiResolution | undefined) ?? DEFAULT_GEMINI_IMAGE_PARAMS.resolution,
+      timeoutMs
+    };
+  }
+  return {
+    ...DEFAULT_IMAGE_PARAMS,
+    providerKind: "openai",
+    model,
+    imageRoute:
+      input.mode === "generate"
+        ? provider.openAIImageRouting?.preferredGenerateRoute ?? DEFAULT_IMAGE_PARAMS.imageRoute
+        : provider.openAIImageRouting?.preferredEditRoute ?? DEFAULT_IMAGE_PARAMS.imageRoute,
+    size: input.size ?? (provider.defaultSize || DEFAULT_IMAGE_PARAMS.size),
+    quality: (input.quality as ImageQuality | undefined) ?? provider.defaultQuality,
+    stream: false,
+    partialImages: 0,
+    timeoutMs
+  };
+}
+
+function buildAgentRunJobRequest(provider: StoredProviderConfig, input: AgentGenerationEnqueueInput): RunJobRequest {
+  return {
+    mode: input.mode,
+    prompt: input.prompt,
+    inputPaths: input.inputPaths,
+    maskPath: input.maskPath,
+    params: buildAgentImageParams(provider, input)
+  };
+}
+
+function validateAgentRunJobRequest(request: RunJobRequest, provider: StoredProviderConfig): RunJobRequest {
+  const validation = validateRunJobRequest(request);
+  if (!validation.ok) {
+    throwCliCommandError("INVALID_ARGUMENT", validation.message ?? "Generation request is invalid.");
+  }
+  const normalizedRequest: RunJobRequest = {
+    ...request,
+    prompt: request.prompt.trim(),
+    params: normalizeImageParams(request.params)
+  };
+  const validationError = getValidationError(normalizedRequest.params, normalizedRequest.prompt);
+  if (validationError) {
+    throwCliCommandError("INVALID_ARGUMENT", validationError);
+  }
+  const adapter = getImageProviderAdapterForRequest(normalizedRequest);
+  if (!adapter) {
+    throwCliCommandError("CAPABILITY_UNSUPPORTED", unsupportedImageProviderMessage(), ["Run crossgen --cli models list --json to inspect supported model capabilities."], 4);
+  }
+  const adapterValidation = adapter.validateJob(normalizedRequest);
+  if (!adapterValidation.ok) {
+    throwCliCommandError("CAPABILITY_UNSUPPORTED", adapterValidation.message ?? "Generation request is not supported by the selected model.", ["Run crossgen --cli models list --json to inspect supported model capabilities."], 4);
+  }
+  if (!canRunRequestWithConfig(normalizedRequest, provider)) {
+    throwCliCommandError("CAPABILITY_UNSUPPORTED", "Request provider/model does not match the selected provider configuration.", ["Switch provider or pass --provider/--model for a compatible configuration."], 4);
+  }
+  return normalizedRequest;
+}
+
+async function enqueueGenerationForAgent(input: AgentGenerationEnqueueInput) {
+  if (!input.costConfirmed) {
+    throwCliCommandError("CONFIRMATION_REQUIRED", "Generation submission requires explicit confirmation.", ["Re-run with --yes or call the MCP tool with confirm: true."], 3);
+  }
+  const idempotencyKey = input.idempotencyKey?.trim() || undefined;
+  if (idempotencyKey) {
+    const existingQueue = await readExistingQueueForCli();
+    const existing = existingQueue.items.find((item) => item.idempotencyKey === idempotencyKey);
+    if (existing) {
+      return {
+        created: false,
+        duplicate: true,
+        idempotencyKey,
+        queueId: existing.queueId,
+        historyJobId: existing.historyJobId,
+        job: buildCliJobStatus(existingQueue, await readExistingStateForCli(), existing.queueId)
+      };
+    }
+  }
+
+  const state = await readState();
+  const provider = selectProviderForAgent(state, input.providerId);
+  const request = validateAgentRunJobRequest(buildAgentRunJobRequest(provider, input), provider);
+  const { inputs, mask } = await resolveRequestInputs(request, getImagesDir(state));
+  const job = createJob(request, provider, inputs, mask);
+  await upsertJob(job);
+  const queueItem = createGenerationQueueItem({
+    source: input.source,
+    providerId: provider.id,
+    request,
+    costConfirmed: true,
+    historyJobId: job.id,
+    maxAttempts: input.maxAttempts,
+    sourceAssetIds: [...inputs.map((asset) => asset.id), ...(mask ? [mask.id] : [])],
+    outputMediaKinds: ["image"],
+    idempotencyKey,
+    requestId: input.requestId,
+    correlationId: input.correlationId
+  });
+  await getGenerationQueueStore().appendItem(queueItem);
+  const queue = await readExistingQueueForCli();
+  return {
+    created: true,
+    duplicate: false,
+    idempotencyKey,
+    queueId: queueItem.queueId,
+    historyJobId: job.id,
+    status: queueItem.status,
+    job: buildCliJobStatus(queue, await readExistingStateForCli(), queueItem.queueId)
+  };
+}
+
+function readGenerationPromptFromCli(args: string[], command: string): string {
+  const prompt = getCliOption(args, "--prompt");
+  if (prompt !== undefined) return prompt;
+  const promptFile = getCliOption(args, "--prompt-file");
+  if (promptFile) return readFileSync(promptFile, "utf8");
+  if (command === "generate") {
+    return getCliPositionalsAfter(args, command).join(" ");
+  }
+  return "";
+}
+
+function getCliGenerationInputPaths(args: string[], command: string): string[] {
+  const explicit = getCliOptions(args, "--input");
+  if (explicit.length > 0) return explicit;
+  return command === "edit" ? getCliPositionalsAfter(args, command) : [];
 }
 
 function normalizeCliDuplicateAction(value: string | undefined): GalleryDuplicateAction {
@@ -3505,6 +3754,39 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
       }
     },
     jobControllers: requestedMode === "generate" ? {
+      generationSubmit: async ({
+        mode,
+        prompt,
+        inputPaths,
+        maskPath,
+        providerId,
+        model,
+        idempotencyKey,
+        confirm,
+        timeoutMs,
+        size,
+        quality,
+        aspectRatio,
+        resolution
+      }) => enqueueGenerationForAgent({
+        source: "mcp",
+        mode,
+        prompt,
+        inputPaths,
+        maskPath,
+        providerId,
+        model,
+        costConfirmed: confirm,
+        idempotencyKey,
+        timeoutMs,
+        size,
+        quality,
+        aspectRatio,
+        resolution
+      }).catch((error: unknown) => {
+        if (error instanceof CliCommandModeError) return mcpToolErrorFromCli(error);
+        throw error;
+      }),
       jobCancel: async ({ queueId }) => cancelGenerationQueueItemForCli(queueId)
     } : undefined,
     sanitizeError: (error) => redactLikelySecrets(normalizeError(error))
@@ -3595,12 +3877,45 @@ async function runCliCommandMode(args: string[]): Promise<number> {
           pathDisclosureRequiresConfirmation: true
         },
         knownLimitations: [
-          "v0.3.1 CLI/MCP command mode currently exposes readonly discovery, queue inspection/cancellation, and Gallery asset management tools.",
-          "The desktop generation path uses the durable queue foundation; CLI/MCP generation submission tools are not implemented yet.",
-          "Agent generation submit/edit tools are still in later v0.3.1 phases."
+          "v0.3.1 CLI/MCP command mode currently exposes readonly discovery, queue inspection/cancellation, Gallery asset management, and generation enqueue tools.",
+          "CLI/MCP generation tools currently submit durable queue items; worker execution and wait-mode completion are still later v0.3.1 phases.",
+          "Agent generation submit/edit tools require explicit confirmation because they may create paid provider requests when a worker executes them."
         ]
       };
       writeCliJson(cliSuccess(requestId, correlationId, data));
+      return 0;
+    }
+
+    if (command === "generate" || command === "edit") {
+      const prompt = readGenerationPromptFromCli(args, command);
+      if (!prompt.trim()) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing prompt.", ["Use --prompt <text> or --prompt-file <path>."]));
+        return 2;
+      }
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Generation submission requires --yes.", [`Re-run ${command} with --yes if you intend to submit this paid job.`]));
+        return 3;
+      }
+      const result = await enqueueGenerationForAgent({
+        source: "cli",
+        mode: command,
+        prompt,
+        inputPaths: getCliGenerationInputPaths(args, command),
+        maskPath: getCliOption(args, "--mask"),
+        providerId: getCliOption(args, "--provider"),
+        model: getCliOption(args, "--model"),
+        costConfirmed: true,
+        idempotencyKey: getCliOption(args, "--idempotency-key"),
+        requestId,
+        correlationId,
+        maxAttempts: parsePositiveIntegerOption(getCliOption(args, "--max-attempts"), "--max-attempts"),
+        timeoutMs: parsePositiveIntegerOption(getCliOption(args, "--timeout-ms"), "--timeout-ms"),
+        size: getCliOption(args, "--size"),
+        quality: getCliOption(args, "--quality"),
+        aspectRatio: getCliOption(args, "--aspect-ratio"),
+        resolution: getCliOption(args, "--resolution")
+      });
+      writeCliJson(cliSuccess(requestId, correlationId, result));
       return 0;
     }
 
@@ -3887,6 +4202,8 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli config status --json.",
       "Use --cli provider list --json.",
       "Use --cli models list --json.",
+      "Use --cli generate --prompt <text> --yes --json.",
+      "Use --cli edit --prompt <text> --input <path> --yes --json.",
       "Use --cli queue status --json.",
       "Use --cli job list --json.",
       "Use --cli job status <queue-id-or-history-job-id> --json.",
@@ -3904,6 +4221,10 @@ async function runCliCommandMode(args: string[]): Promise<number> {
     }
     return 2;
   } catch (error) {
+    if (error instanceof CliCommandModeError) {
+      writeCliJson(cliFailure(requestId, correlationId, error.code, error.message, error.nextActions));
+      return error.exitCode;
+    }
     writeCliJson(cliFailure(requestId, correlationId, "UNKNOWN_ERROR", normalizeError(error)));
     return 1;
   }

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -53,6 +53,17 @@ function writers(): GalleryMcpWriters {
 
 function controllers(): GenerationMcpControllers {
   return {
+    generationSubmit: async ({ mode, prompt, inputPaths, idempotencyKey }) => ({
+      created: true,
+      duplicate: false,
+      queueId: `queue-${mode}`,
+      historyJobId: `history-${mode}`,
+      idempotencyKey,
+      job: {
+        lookupId: `queue-${mode}`,
+        queueItem: { queueId: `queue-${mode}`, mode, promptPreview: prompt, inputCount: inputPaths.length, status: "queued" }
+      }
+    }),
     jobCancel: async ({ queueId }) => (queueId === "missing" ? null : { action: "cancel_requested", queueId, status: "running", cancelRequested: true })
   };
 }
@@ -221,6 +232,8 @@ describe("readonly MCP stdio server", () => {
     });
     const toolNames = (responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
     expect(toolNames).toContain("crossgen_folder_create");
+    expect(toolNames).toContain("crossgen_generate_image");
+    expect(toolNames).toContain("crossgen_edit_image");
     expect(toolNames).toContain("crossgen_job_cancel");
     expect(responses[2]).toMatchObject({
       result: {
@@ -246,6 +259,50 @@ describe("readonly MCP stdio server", () => {
         isError: true,
         structuredContent: {
           error: { code: "JOB_NOT_FOUND" }
+        }
+      }
+    });
+  });
+
+  it("submits generation tools only after confirmation", async () => {
+    const { output } = await runServer(
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "crossgen_generate_image", arguments: { prompt: "yellow product render" } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_generate_image", arguments: { prompt: "yellow product render", idempotencyKey: "idem-1", confirm: true } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_edit_image", arguments: { prompt: "make it brighter", inputPaths: ["/tmp/input.png"], confirm: true } } })
+      ].join("\n"),
+      { mode: "generate", withWriters: true, withControllers: true }
+    );
+
+    const responses = lineResponses(output);
+    expect(responses[0]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "CONFIRMATION_REQUIRED" }
+        }
+      }
+    });
+    expect(responses[1]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: {
+            created: true,
+            queueId: "queue-generate",
+            historyJobId: "history-generate",
+            idempotencyKey: "idem-1"
+          }
+        }
+      }
+    });
+    expect(responses[2]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: {
+            created: true,
+            queueId: "queue-edit",
+            job: { queueItem: { inputCount: 1 } }
+          }
         }
       }
     });

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -41,6 +41,21 @@ export interface ReadonlyMcpReaders {
 }
 
 export interface GenerationMcpControllers {
+  generationSubmit(args: {
+    mode: "generate" | "edit";
+    prompt: string;
+    inputPaths: string[];
+    maskPath?: string;
+    providerId?: string;
+    model?: string;
+    idempotencyKey?: string;
+    confirm: boolean;
+    timeoutMs?: number;
+    size?: string;
+    quality?: string;
+    aspectRatio?: string;
+    resolution?: string;
+  }): Promise<unknown>;
   jobCancel(args: { queueId: string; confirm: boolean }): Promise<unknown | null>;
 }
 
@@ -157,6 +172,10 @@ function nullableStringProperty(description: string): JsonRpcObject {
 
 function confirmProperty(description: string): JsonRpcObject {
   return { type: "boolean", description };
+}
+
+function numberProperty(description: string): JsonRpcObject {
+  return { type: "number", description };
 }
 
 function objectSchema(properties: JsonRpcObject, required: string[] = []): JsonRpcObject {
@@ -298,6 +317,87 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
 
 function makeGenerationControlTools(controllers: GenerationMcpControllers): ReadonlyMcpTool[] {
   return [
+    {
+      name: "crossgen_generate_image",
+      title: "CrossGen Generate Image",
+      description: "Submit a prompt-only image generation request to the durable CrossGen queue.",
+      inputSchema: objectSchema({
+        prompt: stringProperty("Generation prompt."),
+        providerId: stringProperty("Optional provider id. Defaults to the active provider."),
+        model: stringProperty("Optional model id override."),
+        idempotencyKey: stringProperty("Optional key to prevent duplicate paid submissions."),
+        timeoutMs: numberProperty("Optional request timeout in milliseconds."),
+        size: stringProperty("Optional OpenAI image size, such as auto or 1024x1024."),
+        quality: stringProperty("Optional OpenAI quality."),
+        aspectRatio: stringProperty("Optional Gemini aspect ratio."),
+        resolution: stringProperty("Optional Gemini resolution."),
+        confirm: confirmProperty("Must be true to submit a paid generation request.")
+      }, ["prompt", "confirm"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Image generation requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const prompt = requiredString(args, "prompt");
+        if (typeof prompt !== "string") return prompt;
+        return controllers.generationSubmit({
+          mode: "generate",
+          prompt,
+          inputPaths: [],
+          providerId: typeof args.providerId === "string" ? args.providerId.trim() : undefined,
+          model: typeof args.model === "string" ? args.model.trim() : undefined,
+          idempotencyKey: typeof args.idempotencyKey === "string" ? args.idempotencyKey.trim() : undefined,
+          confirm: true,
+          timeoutMs: typeof args.timeoutMs === "number" ? args.timeoutMs : undefined,
+          size: typeof args.size === "string" ? args.size.trim() : undefined,
+          quality: typeof args.quality === "string" ? args.quality.trim() : undefined,
+          aspectRatio: typeof args.aspectRatio === "string" ? args.aspectRatio.trim() : undefined,
+          resolution: typeof args.resolution === "string" ? args.resolution.trim() : undefined
+        });
+      }
+    },
+    {
+      name: "crossgen_edit_image",
+      title: "CrossGen Edit Image",
+      description: "Submit an image edit request with local input image paths to the durable CrossGen queue.",
+      inputSchema: objectSchema({
+        prompt: stringProperty("Edit prompt."),
+        inputPaths: { type: "array", items: { type: "string" }, description: "Local input image paths." },
+        maskPath: stringProperty("Optional mask path for later inpaint-compatible flows."),
+        providerId: stringProperty("Optional provider id. Defaults to the active provider."),
+        model: stringProperty("Optional model id override."),
+        idempotencyKey: stringProperty("Optional key to prevent duplicate paid submissions."),
+        timeoutMs: numberProperty("Optional request timeout in milliseconds."),
+        size: stringProperty("Optional OpenAI image size, such as auto or 1024x1024."),
+        quality: stringProperty("Optional OpenAI quality."),
+        aspectRatio: stringProperty("Optional Gemini aspect ratio."),
+        resolution: stringProperty("Optional Gemini resolution."),
+        confirm: confirmProperty("Must be true to submit a paid edit request.")
+      }, ["prompt", "inputPaths", "confirm"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Image editing requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const prompt = requiredString(args, "prompt");
+        if (typeof prompt !== "string") return prompt;
+        const inputPaths = stringArray(args, "inputPaths");
+        if (!Array.isArray(inputPaths)) return inputPaths;
+        return controllers.generationSubmit({
+          mode: "edit",
+          prompt,
+          inputPaths,
+          maskPath: typeof args.maskPath === "string" ? args.maskPath.trim() : undefined,
+          providerId: typeof args.providerId === "string" ? args.providerId.trim() : undefined,
+          model: typeof args.model === "string" ? args.model.trim() : undefined,
+          idempotencyKey: typeof args.idempotencyKey === "string" ? args.idempotencyKey.trim() : undefined,
+          confirm: true,
+          timeoutMs: typeof args.timeoutMs === "number" ? args.timeoutMs : undefined,
+          size: typeof args.size === "string" ? args.size.trim() : undefined,
+          quality: typeof args.quality === "string" ? args.quality.trim() : undefined,
+          aspectRatio: typeof args.aspectRatio === "string" ? args.aspectRatio.trim() : undefined,
+          resolution: typeof args.resolution === "string" ? args.resolution.trim() : undefined
+        });
+      }
+    },
     {
       name: "crossgen_job_cancel",
       title: "CrossGen Job Cancel",
@@ -679,7 +779,7 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
               ? "CrossGen MCP is running in readonly mode. It can inspect configuration, providers, models, queue state, and Gallery metadata without exposing local asset paths."
               : effectiveMode === "write"
               ? "CrossGen MCP is running in write mode. It can inspect CrossGen state and manage Gallery folders/assets. Generation tools are reserved for later v0.3.1 phases."
-              : "CrossGen MCP is running in generate mode. It can inspect CrossGen state, manage Gallery folders/assets, and request durable queue cancellation. Image generation submission tools are reserved for later v0.3.1 phases.",
+              : "CrossGen MCP is running in generate mode. It can inspect CrossGen state, manage Gallery folders/assets, submit image generation/edit requests to the durable queue, and request queue cancellation.",
           crossgen: {
             requestedMode: options.mode,
             effectiveMode,
@@ -690,9 +790,9 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
             },
             generateModeWarning:
               effectiveMode === "generate"
-                ? "Image generation submit/edit tools are not implemented yet; generate mode currently exposes queue cancellation controls."
+                ? "Generate mode currently enqueues image generation/edit requests. Worker execution and wait-mode completion are still later v0.3.1 phases."
                 : options.mode === "generate"
-                ? "Generate mode was requested, but queue cancellation controls were not available in this process."
+                ? "Generate mode was requested, but generation controls were not available in this process."
                 : undefined
           }
         })


### PR DESCRIPTION
## Summary
- add CLI generate/edit commands that validate requests, require --yes, create history jobs, and append durable queue items
- add MCP generate-mode crossgen_generate_image and crossgen_edit_image tools with confirm gating
- preserve idempotencyKey semantics so repeated submissions return the existing queue item instead of creating another paid task
- update generate-mode config/instructions to describe enqueue support and the remaining worker/wait limitation

## Validation
- pnpm typecheck
- pnpm test -- src/mcp/stdioServer.test.ts src/cli/readonly.test.ts src/core/generationQueue.test.ts
- pnpm build
- pnpm package:dir
- CLI smoke: generate enqueue + duplicate idempotencyKey against temp CROSSGEN_USER_DATA_DIR
- CLI smoke: edit enqueue with temp PNG input
- MCP smoke: crossgen_generate_image confirm gating, enqueue, duplicate idempotencyKey
- MCP smoke: deeper validation returns structured INVALID_ARGUMENT
- Packaged app smoke: CLI generate enqueue via release/mac-arm64/CrossGen.app

## Notes
- This PR submits jobs to the durable queue only. Worker execution, wait-mode completion, and real provider invocation from CLI/MCP remain later Phase 5 work.
