### PR TITLE
Add generation job retry

### DIFF
--- a/src/core/generationQueue.test.ts
+++ b/src/core/generationQueue.test.ts
@@ -3,7 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createGenerationQueueItem } from "./generation";
-import { recordGenerationQueuePartialOutput, requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion, runNextGenerationQueueItem } from "./generationQueue";
+import {
+  recordGenerationQueuePartialOutput,
+  requestGenerationQueueItemCancel,
+  retryGenerationQueueItem,
+  runGenerationQueueItemToCompletion,
+  runNextGenerationQueueItem
+} from "./generationQueue";
 import { createQueueStore } from "./queueStore";
 
 function request() {
@@ -263,6 +269,104 @@ describe("generationQueue", () => {
     const queue = await store.read();
     expect(queue.items[0].partialAssetIds).toEqual(["partial-1", "partial-2"]);
     expect(queue.items[0].outputAssetIds).toEqual(["partial-1", "partial-2"]);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("requeues retryable terminal items and clears stale execution state", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-1"
+    });
+    await store.appendItem({
+      ...item,
+      status: "failed",
+      stage: "finalizing",
+      attempt: 2,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:00:10.000Z",
+      nextRunAt: "2026-01-01T00:01:00.000Z",
+      lastError: "provider failed",
+      lastErrorCategory: "transient",
+      lastErrorRetryable: true,
+      outputAssetIds: ["asset-old"],
+      partialAssetIds: ["partial-old"],
+      galleryAssetIds: ["gallery-old"],
+      cancelRequested: true,
+      workerHostId: "host-old",
+      workerProcessId: 1234,
+      workerHeartbeatAt: "2026-01-01T00:00:05.000Z",
+      workerLeaseExpiresAt: "2026-01-01T00:01:05.000Z"
+    });
+
+    const result = await retryGenerationQueueItem(store, "job-1", () => Date.parse("2026-01-01T00:02:00.000Z"));
+
+    expect(result.action).toBe("retried");
+    expect(result.item).toMatchObject({
+      queueId: item.queueId,
+      historyJobId: "job-1",
+      status: "queued",
+      stage: "queued",
+      attempt: 0,
+      outputAssetIds: [],
+      partialAssetIds: [],
+      galleryAssetIds: [],
+      cancelRequested: false,
+      workerHostId: undefined
+    });
+    expect(result.item?.startedAt).toBeUndefined();
+    expect(result.item?.completedAt).toBeUndefined();
+    expect(result.item?.nextRunAt).toBeUndefined();
+    expect(result.item?.lastError).toBeUndefined();
+    expect(result.item?.lastErrorCategory).toBeUndefined();
+    expect(result.item?.lastErrorRetryable).toBeUndefined();
+    expect(result.item?.workerProcessId).toBeUndefined();
+    expect(result.item?.workerHeartbeatAt).toBeUndefined();
+    expect(result.item?.workerLeaseExpiresAt).toBeUndefined();
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not retry non-terminal or succeeded items", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const queued = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-queued"
+    });
+    const succeeded = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-succeeded"
+    });
+    await store.appendItem(queued);
+    await store.appendItem({
+      ...succeeded,
+      status: "succeeded",
+      stage: "finalizing",
+      completedAt: "2026-01-01T00:00:10.000Z",
+      outputAssetIds: ["asset-1"]
+    });
+
+    const queuedResult = await retryGenerationQueueItem(store, queued.queueId);
+    const succeededResult = await retryGenerationQueueItem(store, "job-succeeded");
+    const missingResult = await retryGenerationQueueItem(store, "missing-job");
+
+    expect(queuedResult).toMatchObject({ action: "not_retryable", item: { queueId: queued.queueId, status: "queued" } });
+    expect(succeededResult).toMatchObject({ action: "not_retryable", item: { queueId: succeeded.queueId, status: "succeeded" } });
+    expect(missingResult).toEqual({ action: "not_found" });
 
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/src/core/generationQueue.ts
+++ b/src/core/generationQueue.ts
@@ -46,12 +46,18 @@ export interface GenerationQueueRunResult<TValue = unknown> {
   execution?: GenerationQueueExecutionResult<TValue>;
 }
 
+export interface GenerationQueueRetryResult {
+  action: "retried" | "not_found" | "not_retryable";
+  item?: GenerationQueueItem;
+}
+
 export interface RunGenerationQueueItemToCompletionOptions<TValue = unknown> extends RunNextGenerationQueueItemOptions<TValue> {
   pollIntervalMs?: number;
   waitTimeoutMs?: number;
 }
 
 const TERMINAL_STATUSES = new Set<JobStatus>(["succeeded", "failed", "cancelled", "interrupted"]);
+const RETRYABLE_TERMINAL_STATUSES = new Set<JobStatus>(["failed", "cancelled", "interrupted"]);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -434,4 +440,48 @@ export async function requestGenerationQueueItemCancel(queueStore: QueueStore, q
     };
   });
   return updated;
+}
+
+export async function retryGenerationQueueItem(queueStore: QueueStore, lookupId: string, now = Date.now): Promise<GenerationQueueRetryResult> {
+  const normalizedLookupId = lookupId.trim();
+  if (!normalizedLookupId) return { action: "not_found" };
+  let found: GenerationQueueItem | undefined;
+  let retried: GenerationQueueItem | undefined;
+  await queueStore.mutate((queue) => {
+    const nowIso = iso(now());
+    return {
+      ...queue,
+      updatedAt: nowIso,
+      items: queue.items.map((item) => {
+        if (item.queueId !== normalizedLookupId && item.historyJobId !== normalizedLookupId) return item;
+        found = item;
+        if (!RETRYABLE_TERMINAL_STATUSES.has(item.status)) return item;
+        retried = {
+          ...item,
+          status: "queued",
+          stage: "queued",
+          attempt: 0,
+          startedAt: undefined,
+          completedAt: undefined,
+          nextRunAt: undefined,
+          lastError: undefined,
+          lastErrorCategory: undefined,
+          lastErrorRetryable: undefined,
+          outputAssetIds: [],
+          partialAssetIds: [],
+          galleryAssetIds: [],
+          cancelRequested: false,
+          workerHostId: undefined,
+          workerProcessId: undefined,
+          workerHeartbeatAt: undefined,
+          workerLeaseExpiresAt: undefined,
+          updatedAt: nowIso
+        };
+        return retried;
+      })
+    };
+  });
+  if (retried) return { action: "retried", item: retried };
+  if (found) return { action: "not_retryable", item: found };
+  return { action: "not_found" };
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -99,7 +99,13 @@ import {
   type GalleryDuplicateAction,
   type GalleryMutationContext
 } from "../core/gallery.js";
-import { recordGenerationQueuePartialOutput, requestGenerationQueueItemCancel, runGenerationQueueItemToCompletion, runNextGenerationQueueItem } from "../core/generationQueue.js";
+import {
+  recordGenerationQueuePartialOutput,
+  requestGenerationQueueItemCancel,
+  retryGenerationQueueItem,
+  runGenerationQueueItemToCompletion,
+  runNextGenerationQueueItem
+} from "../core/generationQueue.js";
 import { getProviderEnvKeyNames } from "../core/keyring.js";
 import { createQueueStore, type QueueStore } from "../core/queueStore.js";
 import { createJsonStateStore, type JsonStateStore } from "../core/stateStore.js";
@@ -3691,6 +3697,29 @@ async function cancelGenerationQueueItemForCli(queueId: string) {
   };
 }
 
+async function retryGenerationQueueItemForCli(jobId: string) {
+  const result = await retryGenerationQueueItem(getGenerationQueueStore(), jobId);
+  if (result.action === "not_found") return { action: "not_found" as const };
+
+  const lookupId = result.item?.queueId ?? jobId;
+  const job = buildCliJobStatus(await readExistingQueueForCli(), await readExistingStateForCli(), lookupId);
+  if (result.action === "not_retryable") {
+    return {
+      action: "not_retryable" as const,
+      queueId: result.item?.queueId,
+      status: result.item?.status,
+      job
+    };
+  }
+
+  return {
+    action: "retried" as const,
+    queueId: result.item?.queueId,
+    status: result.item?.status,
+    job
+  };
+}
+
 interface AgentGenerationEnqueueInput {
   source: QueueSource;
   mode: "generate" | "edit";
@@ -4240,7 +4269,8 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
           throw error;
         }
       },
-      jobCancel: async ({ queueId }) => cancelGenerationQueueItemForCli(queueId)
+      jobCancel: async ({ queueId }) => cancelGenerationQueueItemForCli(queueId),
+      jobRetry: async ({ jobId }) => retryGenerationQueueItemForCli(jobId)
     } : undefined,
     sanitizeError: (error) => redactLikelySecrets(normalizeError(error))
   });
@@ -4489,6 +4519,33 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       return 0;
     }
 
+    if (command === "job" && subcommand === "retry") {
+      const [jobId] = getCliPositionalsAfter(args, subcommand);
+      if (!jobId) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Missing job id.", ["Use job retry <queue-id-or-history-job-id> --yes."]));
+        return 2;
+      }
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Job retry requires --yes.", [
+          "Re-run with --yes if you intend to requeue this failed, cancelled, or interrupted generation job."
+        ]));
+        return 3;
+      }
+      const result = await retryGenerationQueueItemForCli(jobId);
+      if (result.action === "not_found") {
+        writeCliJson(cliFailure(requestId, correlationId, "JOB_NOT_FOUND", "Generation job not found.", ["Run crossgen --cli job list --json to find queue ids."]));
+        return 4;
+      }
+      if (result.action === "not_retryable") {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "Generation job is not retryable.", [
+          "Only failed, cancelled, or interrupted generation jobs can be retried."
+        ]));
+        return 2;
+      }
+      writeCliJson(cliSuccess(requestId, correlationId, result));
+      return 0;
+    }
+
     if (command === "folder" && subcommand === "list") {
       writeCliJson(cliSuccess(requestId, correlationId, buildCliFolderList(await readExistingStateForCli())));
       return 0;
@@ -4720,6 +4777,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli job list --json.",
       "Use --cli job status <queue-id-or-history-job-id> --json.",
       "Use --cli job cancel <queue-id> --yes --json.",
+      "Use --cli job retry <queue-id-or-history-job-id> --yes --json.",
       "Use --cli gallery list --json.",
       "Use --cli folder create <name> --json.",
       "Use --cli asset import <path...> --json.",

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -66,7 +66,12 @@ function controllers(): GenerationMcpControllers {
         queueItem: { queueId: `queue-${mode}`, mode, promptPreview: prompt, inputCount: inputPaths.length, status: "queued" }
       }
     }),
-    jobCancel: async ({ queueId }) => (queueId === "missing" ? null : { action: "cancel_requested", queueId, status: "running", cancelRequested: true })
+    jobCancel: async ({ queueId }) => (queueId === "missing" ? null : { action: "cancel_requested", queueId, status: "running", cancelRequested: true }),
+    jobRetry: async ({ jobId }) => {
+      if (jobId === "missing") return { action: "not_found" };
+      if (jobId === "queued") return { action: "not_retryable", queueId: "queued", status: "queued" };
+      return { action: "retried", queueId: jobId, status: "queued", job: { lookupId: jobId, queueItem: { queueId: jobId, status: "queued" } } };
+    }
   };
 }
 
@@ -237,6 +242,7 @@ describe("readonly MCP stdio server", () => {
     expect(toolNames).toContain("crossgen_generate_image");
     expect(toolNames).toContain("crossgen_edit_image");
     expect(toolNames).toContain("crossgen_job_cancel");
+    expect(toolNames).toContain("crossgen_job_retry");
     expect(responses[2]).toMatchObject({
       result: {
         isError: true,
@@ -257,6 +263,55 @@ describe("readonly MCP stdio server", () => {
       }
     });
     expect(responses[4]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "JOB_NOT_FOUND" }
+        }
+      }
+    });
+  });
+
+  it("retries jobs only after confirmation", async () => {
+    const { output } = await runServer(
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "crossgen_job_retry", arguments: { jobId: "queue-1" } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_job_retry", arguments: { jobId: "queue-1", confirm: true } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_job_retry", arguments: { jobId: "queued", confirm: true } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "crossgen_job_retry", arguments: { jobId: "missing", confirm: true } } })
+      ].join("\n"),
+      { mode: "generate", withWriters: true, withControllers: true }
+    );
+
+    const responses = lineResponses(output);
+    expect(responses[0]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "CONFIRMATION_REQUIRED" }
+        }
+      }
+    });
+    expect(responses[1]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: {
+            action: "retried",
+            queueId: "queue-1",
+            status: "queued"
+          }
+        }
+      }
+    });
+    expect(responses[2]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "INVALID_ARGUMENT" }
+        }
+      }
+    });
+    expect(responses[3]).toMatchObject({
       result: {
         isError: true,
         structuredContent: {

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -59,6 +59,7 @@ export interface GenerationMcpControllers {
     resolution?: string;
   }): Promise<unknown>;
   jobCancel(args: { queueId: string; confirm: boolean }): Promise<unknown | null>;
+  jobRetry(args: { jobId: string; confirm: boolean }): Promise<unknown>;
 }
 
 export interface GalleryMcpWriters {
@@ -429,6 +430,32 @@ function makeGenerationControlTools(controllers: GenerationMcpControllers): Read
           return result;
         });
       }
+    },
+    {
+      name: "crossgen_job_retry",
+      title: "CrossGen Job Retry",
+      description: "Requeue a failed, cancelled, or interrupted durable generation job.",
+      inputSchema: objectSchema({
+        jobId: stringProperty("Durable generation queue id or history job id."),
+        confirm: confirmProperty("Must be true to retry the job.")
+      }, ["jobId", "confirm"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Job retry requires confirm: true.");
+        if (confirmationError) return confirmationError;
+        const jobId = requiredString(args, "jobId");
+        if (typeof jobId !== "string") return jobId;
+        return controllers.jobRetry({ jobId, confirm: true }).then((result) => {
+          const action = asRecord(result).action;
+          if (action === "not_found") {
+            return toolError("JOB_NOT_FOUND", "Generation job not found.", ["Call crossgen_job_list first to find current queue ids."]);
+          }
+          if (action === "not_retryable") {
+            return toolError("INVALID_ARGUMENT", "Generation job is not retryable.", ["Only failed, cancelled, or interrupted generation jobs can be retried."]);
+          }
+          return result;
+        });
+      }
     }
   ];
 }
@@ -789,7 +816,7 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
               ? "CrossGen MCP is running in readonly mode. It can inspect configuration, providers, models, queue state, and Gallery metadata without exposing local asset paths."
               : effectiveMode === "write"
               ? "CrossGen MCP is running in write mode. It can inspect CrossGen state and manage Gallery folders/assets. Generation tools require generate mode."
-              : "CrossGen MCP is running in generate mode. It can inspect CrossGen state, manage Gallery folders/assets, submit image generation/edit requests to the durable queue, start queue execution, wait briefly with waitMs, and request queue cancellation.",
+              : "CrossGen MCP is running in generate mode. It can inspect CrossGen state, manage Gallery folders/assets, submit image generation/edit requests to the durable queue, start queue execution, wait briefly with waitMs, and request queue cancellation or retry.",
           crossgen: {
             requestedMode: options.mode,
             effectiveMode,


### PR DESCRIPTION
## Summary
- add core retry semantics for failed, cancelled, and interrupted generation queue items
- expose CLI `job retry <queue-id-or-history-job-id> --yes`
- expose MCP `crossgen_job_retry` in generate mode with confirmation and stable errors

## Verification
- pnpm typecheck
- pnpm test -- src/core/generationQueue.test.ts src/mcp/stdioServer.test.ts
- pnpm build
- pnpm package:dir
- Electron CLI smoke with isolated CROSSGEN_USER_DATA_DIR: retry failed job by history id -> queued, retry queued job -> INVALID_ARGUMENT