### PR TITLE
Add queue concurrency configuration

### DIFF
--- a/src/cli/readonly.test.ts
+++ b/src/cli/readonly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCliJobStatus, buildCliMcpConfig } from "./readonly";
+import { buildCliConfigStatus, buildCliJobStatus, buildCliMcpConfig, buildCliQueueConfig, buildCliQueueStatus } from "./readonly";
 
 function request() {
   return {
@@ -26,6 +26,35 @@ function request() {
 }
 
 describe("readonly CLI builders", () => {
+  it("reports queue config in config and queue status", () => {
+    const queue = {
+      schemaVersion: 1 as const,
+      updatedAt: "2026-07-14T00:00:00.000Z",
+      workerHosts: [],
+      items: []
+    };
+    const state = {
+      providers: [],
+      activeProviderId: "",
+      galleryFolders: [],
+      galleryAssets: [],
+      history: [],
+      queueConfig: {
+        maxGlobalRunning: 3,
+        providerConcurrency: { "provider-1": 2 }
+      }
+    };
+
+    expect(buildCliQueueConfig(state)).toEqual({ maxGlobalRunning: 3, providerConcurrency: { "provider-1": 2 } });
+    expect(buildCliConfigStatus(state, queue)).toMatchObject({
+      queueConfig: { maxGlobalRunning: 3, providerConcurrency: { "provider-1": 2 } }
+    });
+    expect(buildCliQueueStatus(queue, state.queueConfig)).toMatchObject({
+      config: { maxGlobalRunning: 3, providerConcurrency: { "provider-1": 2 } },
+      totalItems: 0
+    });
+  });
+
   it("builds job status without disclosing local output paths", () => {
     const queue = {
       schemaVersion: 1 as const,

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -1,4 +1,5 @@
 import { listProviderModelCapabilitySummaries } from "../core/modelCapabilities.js";
+import { DEFAULT_QUEUE_RUNTIME_CONFIG, normalizeQueueRuntimeConfig } from "../core/queueConfig.js";
 import type {
   GalleryAsset,
   GalleryFolder,
@@ -10,6 +11,7 @@ import type {
   OpenAIImageRouting,
   ProviderConfig,
   ProviderKind,
+  QueueRuntimeConfig,
   StorageSettings
 } from "../shared/types.js";
 import type { FocusedLaunchId } from "../shared/types.js";
@@ -41,6 +43,7 @@ interface ReadonlyAppState {
   history: GenerationJob[];
   galleryFolders: GalleryFolder[];
   galleryAssets: GalleryAsset[];
+  queueConfig?: QueueRuntimeConfig;
   storage?: StorageSettings;
 }
 
@@ -95,6 +98,10 @@ function promptPreview(prompt: string, maxLength = 180): string {
 
 function liveWorkerHosts(queue: GenerationQueueFile, now = Date.now()): number {
   return queue.workerHosts.filter((host) => Date.parse(host.leaseExpiresAt) > now).length;
+}
+
+export function buildCliQueueConfig(state: ReadonlyAppState | null) {
+  return normalizeQueueRuntimeConfig(state?.queueConfig ?? DEFAULT_QUEUE_RUNTIME_CONFIG);
 }
 
 function publicQueueJob(item: GenerationQueueItem) {
@@ -190,6 +197,7 @@ export function buildCliConfigStatus(state: ReadonlyAppState | null, queue: Gene
     galleryAssetCount: state?.galleryAssets.length ?? 0,
     queueItemCount: queue.items.length,
     queueStatusCounts: queueStatusCounts(queue),
+    queueConfig: buildCliQueueConfig(state),
     liveWorkerHosts: liveWorkerHosts(queue),
     storageConfigured: {
       historyDir: Boolean(state?.storage?.historyDir),
@@ -214,10 +222,11 @@ export function buildCliModelsList(state: ReadonlyAppState | null) {
   };
 }
 
-export function buildCliQueueStatus(queue: GenerationQueueFile) {
+export function buildCliQueueStatus(queue: GenerationQueueFile, queueConfig: QueueRuntimeConfig = DEFAULT_QUEUE_RUNTIME_CONFIG) {
   return {
     schemaVersion: queue.schemaVersion,
     updatedAt: queue.updatedAt,
+    config: normalizeQueueRuntimeConfig(queueConfig),
     totalItems: queue.items.length,
     statusCounts: queueStatusCounts(queue),
     liveWorkerHosts: liveWorkerHosts(queue),

--- a/src/core/queueConfig.ts
+++ b/src/core/queueConfig.ts
@@ -1,0 +1,61 @@
+import type { QueueRuntimeConfig } from "../shared/types.js";
+
+export const MIN_QUEUE_CONCURRENCY = 1;
+export const MAX_QUEUE_CONCURRENCY = 8;
+
+export const DEFAULT_QUEUE_RUNTIME_CONFIG: QueueRuntimeConfig = {
+  maxGlobalRunning: 1,
+  providerConcurrency: {}
+};
+
+export interface QueueRuntimeConfigPatch {
+  maxGlobalRunning?: number;
+  providerConcurrency?: Record<string, number>;
+  clearProviderIds?: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function normalizeQueueConcurrencyValue(value: unknown, fallback = MIN_QUEUE_CONCURRENCY): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : Number.NaN;
+  if (!Number.isSafeInteger(parsed)) return fallback;
+  return Math.min(MAX_QUEUE_CONCURRENCY, Math.max(MIN_QUEUE_CONCURRENCY, parsed));
+}
+
+export function normalizeQueueRuntimeConfig(value: unknown): QueueRuntimeConfig {
+  if (!isRecord(value)) return structuredClone(DEFAULT_QUEUE_RUNTIME_CONFIG);
+  const providerConcurrency: Record<string, number> = {};
+  if (isRecord(value.providerConcurrency)) {
+    for (const [providerId, concurrency] of Object.entries(value.providerConcurrency)) {
+      const normalizedProviderId = providerId.trim();
+      if (!normalizedProviderId) continue;
+      providerConcurrency[normalizedProviderId] = normalizeQueueConcurrencyValue(concurrency);
+    }
+  }
+  return {
+    maxGlobalRunning: normalizeQueueConcurrencyValue(value.maxGlobalRunning, DEFAULT_QUEUE_RUNTIME_CONFIG.maxGlobalRunning),
+    providerConcurrency
+  };
+}
+
+export function applyQueueRuntimeConfigPatch(current: QueueRuntimeConfig, patch: QueueRuntimeConfigPatch): QueueRuntimeConfig {
+  const nextProviderConcurrency = { ...current.providerConcurrency };
+  for (const providerId of patch.clearProviderIds ?? []) {
+    const normalizedProviderId = providerId.trim();
+    if (normalizedProviderId) delete nextProviderConcurrency[normalizedProviderId];
+  }
+  for (const [providerId, concurrency] of Object.entries(patch.providerConcurrency ?? {})) {
+    const normalizedProviderId = providerId.trim();
+    if (!normalizedProviderId) continue;
+    nextProviderConcurrency[normalizedProviderId] = normalizeQueueConcurrencyValue(concurrency);
+  }
+  return {
+    maxGlobalRunning:
+      patch.maxGlobalRunning === undefined
+        ? normalizeQueueConcurrencyValue(current.maxGlobalRunning, DEFAULT_QUEUE_RUNTIME_CONFIG.maxGlobalRunning)
+        : normalizeQueueConcurrencyValue(patch.maxGlobalRunning, DEFAULT_QUEUE_RUNTIME_CONFIG.maxGlobalRunning),
+    providerConcurrency: nextProviderConcurrency
+  };
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -107,6 +107,13 @@ import {
   runNextGenerationQueueItem
 } from "../core/generationQueue.js";
 import { getProviderEnvKeyNames } from "../core/keyring.js";
+import {
+  MAX_QUEUE_CONCURRENCY,
+  MIN_QUEUE_CONCURRENCY,
+  applyQueueRuntimeConfigPatch,
+  normalizeQueueRuntimeConfig,
+  type QueueRuntimeConfigPatch
+} from "../core/queueConfig.js";
 import { createQueueStore, type QueueStore } from "../core/queueStore.js";
 import { createJsonStateStore, type JsonStateStore } from "../core/stateStore.js";
 import { parseGenerationPromptFile, type GenerationPromptFileEntry } from "../cli/generationBatch.js";
@@ -120,6 +127,7 @@ import {
   buildCliMcpConfig,
   buildCliModelsList,
   buildCliProviderList,
+  buildCliQueueConfig,
   buildCliQueueStatus,
   type McpClientName,
   type McpMode
@@ -567,6 +575,7 @@ async function writeState(state: AppStateFile, options: WriteStateOptions = {}):
     promptTemplates: state.promptTemplates,
     galleryFolders: state.galleryFolders,
     galleryAssets: state.galleryAssets,
+    queueConfig: normalizeQueueRuntimeConfig(state.queueConfig),
     storage: state.storage,
     draft: state.draft
   };
@@ -2497,11 +2506,13 @@ async function runQueuedGenerationForAgent(
 ) {
   const startedAt = Date.now();
   const host = { hostId: queueWorkerHostId(hostKind), kind: hostKind, processId: process.pid };
+  const queueConfig = await readQueueRuntimeConfigForCli();
   const result = await runGenerationQueueItemToCompletion<GenerationJob>({
     queueStore: getGenerationQueueStore(),
     queueId,
     host,
-    maxGlobalRunning: 1,
+    maxGlobalRunning: queueConfig.maxGlobalRunning,
+    providerConcurrency: queueConfig.providerConcurrency,
     waitTimeoutMs,
     executeItem: executeGenerationQueueItem,
     onStarted: trackQueuedGenerationStart,
@@ -2552,10 +2563,12 @@ async function registerDesktopQueueWorkerHeartbeat(): Promise<void> {
 }
 
 async function runNextDesktopQueuedGeneration(): Promise<boolean> {
+  const queueConfig = await readQueueRuntimeConfigForCli();
   const result = await runNextGenerationQueueItem<GenerationJob>({
     queueStore: getGenerationQueueStore(),
     host: { hostId: desktopWorkerHostId, kind: "desktop", processId: process.pid },
-    maxGlobalRunning: 1,
+    maxGlobalRunning: queueConfig.maxGlobalRunning,
+    providerConcurrency: queueConfig.providerConcurrency,
     leaseMs: DESKTOP_QUEUE_WORKER_LEASE_MS,
     executeItem: executeGenerationQueueItem,
     onStarted: trackQueuedGenerationStart,
@@ -3539,6 +3552,7 @@ function getCliPositionalsAfter(args: string[], token: string): string[] {
     "--asset-id",
     "--aspect-ratio",
     "--client",
+    "--clear-provider-concurrency",
     "--correlation-id",
     "--duplicate",
     "--folder",
@@ -3546,6 +3560,7 @@ function getCliPositionalsAfter(args: string[], token: string): string[] {
     "--input",
     "--mask",
     "--max-attempts",
+    "--max-global-running",
     "--mode",
     "--model",
     "--name",
@@ -3553,6 +3568,7 @@ function getCliPositionalsAfter(args: string[], token: string): string[] {
     "--prompt",
     "--prompt-file",
     "--provider",
+    "--provider-concurrency",
     "--quality",
     "--request-id",
     "--resolution",
@@ -3658,6 +3674,61 @@ async function readExistingStateForCli(): Promise<AppStateFile | null> {
 
 async function readExistingQueueForCli() {
   return getGenerationQueueStore().read();
+}
+
+async function readQueueRuntimeConfigForCli() {
+  return buildCliQueueConfig(await readExistingStateForCli());
+}
+
+async function setQueueRuntimeConfigForCli(patch: QueueRuntimeConfigPatch) {
+  const nextState = await getAppStateStore().mutate((state) => ({
+    ...state,
+    queueConfig: applyQueueRuntimeConfigPatch(normalizeQueueRuntimeConfig(state.queueConfig), patch)
+  }));
+  stateCache = nextState;
+  return {
+    config: normalizeQueueRuntimeConfig(nextState.queueConfig)
+  };
+}
+
+function parseProviderConcurrencyAssignments(values: string[]): Record<string, number> {
+  const providerConcurrency: Record<string, number> = {};
+  for (const value of values) {
+    const separatorIndex = value.indexOf("=");
+    if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+      throwCliCommandError("INVALID_ARGUMENT", "Provider concurrency must use providerId=number.", ["Use --provider-concurrency <provider-id>=<number>."]);
+    }
+    const providerId = value.slice(0, separatorIndex).trim();
+    if (!providerId) {
+      throwCliCommandError("INVALID_ARGUMENT", "Provider id cannot be empty.", ["Use --provider-concurrency <provider-id>=<number>."]);
+    }
+    providerConcurrency[providerId] = parseCliQueueConcurrencyValue(value.slice(separatorIndex + 1), "--provider-concurrency");
+  }
+  return providerConcurrency;
+}
+
+function parseCliQueueConcurrencyValue(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < MIN_QUEUE_CONCURRENCY || parsed > MAX_QUEUE_CONCURRENCY) {
+    throwCliCommandError(
+      "INVALID_ARGUMENT",
+      `${name} must be an integer from ${MIN_QUEUE_CONCURRENCY} to ${MAX_QUEUE_CONCURRENCY}.`,
+      [`Use ${name} <number> within ${MIN_QUEUE_CONCURRENCY}-${MAX_QUEUE_CONCURRENCY}.`]
+    );
+  }
+  return parsed;
+}
+
+function parseQueueRuntimeConfigPatchFromCli(args: string[]): QueueRuntimeConfigPatch | null {
+  const maxGlobalRunningValue = getCliOption(args, "--max-global-running");
+  const providerConcurrencyValues = getCliOptions(args, "--provider-concurrency");
+  const clearProviderIds = getCliOptions(args, "--clear-provider-concurrency").map((providerId) => providerId.trim()).filter(Boolean);
+  if (maxGlobalRunningValue === undefined && providerConcurrencyValues.length === 0 && clearProviderIds.length === 0) return null;
+  return {
+    maxGlobalRunning: maxGlobalRunningValue === undefined ? undefined : parseCliQueueConcurrencyValue(maxGlobalRunningValue, "--max-global-running"),
+    providerConcurrency: parseProviderConcurrencyAssignments(providerConcurrencyValues),
+    clearProviderIds
+  };
 }
 
 async function cancelGenerationQueueItemForCli(queueId: string) {
@@ -4123,7 +4194,8 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
       configStatus: async () => buildCliConfigStatus(await readExistingStateForCli(), await readExistingQueueForCli()),
       providerList: async () => buildCliProviderList(await readExistingStateForCli()),
       modelsList: async () => buildCliModelsList(await readExistingStateForCli()),
-      queueStatus: async () => buildCliQueueStatus(await readExistingQueueForCli()),
+      queueStatus: async () => buildCliQueueStatus(await readExistingQueueForCli(), await readQueueRuntimeConfigForCli()),
+      queueConfig: async () => ({ config: await readQueueRuntimeConfigForCli() }),
       jobList: async () => buildCliJobList(await readExistingQueueForCli()),
       jobStatus: async (jobId) => buildCliJobStatus(await readExistingQueueForCli(), await readExistingStateForCli(), jobId),
       folderList: async () => buildCliFolderList(await readExistingStateForCli()),
@@ -4213,6 +4285,10 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
           replaced: result.replaced
         };
       }
+    },
+    queueControllers: requestedMode === "readonly" ? undefined : {
+      queueConfigSet: async ({ maxGlobalRunning, providerConcurrency, clearProviderIds }) =>
+        setQueueRuntimeConfigForCli({ maxGlobalRunning, providerConcurrency, clearProviderIds })
     },
     jobControllers: requestedMode === "generate" ? {
       generationSubmit: async ({
@@ -4329,6 +4405,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
 
     if (command === "doctor" && hasCliFlag(args, "--agent")) {
       const state = await readExistingStateForCli();
+      const queueConfig = buildCliQueueConfig(state);
       const activeProvider = state ? state.providers.find((provider) => provider.id === state.activeProviderId) ?? state.providers[0] : undefined;
       const data = {
         appVersion: getAppVersion(),
@@ -4351,6 +4428,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
           : null,
         apiKeyAvailable: activeProvider ? envApiKeyAvailable(activeProvider.kind) || savedApiKeyPresentForCli(activeProvider) : false,
         liveWorkerHost: false,
+        queueConfig,
         permissions: {
           cliMode: "readonly",
           mcpDefaultMode: "readonly",
@@ -4476,7 +4554,30 @@ async function runCliCommandMode(args: string[]): Promise<number> {
     }
 
     if (command === "queue" && subcommand === "status") {
-      writeCliJson(cliSuccess(requestId, correlationId, buildCliQueueStatus(await readExistingQueueForCli())));
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliQueueStatus(await readExistingQueueForCli(), await readQueueRuntimeConfigForCli())));
+      return 0;
+    }
+
+    if (command === "queue" && subcommand === "config" && getCliPositionalsAfter(args, "config")[0] === "get") {
+      writeCliJson(cliSuccess(requestId, correlationId, { config: await readQueueRuntimeConfigForCli() }));
+      return 0;
+    }
+
+    if (command === "queue" && subcommand === "config" && getCliPositionalsAfter(args, "config")[0] === "set") {
+      if (!hasCliFlag(args, "--yes")) {
+        writeCliJson(cliFailure(requestId, correlationId, "CONFIRMATION_REQUIRED", "Queue configuration changes require --yes.", [
+          "Re-run with --yes if you intend to change generation concurrency limits."
+        ]));
+        return 3;
+      }
+      const patch = parseQueueRuntimeConfigPatchFromCli(args);
+      if (!patch) {
+        writeCliJson(cliFailure(requestId, correlationId, "INVALID_ARGUMENT", "No queue configuration fields were provided.", [
+          "Use --max-global-running <number>, --provider-concurrency <provider-id>=<number>, or --clear-provider-concurrency <provider-id>."
+        ]));
+        return 2;
+      }
+      writeCliJson(cliSuccess(requestId, correlationId, await setQueueRuntimeConfigForCli(patch)));
       return 0;
     }
 
@@ -4774,6 +4875,8 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli generate --prompt-file <jsonl> [--folder <id|null>] --yes [--wait|--async|--enqueue-only] --json.",
       "Use --cli edit --prompt <text> --input <path> [--folder <id|null>] --yes [--wait|--async|--enqueue-only] --json.",
       "Use --cli queue status --json.",
+      "Use --cli queue config get --json.",
+      "Use --cli queue config set --max-global-running <number> [--provider-concurrency <provider-id>=<number>] --yes --json.",
       "Use --cli job list --json.",
       "Use --cli job status <queue-id-or-history-job-id> --json.",
       "Use --cli job cancel <queue-id> --yes --json.",

--- a/src/main/services/stateMigration.test.ts
+++ b/src/main/services/stateMigration.test.ts
@@ -127,6 +127,41 @@ describe("state migration", () => {
 
     expect(migrated.galleryAssets).toEqual([]);
     expect(migrated.galleryFolders).toEqual([]);
+    expect(migrated.queueConfig).toEqual({ maxGlobalRunning: 1, providerConcurrency: {} });
+  });
+
+  it("normalizes queue concurrency config in v3 state", () => {
+    const migrated = normalizeState({
+      version: 3,
+      activeProviderId: "default",
+      providers: [{
+        id: "default",
+        baseURL: "https://api.openai.com/v1",
+        defaultModel: "gpt-image-2",
+        defaultSize: "auto",
+        defaultQuality: "auto",
+        timeoutMs: 120000,
+        updatedAt: "2026-01-02T03:04:05.000Z",
+        encryption: "none"
+      }],
+      history: [],
+      queueConfig: {
+        maxGlobalRunning: 99,
+        providerConcurrency: {
+          " provider-1 ": 2,
+          "provider-2": 0,
+          "": 4
+        }
+      }
+    });
+
+    expect(migrated.queueConfig).toEqual({
+      maxGlobalRunning: 8,
+      providerConcurrency: {
+        "provider-1": 2,
+        "provider-2": 1
+      }
+    });
   });
 
   it("preserves OpenAI image route probes in v3 provider state", () => {

--- a/src/main/services/stateMigration.ts
+++ b/src/main/services/stateMigration.ts
@@ -10,9 +10,11 @@ import type {
   OpenAIImageParams,
   PromptTemplate,
   ProviderKind,
+  QueueRuntimeConfig,
   StorageSettings,
   WorkspaceDraft
 } from "../../shared/types.js";
+import { DEFAULT_QUEUE_RUNTIME_CONFIG, normalizeQueueRuntimeConfig } from "../../core/queueConfig.js";
 import path from "node:path";
 import {
   DEFAULT_BASE_URL,
@@ -68,6 +70,7 @@ export interface AppStateFile {
   promptTemplates: PromptTemplate[];
   galleryFolders: GalleryFolder[];
   galleryAssets: GalleryAsset[];
+  queueConfig: QueueRuntimeConfig;
   storage?: StorageSettings;
   draft?: WorkspaceDraft;
 }
@@ -99,7 +102,8 @@ export function getDefaultState(): AppStateFile {
     history: [],
     promptTemplates: [],
     galleryFolders: [],
-    galleryAssets: []
+    galleryAssets: [],
+    queueConfig: structuredClone(DEFAULT_QUEUE_RUNTIME_CONFIG)
   };
 }
 
@@ -118,6 +122,7 @@ export function normalizeState(parsed: unknown): AppStateFile {
       promptTemplates: normalizePromptTemplates(parsed.promptTemplates),
       galleryFolders,
       galleryAssets: normalizeGalleryAssets(parsed.galleryAssets, galleryFolders),
+      queueConfig: normalizeQueueRuntimeConfig(parsed.queueConfig),
       storage: normalizeStorageSettings(parsed.storage),
       draft: normalizeWorkspaceDraft(parsed.draft)
     };
@@ -140,6 +145,7 @@ export function normalizeState(parsed: unknown): AppStateFile {
     promptTemplates: normalizePromptTemplates(parsed.promptTemplates),
     galleryFolders,
     galleryAssets: normalizeGalleryAssets(parsed.galleryAssets, galleryFolders),
+    queueConfig: normalizeQueueRuntimeConfig(parsed.queueConfig),
     storage: normalizeStorageSettings(parsed.storage),
     draft: normalizeWorkspaceDraft(parsed.draft)
   };

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -4,6 +4,7 @@ import {
   runReadonlyMcpStdioServer,
   type GalleryMcpWriters,
   type GenerationMcpControllers,
+  type QueueMcpControllers,
   type ReadonlyMcpMode,
   type ReadonlyMcpReaders
 } from "./stdioServer";
@@ -28,6 +29,7 @@ function readers(): ReadonlyMcpReaders {
     providerList: async () => ({ providers: [{ id: "default", name: "OpenAI" }] }),
     modelsList: async () => ({ providers: [] }),
     queueStatus: async () => ({ totalItems: 0 }),
+    queueConfig: async () => ({ config: { maxGlobalRunning: 1, providerConcurrency: {} } }),
     jobList: async () => ({ jobs: [] }),
     jobStatus: async (jobId) => (jobId === "queue-1" ? { lookupId: "queue-1", queueItem: { queueId: "queue-1", status: "running" } } : null),
     folderList: async () => ({ folders: [] }),
@@ -75,6 +77,18 @@ function controllers(): GenerationMcpControllers {
   };
 }
 
+function queueControllers(): QueueMcpControllers {
+  return {
+    queueConfigSet: async ({ maxGlobalRunning, providerConcurrency, clearProviderIds }) => ({
+      config: {
+        maxGlobalRunning: maxGlobalRunning ?? 1,
+        providerConcurrency: providerConcurrency ?? {},
+        clearProviderIds: clearProviderIds ?? []
+      }
+    })
+  };
+}
+
 async function runServer(inputText: string, options: { mode?: ReadonlyMcpMode; withWriters?: boolean; withControllers?: boolean } = {}) {
   const input = new PassThrough();
   const captured = captureOutput();
@@ -83,6 +97,7 @@ async function runServer(inputText: string, options: { mode?: ReadonlyMcpMode; w
     serverVersion: "0.3.0-test",
     readers: readers(),
     writers: options.withWriters ? writers() : undefined,
+    queueControllers: options.withWriters ? queueControllers() : undefined,
     jobControllers: options.withControllers ? controllers() : undefined,
     input,
     output: captured.output
@@ -128,7 +143,9 @@ describe("readonly MCP stdio server", () => {
     const toolNames = (responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
     expect(toolNames).toContain("crossgen_config_status");
     expect(toolNames).toContain("crossgen_job_status");
+    expect(toolNames).toContain("crossgen_queue_config_get");
     expect(toolNames).not.toContain("crossgen_folder_create");
+    expect(toolNames).not.toContain("crossgen_queue_config_set");
     expect(toolNames).not.toContain("crossgen_job_cancel");
   });
 
@@ -198,6 +215,7 @@ describe("readonly MCP stdio server", () => {
       }
     });
     expect((responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain("crossgen_folder_create");
+    expect((responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain("crossgen_queue_config_set");
     expect((responses[1].result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).not.toContain("crossgen_job_cancel");
     expect(responses[2]).toMatchObject({
       result: {
@@ -211,6 +229,60 @@ describe("readonly MCP stdio server", () => {
         isError: true,
         structuredContent: {
           error: { code: "CONFIRMATION_REQUIRED" }
+        }
+      }
+    });
+  });
+
+  it("gets and sets queue config through MCP tools", async () => {
+    const { output } = await runServer(
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "crossgen_queue_config_get", arguments: {} } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_queue_config_set", arguments: { maxGlobalRunning: 2 } } }),
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: {
+            name: "crossgen_queue_config_set",
+            arguments: {
+              maxGlobalRunning: 2,
+              providerConcurrency: { "provider-1": 1 },
+              clearProviderIds: ["provider-old"],
+              confirm: true
+            }
+          }
+        })
+      ].join("\n"),
+      { mode: "write", withWriters: true }
+    );
+
+    const responses = lineResponses(output);
+    expect(responses[0]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: { config: { maxGlobalRunning: 1, providerConcurrency: {} } }
+        }
+      }
+    });
+    expect(responses[1]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "CONFIRMATION_REQUIRED" }
+        }
+      }
+    });
+    expect(responses[2]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: {
+            config: {
+              maxGlobalRunning: 2,
+              providerConcurrency: { "provider-1": 1 },
+              clearProviderIds: ["provider-old"]
+            }
+          }
         }
       }
     });

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -33,6 +33,7 @@ export interface ReadonlyMcpReaders {
   providerList(): Promise<unknown>;
   modelsList(): Promise<unknown>;
   queueStatus(): Promise<unknown>;
+  queueConfig(): Promise<unknown>;
   jobList(): Promise<unknown>;
   jobStatus(jobId: string): Promise<unknown | null>;
   folderList(): Promise<unknown>;
@@ -62,6 +63,15 @@ export interface GenerationMcpControllers {
   jobRetry(args: { jobId: string; confirm: boolean }): Promise<unknown>;
 }
 
+export interface QueueMcpControllers {
+  queueConfigSet(args: {
+    maxGlobalRunning?: number;
+    providerConcurrency?: Record<string, number>;
+    clearProviderIds?: string[];
+    confirm: boolean;
+  }): Promise<unknown>;
+}
+
 export interface GalleryMcpWriters {
   folderCreate(args: { name: string; parentId?: string | null }): Promise<unknown>;
   folderRename(args: { folderId: string; name: string; parentId?: string | null }): Promise<unknown>;
@@ -80,6 +90,7 @@ export interface ReadonlyMcpStdioServerOptions {
   serverVersion: string;
   readers: ReadonlyMcpReaders;
   writers?: GalleryMcpWriters;
+  queueControllers?: QueueMcpControllers;
   jobControllers?: GenerationMcpControllers;
   input?: Readable;
   output?: Writable;
@@ -109,6 +120,10 @@ function toolError(code: string, message: string, nextActions: string[] = []): T
     content: [{ type: "text", text: `${code}: ${message}` }],
     structuredContent
   };
+}
+
+function isToolCallResult(value: unknown): value is ToolCallResult {
+  return Boolean(value && typeof value === "object" && Array.isArray((value as ToolCallResult).content));
 }
 
 function emptyObjectSchema(): JsonRpcObject {
@@ -179,6 +194,10 @@ function confirmProperty(description: string): JsonRpcObject {
 
 function numberProperty(description: string): JsonRpcObject {
   return { type: "number", description };
+}
+
+function stringArrayProperty(description: string): JsonRpcObject {
+  return { type: "array", items: { type: "string" }, description };
 }
 
 function objectSchema(properties: JsonRpcObject, required: string[] = []): JsonRpcObject {
@@ -254,6 +273,14 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       inputSchema: emptyObjectSchema(),
       annotations: readonlyAnnotations(),
       handler: () => readers.queueStatus()
+    },
+    {
+      name: "crossgen_queue_config_get",
+      title: "CrossGen Queue Config Get",
+      description: "Read CrossGen queue concurrency limits.",
+      inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
+      handler: () => readers.queueConfig()
     },
     {
       name: "crossgen_job_list",
@@ -454,6 +481,69 @@ function makeGenerationControlTools(controllers: GenerationMcpControllers): Read
             return toolError("INVALID_ARGUMENT", "Generation job is not retryable.", ["Only failed, cancelled, or interrupted generation jobs can be retried."]);
           }
           return result;
+        });
+      }
+    }
+  ];
+}
+
+function queueConfigProviderConcurrency(args: JsonRpcObject): Record<string, number> | ToolCallResult | undefined {
+  const raw = args.providerConcurrency;
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return toolError("INVALID_ARGUMENT", "providerConcurrency must be an object keyed by provider id.");
+  }
+  const providerConcurrency: Record<string, number> = {};
+  for (const [providerId, value] of Object.entries(raw as JsonRpcObject)) {
+    const normalizedProviderId = providerId.trim();
+    if (!normalizedProviderId || typeof value !== "number" || !Number.isSafeInteger(value)) {
+      return toolError("INVALID_ARGUMENT", "providerConcurrency values must be integer numbers keyed by non-empty provider ids.");
+    }
+    providerConcurrency[normalizedProviderId] = value;
+  }
+  return providerConcurrency;
+}
+
+function optionalStringArray(args: JsonRpcObject, name: string): string[] | ToolCallResult | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return toolError("INVALID_ARGUMENT", `${name} must be an array of strings.`);
+  return value.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).map((item) => item.trim());
+}
+
+function makeQueueConfigWriteTools(controllers: QueueMcpControllers): ReadonlyMcpTool[] {
+  return [
+    {
+      name: "crossgen_queue_config_set",
+      title: "CrossGen Queue Config Set",
+      description: "Update CrossGen queue concurrency limits.",
+      inputSchema: objectSchema({
+        maxGlobalRunning: numberProperty("Optional max number of globally running generation jobs."),
+        providerConcurrency: {
+          type: "object",
+          additionalProperties: { type: "number" },
+          description: "Optional provider-specific concurrency map keyed by provider id."
+        },
+        clearProviderIds: stringArrayProperty("Optional provider ids to remove from provider-specific concurrency limits."),
+        confirm: confirmProperty("Must be true to update queue concurrency limits.")
+      }, ["confirm"]),
+      annotations: writeAnnotations(),
+      handler: (args) => {
+        const confirmationError = requireConfirmed(args, "Queue configuration changes require confirm: true.");
+        if (confirmationError) return confirmationError;
+        const providerConcurrency = queueConfigProviderConcurrency(args);
+        if (isToolCallResult(providerConcurrency)) return providerConcurrency;
+        const clearProviderIds = optionalStringArray(args, "clearProviderIds");
+        if (isToolCallResult(clearProviderIds)) return clearProviderIds;
+        const maxGlobalRunning = typeof args.maxGlobalRunning === "number" ? args.maxGlobalRunning : undefined;
+        if (maxGlobalRunning === undefined && providerConcurrency === undefined && clearProviderIds === undefined) {
+          return toolError("INVALID_ARGUMENT", "No queue configuration fields were provided.");
+        }
+        return controllers.queueConfigSet({
+          maxGlobalRunning,
+          providerConcurrency,
+          clearProviderIds,
+          confirm: true
         });
       }
     }
@@ -741,6 +831,7 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
   const tools = [
     ...makeReadonlyTools(options.readers),
     ...(effectiveMode !== "readonly" && options.writers ? makeWriteTools(options.writers) : []),
+    ...(effectiveMode !== "readonly" && options.queueControllers ? makeQueueConfigWriteTools(options.queueControllers) : []),
     ...(effectiveMode === "generate" && options.jobControllers ? makeGenerationControlTools(options.jobControllers) : [])
   ];
   const toolMap = new Map(tools.map((tool) => [tool.name, tool]));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,6 +22,11 @@ export type QueueExecutionKind = "sync-provider" | "remote-poll" | "local-cpu";
 
 export type QueueErrorCategory = "transient" | "auth" | "quota" | "safety" | "cancelled" | "unsupported" | "unknown";
 
+export interface QueueRuntimeConfig {
+  maxGlobalRunning: number;
+  providerConcurrency: Record<string, number>;
+}
+
 export type QueueStage =
   | "queued"
   | "claiming"


### PR DESCRIPTION
## Summary
- add normalized queue runtime concurrency config in app state
- expose CLI `queue config get/set` and include config in queue/config status plus doctor output
- expose MCP `crossgen_queue_config_get` and `crossgen_queue_config_set` with confirmation
- make existing CLI/MCP/desktop queue claims respect configured global and provider concurrency limits

## Verification
- pnpm typecheck
- pnpm test -- src/main/services/stateMigration.test.ts src/cli/readonly.test.ts src/mcp/stdioServer.test.ts src/core/queueStore.test.ts
- isolated Electron CLI smoke for queue config get/set/status
- pnpm build
- pnpm package:dir