### PR TITLE
Add prompt-file batch generation

### DIFF
--- a/src/cli/generationBatch.test.ts
+++ b/src/cli/generationBatch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { parseGenerationPromptFile } from "./generationBatch";
+
+describe("generation prompt file parser", () => {
+  it("parses plain prompt lines and JSONL prompt objects", () => {
+    const entries = parseGenerationPromptFile(`
+# comment
+yellow product poster
+{"prompt":"blue hero image","model":"gpt-image-2","provider":"provider-1","idempotency_key":"idem-2","timeout_ms":"30000","max_attempts":2,"aspect_ratio":"1:1"}
+`);
+
+    expect(entries).toEqual([
+      { line: 3, prompt: "yellow product poster" },
+      {
+        line: 4,
+        prompt: "blue hero image",
+        providerId: "provider-1",
+        model: "gpt-image-2",
+        idempotencyKey: "idem-2",
+        timeoutMs: 30000,
+        maxAttempts: 2,
+        aspectRatio: "1:1"
+      }
+    ]);
+  });
+
+  it("rejects invalid JSONL records with line numbers", () => {
+    expect(() => parseGenerationPromptFile('{"model":"gpt-image-2"}')).toThrow("Line 1 is missing required string field prompt.");
+    expect(() => parseGenerationPromptFile('{"prompt":"ok","timeout_ms":"soon"}')).toThrow("timeout_ms must be a positive integer.");
+    expect(() => parseGenerationPromptFile("\n# no prompts\n")).toThrow("Prompt file does not contain any prompts.");
+  });
+});

--- a/src/cli/generationBatch.ts
+++ b/src/cli/generationBatch.ts
@@ -1,0 +1,81 @@
+export interface GenerationPromptFileEntry {
+  line: number;
+  prompt: string;
+  providerId?: string;
+  model?: string;
+  idempotencyKey?: string;
+  maxAttempts?: number;
+  timeoutMs?: number;
+  size?: string;
+  quality?: string;
+  aspectRatio?: string;
+  resolution?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function optionalString(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function optionalPositiveInteger(record: Record<string, unknown>, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (value === undefined || value === null || value === "") continue;
+    const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+    if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+    throw new Error(`${key} must be a positive integer.`);
+  }
+  return undefined;
+}
+
+function parseJsonLine(line: string, lineNumber: number): GenerationPromptFileEntry {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Line ${lineNumber} is not valid JSON: ${message}`);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`Line ${lineNumber} must be a JSON object with a prompt field.`);
+  }
+  const prompt = optionalString(parsed, "prompt");
+  if (!prompt) {
+    throw new Error(`Line ${lineNumber} is missing required string field prompt.`);
+  }
+  return {
+    line: lineNumber,
+    prompt,
+    providerId: optionalString(parsed, "providerId", "provider"),
+    model: optionalString(parsed, "model"),
+    idempotencyKey: optionalString(parsed, "idempotencyKey", "idempotency_key"),
+    maxAttempts: optionalPositiveInteger(parsed, "maxAttempts", "max_attempts"),
+    timeoutMs: optionalPositiveInteger(parsed, "timeoutMs", "timeout_ms"),
+    size: optionalString(parsed, "size"),
+    quality: optionalString(parsed, "quality"),
+    aspectRatio: optionalString(parsed, "aspectRatio", "aspect_ratio"),
+    resolution: optionalString(parsed, "resolution")
+  };
+}
+
+export function parseGenerationPromptFile(raw: string): GenerationPromptFileEntry[] {
+  const entries: GenerationPromptFileEntry[] = [];
+  const lines = raw.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const lineNumber = index + 1;
+    const trimmed = lines[index].trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    entries.push(trimmed.startsWith("{") ? parseJsonLine(trimmed, lineNumber) : { line: lineNumber, prompt: trimmed });
+  }
+  if (entries.length === 0) {
+    throw new Error("Prompt file does not contain any prompts.");
+  }
+  return entries;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -103,6 +103,7 @@ import { recordGenerationQueuePartialOutput, requestGenerationQueueItemCancel, r
 import { getProviderEnvKeyNames } from "../core/keyring.js";
 import { createQueueStore, type QueueStore } from "../core/queueStore.js";
 import { createJsonStateStore, type JsonStateStore } from "../core/stateStore.js";
+import { parseGenerationPromptFile, type GenerationPromptFileEntry } from "../cli/generationBatch.js";
 import {
   buildCliAssetInspect,
   buildCliConfigStatus,
@@ -3436,7 +3437,8 @@ function getCliPositionalsAfter(args: string[], token: string): string[] {
     "--size",
     "--tag",
     "--timeout-ms",
-    "--to"
+    "--to",
+    "--wait-ms"
   ]);
   const result: string[] = [];
   for (let cursor = index + 1; cursor < args.length; cursor += 1) {
@@ -3749,17 +3751,166 @@ function readGenerationPromptFromCli(args: string[], command: string): string {
   const prompt = getCliOption(args, "--prompt");
   if (prompt !== undefined) return prompt;
   const promptFile = getCliOption(args, "--prompt-file");
-  if (promptFile) return readFileSync(promptFile, "utf8");
+  if (promptFile && command !== "generate") return readFileSync(promptFile, "utf8");
   if (command === "generate") {
     return getCliPositionalsAfter(args, command).join(" ");
   }
   return "";
 }
 
+function readGenerationPromptFileEntriesFromCli(args: string[]): { path: string; entries: GenerationPromptFileEntry[] } | null {
+  const promptFile = getCliOption(args, "--prompt-file");
+  if (!promptFile) return null;
+  try {
+    return {
+      path: promptFile,
+      entries: parseGenerationPromptFile(readFileSync(promptFile, "utf8"))
+    };
+  } catch (error) {
+    throwCliCommandError("INVALID_ARGUMENT", error instanceof Error ? error.message : String(error), ["Use one prompt per line, or JSONL objects such as {\"prompt\":\"...\",\"model\":\"...\"}."]);
+  }
+}
+
 function getCliGenerationInputPaths(args: string[], command: string): string[] {
   const explicit = getCliOptions(args, "--input");
   if (explicit.length > 0) return explicit;
   return command === "edit" ? getCliPositionalsAfter(args, command) : [];
+}
+
+function cliCommandErrorPayload(error: CliCommandModeError) {
+  return {
+    code: error.code,
+    message: redactLikelySecrets(error.message),
+    nextActions: error.nextActions
+  };
+}
+
+function batchIdempotencyKey(globalKey: string | undefined, entry: GenerationPromptFileEntry, index: number): string | undefined {
+  if (entry.idempotencyKey) return entry.idempotencyKey;
+  const normalized = globalKey?.trim();
+  return normalized ? `${normalized}:${index + 1}` : undefined;
+}
+
+type CliGenerationEnqueueResult = Awaited<ReturnType<typeof enqueueGenerationForAgent>>;
+type CliGenerationWaitExecution = Awaited<ReturnType<typeof runQueuedGenerationForAgent>>;
+type CliGenerationQueuedExecution = {
+  mode: "enqueue-only" | "async";
+  queueId: string;
+  pendingLiveWorker: boolean;
+  liveWorkerAvailable: boolean;
+  job: Awaited<ReturnType<typeof buildQueuedGenerationJobStatus>>;
+};
+type CliGenerationBatchExecution = CliGenerationWaitExecution | CliGenerationQueuedExecution;
+type CliCommandErrorPayload = ReturnType<typeof cliCommandErrorPayload>;
+
+type CliGeneratePromptFileBatchSuccess = CliGenerationEnqueueResult & {
+  ok: true;
+  index: number;
+  line: number;
+  promptPreview: string;
+  execution: CliGenerationBatchExecution;
+};
+
+interface CliGeneratePromptFileBatchFailure {
+  ok: false;
+  index: number;
+  line: number;
+  promptPreview: string;
+  error: CliCommandErrorPayload;
+}
+
+type CliGeneratePromptFileBatchItem = CliGeneratePromptFileBatchSuccess | CliGeneratePromptFileBatchFailure;
+
+function isCliGeneratePromptFileBatchSuccess(item: CliGeneratePromptFileBatchItem): item is CliGeneratePromptFileBatchSuccess {
+  return item.ok === true;
+}
+
+async function runCliGeneratePromptFileBatch(input: {
+  args: string[];
+  requestId: string;
+  correlationId: string;
+  promptFile: string;
+  entries: GenerationPromptFileEntry[];
+  enqueueOnly: boolean;
+  asyncRequested: boolean;
+  waitRequested: boolean;
+  waitMs?: number;
+  globalMaxAttempts?: number;
+  globalTimeoutMs?: number;
+}) {
+  const providerId = getCliOption(input.args, "--provider");
+  const model = getCliOption(input.args, "--model");
+  const globalIdempotencyKey = getCliOption(input.args, "--idempotency-key");
+  const size = getCliOption(input.args, "--size");
+  const quality = getCliOption(input.args, "--quality");
+  const aspectRatio = getCliOption(input.args, "--aspect-ratio");
+  const resolution = getCliOption(input.args, "--resolution");
+  const items: CliGeneratePromptFileBatchItem[] = [];
+
+  for (let index = 0; index < input.entries.length; index += 1) {
+    const entry = input.entries[index];
+    try {
+      const result = await enqueueGenerationForAgent({
+        source: "cli",
+        mode: "generate",
+        prompt: entry.prompt,
+        inputPaths: [],
+        providerId: entry.providerId ?? providerId,
+        model: entry.model ?? model,
+        costConfirmed: true,
+        idempotencyKey: batchIdempotencyKey(globalIdempotencyKey, entry, index),
+        requestId: `${input.requestId}:${index + 1}`,
+        correlationId: input.correlationId,
+        maxAttempts: entry.maxAttempts ?? input.globalMaxAttempts,
+        timeoutMs: entry.timeoutMs ?? input.globalTimeoutMs,
+        size: entry.size ?? size,
+        quality: entry.quality ?? quality,
+        aspectRatio: entry.aspectRatio ?? aspectRatio,
+        resolution: entry.resolution ?? resolution
+      });
+      const execution: CliGenerationBatchExecution = input.waitRequested
+        ? await runQueuedGenerationForAgent(result.queueId, "cli-worker", input.waitMs)
+        : {
+            mode: input.enqueueOnly ? "enqueue-only" : "async",
+            queueId: result.queueId,
+            pendingLiveWorker: input.asyncRequested,
+            liveWorkerAvailable: input.asyncRequested,
+            job: await buildQueuedGenerationJobStatus(result.queueId)
+          };
+      items.push({
+        ok: true,
+        index,
+        line: entry.line,
+        promptPreview: entry.prompt.replace(/\s+/g, " ").trim().slice(0, 180),
+        ...result,
+        execution
+      });
+    } catch (error) {
+      if (error instanceof CliCommandModeError) {
+        items.push({
+          ok: false,
+          index,
+          line: entry.line,
+          promptPreview: entry.prompt.replace(/\s+/g, " ").trim().slice(0, 180),
+          error: cliCommandErrorPayload(error)
+        });
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return {
+    batch: true,
+    mode: "generate",
+    promptFile: input.promptFile,
+    total: input.entries.length,
+    submitted: items.filter(isCliGeneratePromptFileBatchSuccess).length,
+    failedToSubmit: items.filter((item) => !isCliGeneratePromptFileBatchSuccess(item)).length,
+    executionMode: input.waitRequested ? "wait" : input.enqueueOnly ? "enqueue-only" : "async",
+    queueIds: items.filter(isCliGeneratePromptFileBatchSuccess).map((item) => item.queueId),
+    items
+  };
 }
 
 function normalizeCliDuplicateAction(value: string | undefined): GalleryDuplicateAction {
@@ -4055,8 +4206,9 @@ async function runCliCommandMode(args: string[]): Promise<number> {
     }
 
     if (command === "generate" || command === "edit") {
+      const promptFileBatch = command === "generate" ? readGenerationPromptFileEntriesFromCli(args) : null;
       const prompt = readGenerationPromptFromCli(args, command);
-      if (!prompt.trim()) {
+      if (!promptFileBatch && !prompt.trim()) {
         writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing prompt.", ["Use --prompt <text> or --prompt-file <path>."]));
         return 2;
       }
@@ -4066,7 +4218,8 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       }
       const enqueueOnly = hasCliFlag(args, "--enqueue-only");
       const asyncRequested = hasCliFlag(args, "--async");
-      const waitRequested = hasCliFlag(args, "--wait") || hasCliFlag(args, "--wait-ms") || (!enqueueOnly && !asyncRequested);
+      const explicitWaitRequested = hasCliFlag(args, "--wait") || hasCliFlag(args, "--wait-ms");
+      const waitRequested = explicitWaitRequested || (!promptFileBatch && !enqueueOnly && !asyncRequested);
       if (asyncRequested && waitRequested) {
         writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Use either --async or --wait, not both.", ["Use --enqueue-only if you only want to write a durable queue item."]));
         return 2;
@@ -4075,7 +4228,9 @@ async function runCliCommandMode(args: string[]): Promise<number> {
         writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Use either --async or --enqueue-only, not both."));
         return 2;
       }
-      if (asyncRequested && !(await hasLiveGenerationWorkerHost())) {
+      const batchDefaultsToAsync = Boolean(promptFileBatch);
+      const effectiveAsyncRequested = asyncRequested || (batchDefaultsToAsync && !waitRequested && !enqueueOnly);
+      if (effectiveAsyncRequested && !(await hasLiveGenerationWorkerHost())) {
         writeCliJson(cliFailure(requestId, correlationId, "NO_LIVE_QUEUE_WORKER", "No live CrossGen generation worker is available for --async.", [
           "Open CrossGen desktop, start MCP generate mode, run a queue worker, or use --wait so this CLI process executes the job.",
           "Use --enqueue-only only if you intentionally want to leave a pending durable queue item."
@@ -4084,6 +4239,30 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       }
       const timeoutMs = parsePositiveIntegerOption(getCliOption(args, "--timeout-ms"), "--timeout-ms");
       const waitMs = parsePositiveIntegerOption(getCliOption(args, "--wait-ms"), "--wait-ms");
+      const maxAttempts = parsePositiveIntegerOption(getCliOption(args, "--max-attempts"), "--max-attempts");
+      if (promptFileBatch) {
+        const result = await runCliGeneratePromptFileBatch({
+          args,
+          requestId,
+          correlationId,
+          promptFile: promptFileBatch.path,
+          entries: promptFileBatch.entries,
+          enqueueOnly,
+          asyncRequested: effectiveAsyncRequested,
+          waitRequested,
+          waitMs,
+          globalMaxAttempts: maxAttempts,
+          globalTimeoutMs: timeoutMs
+        });
+        const firstItem = result.items[0];
+        if (result.submitted === 0 && firstItem && !isCliGeneratePromptFileBatchSuccess(firstItem)) {
+          const firstError = firstItem.error;
+          writeCliJson(cliFailure(requestId, correlationId, firstError.code, firstError.message, firstError.nextActions));
+          return 1;
+        }
+        writeCliJson(cliSuccess(requestId, correlationId, result));
+        return 0;
+      }
       const result = await enqueueGenerationForAgent({
         source: "cli",
         mode: command,
@@ -4096,7 +4275,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
         idempotencyKey: getCliOption(args, "--idempotency-key"),
         requestId,
         correlationId,
-        maxAttempts: parsePositiveIntegerOption(getCliOption(args, "--max-attempts"), "--max-attempts"),
+        maxAttempts,
         timeoutMs,
         size: getCliOption(args, "--size"),
         quality: getCliOption(args, "--quality"),
@@ -4400,6 +4579,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli provider list --json.",
       "Use --cli models list --json.",
       "Use --cli generate --prompt <text> --yes [--wait|--async|--enqueue-only] --json.",
+      "Use --cli generate --prompt-file <jsonl> --yes [--wait|--async|--enqueue-only] --json.",
       "Use --cli edit --prompt <text> --input <path> --yes [--wait|--async|--enqueue-only] --json.",
       "Use --cli queue status --json.",
       "Use --cli job list --json.",


### PR DESCRIPTION
## Summary
- parse generate --prompt-file as batch input instead of one large prompt
- support plain prompt lines and JSONL prompt objects with per-item provider/model/timeout/size overrides
- submit each prompt as an independent queue item with per-item success/failure output
- keep batch default async semantics, require a live worker for async, and allow explicit --wait or --enqueue-only

## Verification
- pnpm typecheck
- pnpm test -- src/cli/generationBatch.test.ts src/cli/readonly.test.ts src/core/generationQueue.test.ts src/mcp/stdioServer.test.ts
- pnpm build
- local mock OpenAI CLI smoke: prompt-file --wait, default async without worker, prompt-file --enqueue-only
- pnpm package:dir
- packaged app CLI --version smoke