### PR TITLE
Import generation outputs into gallery

### DIFF
--- a/src/cli/generationBatch.test.ts
+++ b/src/cli/generationBatch.test.ts
@@ -6,7 +6,7 @@ describe("generation prompt file parser", () => {
     const entries = parseGenerationPromptFile(`
 # comment
 yellow product poster
-{"prompt":"blue hero image","model":"gpt-image-2","provider":"provider-1","idempotency_key":"idem-2","timeout_ms":"30000","max_attempts":2,"aspect_ratio":"1:1"}
+{"prompt":"blue hero image","model":"gpt-image-2","provider":"provider-1","folder":"folder-1","idempotency_key":"idem-2","timeout_ms":"30000","max_attempts":2,"aspect_ratio":"1:1"}
 `);
 
     expect(entries).toEqual([
@@ -14,6 +14,7 @@ yellow product poster
       {
         line: 4,
         prompt: "blue hero image",
+        folderId: "folder-1",
         providerId: "provider-1",
         model: "gpt-image-2",
         idempotencyKey: "idem-2",

--- a/src/cli/generationBatch.ts
+++ b/src/cli/generationBatch.ts
@@ -1,6 +1,7 @@
 export interface GenerationPromptFileEntry {
   line: number;
   prompt: string;
+  folderId?: string;
   providerId?: string;
   model?: string;
   idempotencyKey?: string;
@@ -53,6 +54,7 @@ function parseJsonLine(line: string, lineNumber: number): GenerationPromptFileEn
   return {
     line: lineNumber,
     prompt,
+    folderId: optionalString(parsed, "folderId", "folder"),
     providerId: optionalString(parsed, "providerId", "provider"),
     model: optionalString(parsed, "model"),
     idempotencyKey: optionalString(parsed, "idempotencyKey", "idempotency_key"),

--- a/src/cli/readonly.test.ts
+++ b/src/cli/readonly.test.ts
@@ -46,6 +46,8 @@ describe("readonly CLI builders", () => {
           historyJobId: "history-1",
           outputAssetIds: ["asset-1"],
           partialAssetIds: ["asset-partial"],
+          galleryAssetIds: ["gallery-1"],
+          targetGalleryFolderId: "folder-1",
           cancelRequested: false,
           costConfirmed: true,
           executionKind: "sync-provider" as const,
@@ -105,7 +107,9 @@ describe("readonly CLI builders", () => {
         historyJobId: "history-1",
         status: "running",
         inputCount: 1,
-        outputAssetIds: ["asset-1"]
+        outputAssetIds: ["asset-1"],
+        galleryAssetIds: ["gallery-1"],
+        targetGalleryFolderId: "folder-1"
       },
       historyJob: {
         id: "history-1",

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -121,6 +121,8 @@ function publicQueueJob(item: GenerationQueueItem) {
     historyJobId: item.historyJobId,
     outputAssetIds: item.outputAssetIds,
     partialAssetIds: item.partialAssetIds,
+    galleryAssetIds: item.galleryAssetIds,
+    targetGalleryFolderId: item.targetGalleryFolderId ?? null,
     cancelRequested: item.cancelRequested,
     workerHostId: item.workerHostId,
     workerProcessId: item.workerProcessId,

--- a/src/core/gallery.test.ts
+++ b/src/core/gallery.test.ts
@@ -62,6 +62,29 @@ describe("gallery core mutations", () => {
     await expect(readFile(managedPath, "utf8")).resolves.toBe("image-one");
   });
 
+  it("imports generated result assets with source metadata", async () => {
+    const { dir, context } = await tempContext();
+    const sourcePath = path.join(dir, "result.png");
+    await writeFile(sourcePath, Buffer.from("generated-image"));
+
+    const createdFolder = await createGalleryFolder(state(), context, { name: "Campaign" });
+    const imported = await importGalleryAssets(createdFolder.state, context, [sourcePath], createdFolder.folder.id, {
+      source: "result",
+      sourceJobId: "job_1",
+      sourceAssetId: "history_asset_1",
+      tags: ["generated", "generated"]
+    });
+
+    expect(imported.result.assets[0]).toMatchObject({
+      id: "asset_1",
+      source: "result",
+      folderId: "folder_1",
+      tags: ["generated"],
+      sourceJobId: "job_1",
+      sourceAssetId: "history_asset_1"
+    });
+  });
+
   it("handles duplicate imports with cancel, copy, and replace actions", async () => {
     const { dir, context } = await tempContext();
     const sourcePath = path.join(dir, "source.png");

--- a/src/core/gallery.ts
+++ b/src/core/gallery.ts
@@ -24,6 +24,13 @@ export interface GalleryImportResult {
   replacedAssetIds: string[];
 }
 
+export interface GalleryImportOptions {
+  source?: GalleryAsset["source"];
+  tags?: string[];
+  sourceJobId?: string;
+  sourceAssetId?: string;
+}
+
 export interface GalleryPathResult {
   asset: GalleryAsset;
   path: string;
@@ -446,7 +453,8 @@ async function createGalleryAssetFromFile(
   state: GalleryStateSlice,
   context: GalleryMutationContext,
   sourcePath: string,
-  folderId: string | null
+  folderId: string | null,
+  options: GalleryImportOptions = {}
 ): Promise<{ asset: GalleryAsset | null; replacedAssetId?: string; skipped?: { reason: string; existingAssetId?: string } }> {
   if (!isImagePath(sourcePath)) {
     return { asset: null, skipped: { reason: "unsupported_file_type" } };
@@ -457,6 +465,8 @@ async function createGalleryAssetFromFile(
   const originalName = path.basename(sourcePath);
   const contentHash = await fileContentHash(sourcePath);
   const sourcePathHash = filePathHash(sourcePath);
+  const source = options.source ?? "import";
+  const tags = normalizeTags(options.tags);
   const duplicate = await findDuplicateGalleryAsset(state, context, folderId, contentHash, sourcePathHash);
   if (duplicate) {
     const duplicateAction = context.duplicateAction ?? "cancel";
@@ -475,12 +485,13 @@ async function createGalleryAssetFromFile(
           originalName,
           mimeType: mimeTypeForFile(sourcePath),
           sizeBytes: nextStat.size,
-          source: "import",
+          tags: mergeTags(duplicate.tags, tags),
+          source,
           updatedAt: nowIso(context),
           contentHash,
           sourcePathHash,
-          sourceJobId: undefined,
-          sourceAssetId: undefined,
+          sourceJobId: options.sourceJobId,
+          sourceAssetId: options.sourceAssetId,
           modifiedAt: nextStat.mtime.toISOString()
         }
       };
@@ -502,12 +513,14 @@ async function createGalleryAssetFromFile(
       mimeType: mimeTypeForFile(sourcePath),
       sizeBytes: stat.size,
       folderId,
-      tags: [],
-      source: "import",
+      tags,
+      source,
       createdAt: nowIso(context),
       updatedAt: nowIso(context),
       contentHash,
       sourcePathHash,
+      sourceJobId: options.sourceJobId,
+      sourceAssetId: options.sourceAssetId,
       modifiedAt: stat.mtime.toISOString()
     }
   };
@@ -612,7 +625,13 @@ export async function deleteGalleryFolder(state: GalleryStateSlice, context: Gal
   };
 }
 
-export async function importGalleryAssets(state: GalleryStateSlice, context: GalleryMutationContext, sourcePaths: string[], folderId?: string | null): Promise<{ state: GalleryStateSlice; result: GalleryImportResult }> {
+export async function importGalleryAssets(
+  state: GalleryStateSlice,
+  context: GalleryMutationContext,
+  sourcePaths: string[],
+  folderId?: string | null,
+  options: GalleryImportOptions = {}
+): Promise<{ state: GalleryStateSlice; result: GalleryImportResult }> {
   let nextState = state;
   const targetFolderId = normalizeGalleryFolderId(state, folderId);
   const result: GalleryImportResult = {
@@ -623,7 +642,7 @@ export async function importGalleryAssets(state: GalleryStateSlice, context: Gal
 
   for (const sourcePath of sourcePaths) {
     if (typeof sourcePath !== "string" || !sourcePath.trim()) continue;
-    const created = await createGalleryAssetFromFile(nextState, context, path.resolve(sourcePath), targetFolderId);
+    const created = await createGalleryAssetFromFile(nextState, context, path.resolve(sourcePath), targetFolderId, options);
     if (created.skipped) {
       result.skipped.push({ path: sourcePath, reason: created.skipped.reason, existingAssetId: created.skipped.existingAssetId });
       continue;

--- a/src/core/generation.ts
+++ b/src/core/generation.ts
@@ -11,6 +11,7 @@ export interface CreateGenerationQueueItemInput {
   historyJobId?: string;
   sourceAssetIds?: string[];
   outputMediaKinds?: MediaKind[];
+  targetGalleryFolderId?: string | null;
   idempotencyKey?: string;
   requestId?: string;
   correlationId?: string;
@@ -33,6 +34,8 @@ export function createGenerationQueueItem(input: CreateGenerationQueueItemInput)
     historyJobId: input.historyJobId,
     outputAssetIds: [],
     partialAssetIds: [],
+    galleryAssetIds: [],
+    targetGalleryFolderId: input.targetGalleryFolderId,
     cancelRequested: false,
     costConfirmed: input.costConfirmed,
     executionKind: "sync-provider",

--- a/src/core/generationQueue.ts
+++ b/src/core/generationQueue.ts
@@ -12,6 +12,7 @@ export interface GenerationQueueExecutionResult<TValue = unknown> {
   historyJobId?: string;
   outputAssetIds?: string[];
   partialAssetIds?: string[];
+  galleryAssetIds?: string[];
   error?: string;
   errorCategory?: QueueErrorCategory;
   retryable?: boolean;
@@ -184,6 +185,7 @@ async function completeClaimedItem(
           historyJobId: result.historyJobId ?? current.historyJobId,
           outputAssetIds: result.outputAssetIds ?? current.outputAssetIds,
           partialAssetIds: result.partialAssetIds ?? current.partialAssetIds,
+          galleryAssetIds: result.galleryAssetIds ?? current.galleryAssetIds,
           cancelRequested: status === "cancelled" ? true : current.cancelRequested,
           workerHostId: undefined,
           workerProcessId: undefined,
@@ -252,7 +254,8 @@ async function failClaimedItem<TValue = unknown>(
       retryable: classification.retryable,
       historyJobId: item.historyJobId,
       outputAssetIds: item.outputAssetIds,
-      partialAssetIds: item.partialAssetIds
+      partialAssetIds: item.partialAssetIds,
+      galleryAssetIds: item.galleryAssetIds
     },
     nowMs
   );
@@ -263,7 +266,8 @@ async function failClaimedItem<TValue = unknown>(
     retryable: classification.retryable,
     historyJobId: item.historyJobId,
     outputAssetIds: item.outputAssetIds,
-    partialAssetIds: item.partialAssetIds
+    partialAssetIds: item.partialAssetIds,
+    galleryAssetIds: item.galleryAssetIds
   };
 }
 
@@ -336,7 +340,8 @@ export async function runNextGenerationQueueItem<TValue = unknown>(
           retryable: classification.retryable,
           historyJobId: item.historyJobId,
           outputAssetIds: item.outputAssetIds,
-          partialAssetIds: item.partialAssetIds
+          partialAssetIds: item.partialAssetIds,
+          galleryAssetIds: item.galleryAssetIds
         }
       };
     }

--- a/src/core/queueStore.test.ts
+++ b/src/core/queueStore.test.ts
@@ -40,6 +40,7 @@ function queueItem(patch: Partial<GenerationQueueItem> = {}): GenerationQueueIte
     updatedAt: now,
     outputAssetIds: [],
     partialAssetIds: [],
+    galleryAssetIds: [],
     cancelRequested: false,
     costConfirmed: true,
     executionKind: "sync-provider",
@@ -62,12 +63,14 @@ describe("queueStore", () => {
       leaseMs: 10
     });
 
-    const item = queueItem();
+    const item = queueItem({ targetGalleryFolderId: "folder-1", galleryAssetIds: ["gallery-1"] });
 
     await store.appendItem(item);
     const claimed = await store.claimRunnableItems({ host: { hostId: "host-1", kind: "desktop", processId: process.pid }, limit: 1 });
     expect(claimed).toHaveLength(1);
     expect(claimed[0].attempt).toBe(1);
+    expect(claimed[0].targetGalleryFolderId).toBe("folder-1");
+    expect(claimed[0].galleryAssetIds).toEqual(["gallery-1"]);
 
     const recovered = await store.recoverStaleRunningItems(Date.now() + 1000);
     expect(recovered.items[0].status).toBe("interrupted");

--- a/src/core/queueStore.ts
+++ b/src/core/queueStore.ts
@@ -106,6 +106,8 @@ function normalizeQueueItem(raw: Partial<GenerationQueueItem>): GenerationQueueI
     historyJobId: typeof raw.historyJobId === "string" ? raw.historyJobId : undefined,
     outputAssetIds: Array.isArray(raw.outputAssetIds) ? raw.outputAssetIds.filter((value): value is string => typeof value === "string") : [],
     partialAssetIds: Array.isArray(raw.partialAssetIds) ? raw.partialAssetIds.filter((value): value is string => typeof value === "string") : [],
+    galleryAssetIds: Array.isArray(raw.galleryAssetIds) ? raw.galleryAssetIds.filter((value): value is string => typeof value === "string") : [],
+    targetGalleryFolderId: typeof raw.targetGalleryFolderId === "string" ? raw.targetGalleryFolderId : raw.targetGalleryFolderId === null ? null : undefined,
     cancelRequested: Boolean(raw.cancelRequested),
     costConfirmed: Boolean(raw.costConfirmed),
     workerHostId: typeof raw.workerHostId === "string" ? raw.workerHostId : undefined,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2336,6 +2336,32 @@ async function getOrCreateHistoryJobForQueueItem(
   return job;
 }
 
+async function importGenerationResultOutputsToGallery(job: GenerationJob, item: GenerationQueueItem): Promise<GalleryAsset[]> {
+  if (item.targetGalleryFolderId === undefined) return [];
+  const outputs = job.outputs.filter((asset) => asset.sourceType === "result");
+  if (outputs.length === 0) return [];
+
+  const importedAssets: GalleryAsset[] = [];
+  const nextState = await getAppStateStore().mutate(async (state) => {
+    let nextStateForImport = state;
+    const context = galleryMutationContext(state, { duplicateAction: "copy" });
+    for (const output of outputs) {
+      const outcome = await importCoreGalleryAssets(nextStateForImport, context, [output.path], item.targetGalleryFolderId ?? null, {
+        source: "result",
+        sourceJobId: job.id,
+        sourceAssetId: output.id,
+        tags: job.tags
+      });
+      importedAssets.push(...outcome.result.assets);
+      nextStateForImport = mergeGalleryState(nextStateForImport, outcome.state);
+    }
+    return mergeGalleryState(state, nextStateForImport);
+  });
+  stateCache = nextState;
+  if (importedAssets.length > 0) sendGalleryEvent(nextState, "mutation");
+  return importedAssets;
+}
+
 async function executeGenerationQueueItem(item: GenerationQueueItem, abortSignal: AbortSignal) {
   const state = await readState();
   const provider = selectProviderForQueueItem(state, item);
@@ -2381,6 +2407,7 @@ async function executeGenerationQueueItem(item: GenerationQueueItem, abortSignal
       updatedAt: new Date().toISOString()
     };
     await upsertJob(job);
+    const galleryAssets = job.status === "succeeded" ? await importGenerationResultOutputsToGallery(job, item) : [];
     if (job.status === "succeeded") {
       sendQueuedJobEvent({ jobId: job.id, queueId: item.queueId, type: "completed" });
     } else {
@@ -2391,6 +2418,7 @@ async function executeGenerationQueueItem(item: GenerationQueueItem, abortSignal
       value: job,
       historyJobId: job.id,
       outputAssetIds: job.outputs.map((asset) => asset.id),
+      galleryAssetIds: galleryAssets.map((asset) => asset.id),
       partialAssetIds: job.outputs.filter((asset) => asset.sourceType === "partial").map((asset) => asset.id),
       error: job.status === "failed" ? job.error : undefined
     };
@@ -2411,6 +2439,7 @@ async function executeGenerationQueueItem(item: GenerationQueueItem, abortSignal
       value: job,
       historyJobId: job.id,
       outputAssetIds: job.outputs.map((asset) => asset.id),
+      galleryAssetIds: item.galleryAssetIds,
       partialAssetIds: partialAssets.map((asset) => asset.id),
       error: message
     };
@@ -3581,6 +3610,7 @@ interface AgentGenerationEnqueueInput {
   prompt: string;
   inputPaths: string[];
   maskPath?: string;
+  targetGalleryFolderId?: string | null;
   providerId?: string;
   model?: string;
   costConfirmed: boolean;
@@ -3614,6 +3644,17 @@ function selectProviderForAgent(state: AppStateFile, providerId?: string): Store
     throwCliCommandError("CONFIG_NOT_FOUND", "Provider configuration is disabled.", ["Enable or switch provider in CrossGen before submitting generation jobs."], 4);
   }
   return provider;
+}
+
+function normalizeTargetGalleryFolderId(state: AppStateFile, folderId: string | null | undefined): string | null | undefined {
+  if (folderId === undefined) return undefined;
+  if (folderId === null) return null;
+  const normalized = folderId.trim();
+  if (!normalized || normalized === "null") return null;
+  if (!state.galleryFolders.some((folder) => folder.id === normalized)) {
+    throwCliCommandError("ASSET_NOT_FOUND", "Gallery folder not found.", ["Run crossgen --cli gallery list --json to find folder ids."]);
+  }
+  return normalized;
 }
 
 function activeProviderModel(provider: StoredProviderConfig, override?: string): string {
@@ -3717,6 +3758,7 @@ async function enqueueGenerationForAgent(input: AgentGenerationEnqueueInput) {
 
   const state = await readState();
   const provider = selectProviderForAgent(state, input.providerId);
+  const targetGalleryFolderId = normalizeTargetGalleryFolderId(state, input.targetGalleryFolderId);
   const request = validateAgentRunJobRequest(buildAgentRunJobRequest(provider, input), provider);
   const { inputs, mask } = await resolveRequestInputs(request, getImagesDir(state));
   const job = createJob(request, provider, inputs, mask);
@@ -3728,6 +3770,7 @@ async function enqueueGenerationForAgent(input: AgentGenerationEnqueueInput) {
     costConfirmed: true,
     historyJobId: job.id,
     maxAttempts: input.maxAttempts,
+    targetGalleryFolderId,
     sourceAssetIds: [...inputs.map((asset) => asset.id), ...(mask ? [mask.id] : [])],
     outputMediaKinds: ["image"],
     idempotencyKey,
@@ -3845,6 +3888,7 @@ async function runCliGeneratePromptFileBatch(input: {
   const quality = getCliOption(input.args, "--quality");
   const aspectRatio = getCliOption(input.args, "--aspect-ratio");
   const resolution = getCliOption(input.args, "--resolution");
+  const targetGalleryFolderId = getCliOption(input.args, "--folder");
   const items: CliGeneratePromptFileBatchItem[] = [];
 
   for (let index = 0; index < input.entries.length; index += 1) {
@@ -3855,6 +3899,7 @@ async function runCliGeneratePromptFileBatch(input: {
         mode: "generate",
         prompt: entry.prompt,
         inputPaths: [],
+        targetGalleryFolderId: entry.folderId ?? targetGalleryFolderId,
         providerId: entry.providerId ?? providerId,
         model: entry.model ?? model,
         costConfirmed: true,
@@ -4059,6 +4104,7 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
         prompt,
         inputPaths,
         maskPath,
+        folderId,
         providerId,
         model,
         idempotencyKey,
@@ -4077,6 +4123,7 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
             prompt,
             inputPaths,
             maskPath,
+            targetGalleryFolderId: folderId,
             providerId,
             model,
             costConfirmed: confirm,
@@ -4269,6 +4316,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
         prompt,
         inputPaths: getCliGenerationInputPaths(args, command),
         maskPath: getCliOption(args, "--mask"),
+        targetGalleryFolderId: getCliOption(args, "--folder"),
         providerId: getCliOption(args, "--provider"),
         model: getCliOption(args, "--model"),
         costConfirmed: true,
@@ -4578,9 +4626,9 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli config status --json.",
       "Use --cli provider list --json.",
       "Use --cli models list --json.",
-      "Use --cli generate --prompt <text> --yes [--wait|--async|--enqueue-only] --json.",
-      "Use --cli generate --prompt-file <jsonl> --yes [--wait|--async|--enqueue-only] --json.",
-      "Use --cli edit --prompt <text> --input <path> --yes [--wait|--async|--enqueue-only] --json.",
+      "Use --cli generate --prompt <text> [--folder <id|null>] --yes [--wait|--async|--enqueue-only] --json.",
+      "Use --cli generate --prompt-file <jsonl> [--folder <id|null>] --yes [--wait|--async|--enqueue-only] --json.",
+      "Use --cli edit --prompt <text> --input <path> [--folder <id|null>] --yes [--wait|--async|--enqueue-only] --json.",
       "Use --cli queue status --json.",
       "Use --cli job list --json.",
       "Use --cli job status <queue-id-or-history-job-id> --json.",

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -53,11 +53,12 @@ function writers(): GalleryMcpWriters {
 
 function controllers(): GenerationMcpControllers {
   return {
-    generationSubmit: async ({ mode, prompt, inputPaths, idempotencyKey, waitMs }) => ({
+    generationSubmit: async ({ mode, prompt, inputPaths, folderId, idempotencyKey, waitMs }) => ({
       created: true,
       duplicate: false,
       queueId: `queue-${mode}`,
       historyJobId: `history-${mode}`,
+      folderId,
       idempotencyKey,
       execution: waitMs ? { mode: "waitMs", waitMs } : { mode: "async" },
       job: {
@@ -269,8 +270,8 @@ describe("readonly MCP stdio server", () => {
     const { output } = await runServer(
       [
         JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "crossgen_generate_image", arguments: { prompt: "yellow product render" } } }),
-        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_generate_image", arguments: { prompt: "yellow product render", idempotencyKey: "idem-1", confirm: true, waitMs: 250 } } }),
-        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_edit_image", arguments: { prompt: "make it brighter", inputPaths: ["/tmp/input.png"], confirm: true } } })
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_generate_image", arguments: { prompt: "yellow product render", folderId: "folder-1", idempotencyKey: "idem-1", confirm: true, waitMs: 250 } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_edit_image", arguments: { prompt: "make it brighter", inputPaths: ["/tmp/input.png"], folderId: "folder-2", confirm: true } } })
       ].join("\n"),
       { mode: "generate", withWriters: true, withControllers: true }
     );
@@ -291,6 +292,7 @@ describe("readonly MCP stdio server", () => {
             created: true,
             queueId: "queue-generate",
             historyJobId: "history-generate",
+            folderId: "folder-1",
             idempotencyKey: "idem-1",
             execution: { mode: "waitMs", waitMs: 250 }
           }
@@ -303,6 +305,7 @@ describe("readonly MCP stdio server", () => {
           data: {
             created: true,
             queueId: "queue-edit",
+            folderId: "folder-2",
             job: { queueItem: { inputCount: 1 } }
           }
         }

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -46,6 +46,7 @@ export interface GenerationMcpControllers {
     prompt: string;
     inputPaths: string[];
     maskPath?: string;
+    folderId?: string | null;
     providerId?: string;
     model?: string;
     idempotencyKey?: string;
@@ -326,6 +327,7 @@ function makeGenerationControlTools(controllers: GenerationMcpControllers): Read
         prompt: stringProperty("Generation prompt."),
         providerId: stringProperty("Optional provider id. Defaults to the active provider."),
         model: stringProperty("Optional model id override."),
+        folderId: nullableStringProperty("Optional Gallery folder id for generated outputs. Use null for uncategorized."),
         idempotencyKey: stringProperty("Optional key to prevent duplicate paid submissions."),
         waitMs: numberProperty("Optional short wait window in milliseconds. The MCP host still starts queue execution in generate mode."),
         timeoutMs: numberProperty("Optional request timeout in milliseconds."),
@@ -345,6 +347,7 @@ function makeGenerationControlTools(controllers: GenerationMcpControllers): Read
           mode: "generate",
           prompt,
           inputPaths: [],
+          folderId: optionalStringOrNull(args, "folderId"),
           providerId: typeof args.providerId === "string" ? args.providerId.trim() : undefined,
           model: typeof args.model === "string" ? args.model.trim() : undefined,
           idempotencyKey: typeof args.idempotencyKey === "string" ? args.idempotencyKey.trim() : undefined,
@@ -366,6 +369,7 @@ function makeGenerationControlTools(controllers: GenerationMcpControllers): Read
         prompt: stringProperty("Edit prompt."),
         inputPaths: { type: "array", items: { type: "string" }, description: "Local input image paths." },
         maskPath: stringProperty("Optional mask path for later inpaint-compatible flows."),
+        folderId: nullableStringProperty("Optional Gallery folder id for edited outputs. Use null for uncategorized."),
         providerId: stringProperty("Optional provider id. Defaults to the active provider."),
         model: stringProperty("Optional model id override."),
         idempotencyKey: stringProperty("Optional key to prevent duplicate paid submissions."),
@@ -390,6 +394,7 @@ function makeGenerationControlTools(controllers: GenerationMcpControllers): Read
           prompt,
           inputPaths,
           maskPath: typeof args.maskPath === "string" ? args.maskPath.trim() : undefined,
+          folderId: optionalStringOrNull(args, "folderId"),
           providerId: typeof args.providerId === "string" ? args.providerId.trim() : undefined,
           model: typeof args.model === "string" ? args.model.trim() : undefined,
           idempotencyKey: typeof args.idempotencyKey === "string" ? args.idempotencyKey.trim() : undefined,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -369,6 +369,8 @@ export interface GenerationQueueItem {
   historyJobId?: string;
   outputAssetIds: string[];
   partialAssetIds: string[];
+  galleryAssetIds: string[];
+  targetGalleryFolderId?: string | null;
   cancelRequested: boolean;
   costConfirmed: boolean;
   workerHostId?: string;


### PR DESCRIPTION
## Summary
- persist optional target Gallery folder on generation queue items
- support CLI --folder and MCP folderId for generate/edit, including prompt-file JSONL folder overrides
- import successful result outputs into Gallery with source job/asset metadata and expose galleryAssetIds in job status
- validate missing folders before provider execution so invalid --folder does not create a paid request

## Verification
- pnpm typecheck
- pnpm test -- src/cli/generationBatch.test.ts src/core/gallery.test.ts src/core/queueStore.test.ts src/core/generationQueue.test.ts src/mcp/stdioServer.test.ts src/cli/readonly.test.ts
- pnpm build
- mock OpenAI CLI smoke: generate --folder folder-1 --wait imports result to Gallery and asset path/export succeeds
- mock OpenAI CLI smoke: invalid --folder returns ASSET_NOT_FOUND before any provider request
- pnpm package:dir