### PR TITLE
Add readonly list filters

### DIFF
--- a/src/cli/readonly.test.ts
+++ b/src/cli/readonly.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { buildCliConfigStatus, buildCliJobStatus, buildCliMcpConfig, buildCliQueueConfig, buildCliQueueStatus } from "./readonly";
+import {
+  buildCliConfigStatus,
+  buildCliFolderTree,
+  buildCliGalleryList,
+  buildCliJobList,
+  buildCliJobStatus,
+  buildCliMcpConfig,
+  buildCliQueueConfig,
+  buildCliQueueStatus
+} from "./readonly";
 
 function request() {
   return {
@@ -53,6 +62,100 @@ describe("readonly CLI builders", () => {
       config: { maxGlobalRunning: 3, providerConcurrency: { "provider-1": 2 } },
       totalItems: 0
     });
+  });
+
+  it("filters job and gallery lists and builds folder tree", () => {
+    const queue = {
+      schemaVersion: 1 as const,
+      updatedAt: "2026-07-14T00:00:00.000Z",
+      workerHosts: [],
+      items: [
+        {
+          queueId: "queue-failed",
+          source: "cli" as const,
+          providerId: "provider-1",
+          request: request(),
+          status: "failed" as const,
+          priority: 0,
+          attempt: 1,
+          maxAttempts: 2,
+          createdAt: "2026-07-14T00:00:00.000Z",
+          updatedAt: "2026-07-14T00:00:01.000Z",
+          outputAssetIds: [],
+          partialAssetIds: [],
+          galleryAssetIds: [],
+          cancelRequested: false,
+          costConfirmed: true,
+          executionKind: "sync-provider" as const,
+          stage: "finalizing" as const,
+          sourceAssetIds: [],
+          outputMediaKinds: ["image" as const]
+        },
+        {
+          queueId: "queue-running",
+          source: "cli" as const,
+          providerId: "provider-1",
+          request: request(),
+          status: "running" as const,
+          priority: 0,
+          attempt: 1,
+          maxAttempts: 2,
+          createdAt: "2026-07-14T00:00:00.000Z",
+          updatedAt: "2026-07-14T00:00:01.000Z",
+          outputAssetIds: [],
+          partialAssetIds: [],
+          galleryAssetIds: [],
+          cancelRequested: false,
+          costConfirmed: true,
+          executionKind: "sync-provider" as const,
+          stage: "calling_provider" as const,
+          sourceAssetIds: [],
+          outputMediaKinds: ["image" as const]
+        }
+      ]
+    };
+    const state = {
+      providers: [],
+      activeProviderId: "",
+      history: [],
+      galleryFolders: [
+        { id: "root", name: "Root", parentId: null, color: "#ffffff", createdAt: "2026-07-14T00:00:00.000Z", updatedAt: "2026-07-14T00:00:00.000Z" },
+        { id: "child", name: "Child", parentId: "root", color: "#ffffff", createdAt: "2026-07-14T00:00:00.000Z", updatedAt: "2026-07-14T00:00:00.000Z" }
+      ],
+      galleryAssets: [
+        {
+          id: "asset-1",
+          fileName: "hero.png",
+          originalName: "Hero Product.png",
+          mimeType: "image/png",
+          sizeBytes: 100,
+          folderId: "child",
+          tags: ["Generated", "Product"],
+          source: "result" as const,
+          sourceJobId: "history-1",
+          createdAt: "2026-07-14T00:00:00.000Z",
+          updatedAt: "2026-07-14T00:00:00.000Z"
+        },
+        {
+          id: "asset-2",
+          fileName: "other.png",
+          originalName: "Other.png",
+          mimeType: "image/png",
+          sizeBytes: 100,
+          folderId: null,
+          tags: ["Import"],
+          source: "import" as const,
+          createdAt: "2026-07-14T00:00:00.000Z",
+          updatedAt: "2026-07-14T00:00:00.000Z"
+        }
+      ]
+    };
+
+    expect(buildCliJobList(queue, { status: "failed" }).jobs.map((job) => job.queueId)).toEqual(["queue-failed"]);
+    expect(buildCliGalleryList(state, { folderId: "child", tags: ["generated"], query: "hero" }).assets.map((asset) => asset.id)).toEqual(["asset-1"]);
+    expect(buildCliFolderTree(state).folders).toMatchObject([
+      { id: "root", children: [{ id: "child", children: [] }] }
+    ]);
   });
 
   it("builds job status without disclosing local output paths", () => {

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -47,6 +47,16 @@ interface ReadonlyAppState {
   storage?: StorageSettings;
 }
 
+export interface CliJobListOptions {
+  status?: JobStatus | JobStatus[];
+}
+
+export interface CliGalleryListOptions {
+  folderId?: string | null;
+  tags?: string[];
+  query?: string;
+}
+
 export type McpClientName = "codex" | "claude-code" | "cursor";
 
 export type McpMode = "readonly" | "write" | "generate";
@@ -186,6 +196,71 @@ function isTerminalStatus(status: JobStatus): boolean {
   return status === "succeeded" || status === "failed" || status === "cancelled" || status === "interrupted";
 }
 
+function publicFolder(folder: GalleryFolder) {
+  return {
+    id: folder.id,
+    name: folder.name,
+    parentId: folder.parentId ?? null,
+    color: folder.color,
+    createdAt: folder.createdAt,
+    updatedAt: folder.updatedAt
+  };
+}
+
+type PublicFolder = ReturnType<typeof publicFolder>;
+
+interface PublicFolderTreeNode extends PublicFolder {
+  children: PublicFolderTreeNode[];
+}
+
+function publicGalleryAsset(asset: GalleryAsset) {
+  return {
+    id: asset.id,
+    originalName: asset.originalName,
+    mimeType: asset.mimeType,
+    kind: asset.kind ?? "image",
+    sizeBytes: asset.sizeBytes,
+    width: asset.width,
+    height: asset.height,
+    folderId: asset.folderId ?? null,
+    tags: asset.tags,
+    source: asset.source,
+    sourceJobId: asset.sourceJobId,
+    sourceAssetId: asset.sourceAssetId,
+    createdAt: asset.createdAt,
+    updatedAt: asset.updatedAt,
+    modifiedAt: asset.modifiedAt,
+    hasContentHash: Boolean(asset.contentHash)
+  };
+}
+
+function normalizedTags(tags: string[] | undefined): string[] {
+  return [...new Set((tags ?? []).map((tag) => tag.trim().toLowerCase()).filter(Boolean))];
+}
+
+function galleryAssetMatches(asset: GalleryAsset, options: CliGalleryListOptions): boolean {
+  if (options.folderId !== undefined && (asset.folderId ?? null) !== options.folderId) return false;
+  const requiredTags = normalizedTags(options.tags);
+  if (requiredTags.length > 0) {
+    const assetTags = new Set(asset.tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean));
+    if (!requiredTags.every((tag) => assetTags.has(tag))) return false;
+  }
+  const query = options.query?.trim().toLowerCase();
+  if (query) {
+    const haystack = [
+      asset.originalName,
+      asset.fileName,
+      asset.mimeType,
+      asset.source,
+      asset.sourceJobId,
+      asset.sourceAssetId,
+      ...(asset.tags ?? [])
+    ].filter((value): value is string => typeof value === "string").join("\n").toLowerCase();
+    if (!haystack.includes(query)) return false;
+  }
+  return true;
+}
+
 export function buildCliConfigStatus(state: ReadonlyAppState | null, queue: GenerationQueueFile) {
   const provider = state ? activeProvider(state) : undefined;
   return {
@@ -241,9 +316,14 @@ export function buildCliQueueStatus(queue: GenerationQueueFile, queueConfig: Que
   };
 }
 
-export function buildCliJobList(queue: GenerationQueueFile) {
+export function buildCliJobList(queue: GenerationQueueFile, options: CliJobListOptions = {}) {
+  const statuses = new Set(Array.isArray(options.status) ? options.status : options.status ? [options.status] : []);
+  const items = statuses.size > 0 ? queue.items.filter((item) => statuses.has(item.status)) : queue.items;
   return {
-    jobs: queue.items.map(publicQueueJob)
+    filters: {
+      status: statuses.size > 0 ? [...statuses] : null
+    },
+    jobs: items.map(publicQueueJob)
   };
 }
 
@@ -262,47 +342,46 @@ export function buildCliJobStatus(queue: GenerationQueueFile, state: ReadonlyApp
   };
 }
 
-export function buildCliGalleryList(state: ReadonlyAppState | null) {
+export function buildCliGalleryList(state: ReadonlyAppState | null, options: CliGalleryListOptions = {}) {
+  const assets = state?.galleryAssets.filter((asset) => galleryAssetMatches(asset, options)) ?? [];
   return {
-    folders: state?.galleryFolders.map((folder) => ({
-      id: folder.id,
-      name: folder.name,
-      parentId: folder.parentId ?? null,
-      color: folder.color,
-      createdAt: folder.createdAt,
-      updatedAt: folder.updatedAt
-    })) ?? [],
-    assets: state?.galleryAssets.map((asset) => ({
-      id: asset.id,
-      originalName: asset.originalName,
-      mimeType: asset.mimeType,
-      kind: asset.kind ?? "image",
-      sizeBytes: asset.sizeBytes,
-      width: asset.width,
-      height: asset.height,
-      folderId: asset.folderId ?? null,
-      tags: asset.tags,
-      source: asset.source,
-      sourceJobId: asset.sourceJobId,
-      sourceAssetId: asset.sourceAssetId,
-      createdAt: asset.createdAt,
-      updatedAt: asset.updatedAt,
-      modifiedAt: asset.modifiedAt,
-      hasContentHash: Boolean(asset.contentHash)
-    })) ?? []
+    filters: {
+      folderId: options.folderId ?? null,
+      tags: normalizedTags(options.tags),
+      query: options.query?.trim() || null
+    },
+    folders: state?.galleryFolders.map(publicFolder) ?? [],
+    assets: assets.map(publicGalleryAsset)
   };
 }
 
 export function buildCliFolderList(state: ReadonlyAppState | null) {
   return {
-    folders: state?.galleryFolders.map((folder) => ({
-      id: folder.id,
-      name: folder.name,
-      parentId: folder.parentId ?? null,
-      color: folder.color,
-      createdAt: folder.createdAt,
-      updatedAt: folder.updatedAt
-    })) ?? []
+    folders: state?.galleryFolders.map(publicFolder) ?? []
+  };
+}
+
+export function buildCliFolderTree(state: ReadonlyAppState | null) {
+  const folders = state?.galleryFolders ?? [];
+  const nodes = new Map<string, PublicFolderTreeNode>();
+  for (const folder of folders) {
+    nodes.set(folder.id, { ...publicFolder(folder), children: [] });
+  }
+  const roots: PublicFolderTreeNode[] = [];
+  for (const folder of folders) {
+    const node = nodes.get(folder.id);
+    if (!node) continue;
+    const parent = folder.parentId ? nodes.get(folder.parentId) : undefined;
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  }
+  const sortTree = (items: PublicFolderTreeNode[]) => {
+    items.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+    for (const item of items) sortTree(item.children);
+  };
+  sortTree(roots);
+  return {
+    folders: roots
   };
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,6 +39,7 @@ import type {
   InputAsset,
   ImageParams,
   ImageQuality,
+  JobStatus,
   JobProgressEvent,
   OpenAIImageRoute,
   OpenAIImageRouteProbe,
@@ -121,6 +122,7 @@ import {
   buildCliAssetInspect,
   buildCliConfigStatus,
   buildCliFolderList,
+  buildCliFolderTree,
   buildCliGalleryList,
   buildCliJobList,
   buildCliJobStatus,
@@ -3570,9 +3572,11 @@ function getCliPositionalsAfter(args: string[], token: string): string[] {
     "--provider",
     "--provider-concurrency",
     "--quality",
+    "--query",
     "--request-id",
     "--resolution",
     "--size",
+    "--status",
     "--tag",
     "--timeout-ms",
     "--to",
@@ -3728,6 +3732,37 @@ function parseQueueRuntimeConfigPatchFromCli(args: string[]): QueueRuntimeConfig
     maxGlobalRunning: maxGlobalRunningValue === undefined ? undefined : parseCliQueueConcurrencyValue(maxGlobalRunningValue, "--max-global-running"),
     providerConcurrency: parseProviderConcurrencyAssignments(providerConcurrencyValues),
     clearProviderIds
+  };
+}
+
+function parseCliJobStatuses(args: string[]): JobStatus[] | undefined {
+  const statuses = getCliOptions(args, "--status").flatMap((value) => value.split(",")).map((value) => value.trim()).filter(Boolean);
+  if (statuses.length === 0) return undefined;
+  const validStatuses = new Set<JobStatus>(["queued", "running", "succeeded", "failed", "cancelled", "interrupted"]);
+  const parsed: JobStatus[] = [];
+  for (const status of statuses) {
+    if (!validStatuses.has(status as JobStatus)) {
+      throwCliCommandError("INVALID_ARGUMENT", `Unsupported job status filter: ${status}.`, [
+        "Use one of queued, running, succeeded, failed, cancelled, interrupted."
+      ]);
+    }
+    parsed.push(status as JobStatus);
+  }
+  return [...new Set(parsed)];
+}
+
+function parseCliNullableFolderOption(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!normalized || normalized.toLowerCase() === "null" || normalized.toLowerCase() === "uncategorized") return null;
+  return normalized;
+}
+
+function parseCliGalleryListOptions(args: string[]) {
+  return {
+    folderId: parseCliNullableFolderOption(getCliOption(args, "--folder")),
+    tags: getCliOptions(args, "--tag"),
+    query: getCliOption(args, "--query")
   };
 }
 
@@ -4196,10 +4231,11 @@ async function runMcpCommandMode(args: string[]): Promise<number> {
       modelsList: async () => buildCliModelsList(await readExistingStateForCli()),
       queueStatus: async () => buildCliQueueStatus(await readExistingQueueForCli(), await readQueueRuntimeConfigForCli()),
       queueConfig: async () => ({ config: await readQueueRuntimeConfigForCli() }),
-      jobList: async () => buildCliJobList(await readExistingQueueForCli()),
+      jobList: async (options) => buildCliJobList(await readExistingQueueForCli(), options),
       jobStatus: async (jobId) => buildCliJobStatus(await readExistingQueueForCli(), await readExistingStateForCli(), jobId),
       folderList: async () => buildCliFolderList(await readExistingStateForCli()),
-      galleryList: async () => buildCliGalleryList(await readExistingStateForCli()),
+      folderTree: async () => buildCliFolderTree(await readExistingStateForCli()),
+      galleryList: async (options) => buildCliGalleryList(await readExistingStateForCli(), options),
       assetInspect: async (assetId) => buildCliAssetInspect(await readExistingStateForCli(), assetId)
     },
     writers: requestedMode === "readonly" ? undefined : {
@@ -4582,7 +4618,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
     }
 
     if (command === "job" && subcommand === "list") {
-      writeCliJson(cliSuccess(requestId, correlationId, buildCliJobList(await readExistingQueueForCli())));
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliJobList(await readExistingQueueForCli(), { status: parseCliJobStatuses(args) })));
       return 0;
     }
 
@@ -4652,8 +4688,13 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       return 0;
     }
 
+    if (command === "folder" && subcommand === "tree") {
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliFolderTree(await readExistingStateForCli())));
+      return 0;
+    }
+
     if (command === "gallery" && subcommand === "list") {
-      writeCliJson(cliSuccess(requestId, correlationId, buildCliGalleryList(await readExistingStateForCli())));
+      writeCliJson(cliSuccess(requestId, correlationId, buildCliGalleryList(await readExistingStateForCli(), parseCliGalleryListOptions(args))));
       return 0;
     }
 
@@ -4877,11 +4918,12 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       "Use --cli queue status --json.",
       "Use --cli queue config get --json.",
       "Use --cli queue config set --max-global-running <number> [--provider-concurrency <provider-id>=<number>] --yes --json.",
-      "Use --cli job list --json.",
+      "Use --cli job list [--status queued|running|succeeded|failed|cancelled|interrupted] --json.",
       "Use --cli job status <queue-id-or-history-job-id> --json.",
       "Use --cli job cancel <queue-id> --yes --json.",
       "Use --cli job retry <queue-id-or-history-job-id> --yes --json.",
-      "Use --cli gallery list --json.",
+      "Use --cli folder tree --json.",
+      "Use --cli gallery list [--folder <id|null>] [--tag <tag>] [--query <text>] --json.",
       "Use --cli folder create <name> --json.",
       "Use --cli asset import <path...> --json.",
       "Use --cli asset export <id> --to <path> --yes --json.",

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -30,10 +30,11 @@ function readers(): ReadonlyMcpReaders {
     modelsList: async () => ({ providers: [] }),
     queueStatus: async () => ({ totalItems: 0 }),
     queueConfig: async () => ({ config: { maxGlobalRunning: 1, providerConcurrency: {} } }),
-    jobList: async () => ({ jobs: [] }),
+    jobList: async (options) => ({ filters: options ?? {}, jobs: options?.status ? [{ queueId: "queue-filtered", status: options.status }] : [] }),
     jobStatus: async (jobId) => (jobId === "queue-1" ? { lookupId: "queue-1", queueItem: { queueId: "queue-1", status: "running" } } : null),
     folderList: async () => ({ folders: [] }),
-    galleryList: async () => ({ assets: [] }),
+    folderTree: async () => ({ folders: [{ id: "folder-root", children: [] }] }),
+    galleryList: async (options) => ({ filters: options ?? {}, assets: options?.folderId ? [{ id: "asset-filtered", folderId: options.folderId }] : [] }),
     assetInspect: async (assetId) => (assetId === "asset-1" ? { id: "asset-1", originalName: "sample.png" } : null)
   };
 }
@@ -144,6 +145,7 @@ describe("readonly MCP stdio server", () => {
     expect(toolNames).toContain("crossgen_config_status");
     expect(toolNames).toContain("crossgen_job_status");
     expect(toolNames).toContain("crossgen_queue_config_get");
+    expect(toolNames).toContain("crossgen_folder_tree");
     expect(toolNames).not.toContain("crossgen_folder_create");
     expect(toolNames).not.toContain("crossgen_queue_config_set");
     expect(toolNames).not.toContain("crossgen_job_cancel");
@@ -189,6 +191,44 @@ describe("readonly MCP stdio server", () => {
               queueItem: { queueId: "queue-1", status: "running" }
             }
           }
+        }
+      }
+    });
+  });
+
+  it("filters readonly job and gallery list tools", async () => {
+    const { output } = await runServer(
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "crossgen_job_list", arguments: { status: "failed" } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crossgen_gallery_list", arguments: { folderId: "folder-1", tags: ["Generated"], query: "hero" } } }),
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "crossgen_folder_tree", arguments: {} } })
+      ].join("\n")
+    );
+
+    const responses = lineResponses(output);
+    expect(responses[0]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: {
+            jobs: [{ queueId: "queue-filtered", status: ["failed"] }]
+          }
+        }
+      }
+    });
+    expect(responses[1]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: {
+            filters: { folderId: "folder-1", tags: ["Generated"], query: "hero" },
+            assets: [{ id: "asset-filtered", folderId: "folder-1" }]
+          }
+        }
+      }
+    });
+    expect(responses[2]).toMatchObject({
+      result: {
+        structuredContent: {
+          data: { folders: [{ id: "folder-root", children: [] }] }
         }
       }
     });

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
+import type { JobStatus } from "../shared/types.js";
 
 export type ReadonlyMcpMode = "readonly" | "write" | "generate";
 
@@ -34,10 +35,11 @@ export interface ReadonlyMcpReaders {
   modelsList(): Promise<unknown>;
   queueStatus(): Promise<unknown>;
   queueConfig(): Promise<unknown>;
-  jobList(): Promise<unknown>;
+  jobList(options?: { status?: JobStatus | JobStatus[] }): Promise<unknown>;
   jobStatus(jobId: string): Promise<unknown | null>;
   folderList(): Promise<unknown>;
-  galleryList(): Promise<unknown>;
+  folderTree(): Promise<unknown>;
+  galleryList(options?: { folderId?: string | null; tags?: string[]; query?: string }): Promise<unknown>;
   assetInspect(assetId: string): Promise<unknown | null>;
 }
 
@@ -162,6 +164,30 @@ function jobStatusSchema(): JsonRpcObject {
   };
 }
 
+function jobListSchema(): JsonRpcObject {
+  return {
+    type: "object",
+    properties: {
+      status: {
+        oneOf: [
+          { type: "string" },
+          { type: "array", items: { type: "string" } }
+        ],
+        description: "Optional job status filter."
+      }
+    },
+    additionalProperties: false
+  };
+}
+
+function galleryListSchema(): JsonRpcObject {
+  return objectSchema({
+    folderId: nullableStringProperty("Optional Gallery folder id. Use null for uncategorized assets."),
+    tags: { type: "array", items: { type: "string" }, description: "Optional tags. Assets must contain all listed tags." },
+    query: stringProperty("Optional text query over asset names, tags, and source ids.")
+  });
+}
+
 function readonlyAnnotations(): JsonRpcObject {
   return {
     readOnlyHint: true,
@@ -236,6 +262,28 @@ function stringArray(args: JsonRpcObject, name: string): string[] | ToolCallResu
   return strings;
 }
 
+function optionalStringArrayForFilter(args: JsonRpcObject, name: string): string[] | ToolCallResult | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return toolError("INVALID_ARGUMENT", `${name} must be an array of strings.`);
+  return value.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).map((item) => item.trim());
+}
+
+function optionalJobStatuses(args: JsonRpcObject): JobStatus[] | ToolCallResult | undefined {
+  const value = args.status;
+  if (value === undefined) return undefined;
+  const values = Array.isArray(value) ? value : [value];
+  const validStatuses = new Set<JobStatus>(["queued", "running", "succeeded", "failed", "cancelled", "interrupted"]);
+  const statuses: JobStatus[] = [];
+  for (const item of values) {
+    if (typeof item !== "string" || !validStatuses.has(item.trim() as JobStatus)) {
+      return toolError("INVALID_ARGUMENT", "status must be one of queued, running, succeeded, failed, cancelled, interrupted.");
+    }
+    statuses.push(item.trim() as JobStatus);
+  }
+  return [...new Set(statuses)];
+}
+
 function requireConfirmed(args: JsonRpcObject, message: string): ToolCallResult | null {
   return args.confirm === true ? null : toolError("CONFIRMATION_REQUIRED", message, ["Call this tool again with confirm: true if you intend to perform this operation."]);
 }
@@ -286,9 +334,13 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       name: "crossgen_job_list",
       title: "CrossGen Job List",
       description: "List durable generation queue items, attempts, retry metadata, partial outputs, and completion status.",
-      inputSchema: emptyObjectSchema(),
+      inputSchema: jobListSchema(),
       annotations: readonlyAnnotations(),
-      handler: () => readers.jobList()
+      handler: (args) => {
+        const status = optionalJobStatuses(args);
+        if (isToolCallResult(status)) return status;
+        return readers.jobList({ status });
+      }
     },
     {
       name: "crossgen_job_status",
@@ -317,12 +369,28 @@ function makeReadonlyTools(readers: ReadonlyMcpReaders): ReadonlyMcpTool[] {
       handler: () => readers.folderList()
     },
     {
+      name: "crossgen_folder_tree",
+      title: "CrossGen Folder Tree",
+      description: "List CrossGen Gallery folders as a parent/child tree.",
+      inputSchema: emptyObjectSchema(),
+      annotations: readonlyAnnotations(),
+      handler: () => readers.folderTree()
+    },
+    {
       name: "crossgen_gallery_list",
       title: "CrossGen Gallery List",
       description: "List Gallery folders and assets without disclosing local absolute file paths.",
-      inputSchema: emptyObjectSchema(),
+      inputSchema: galleryListSchema(),
       annotations: readonlyAnnotations(),
-      handler: () => readers.galleryList()
+      handler: (args) => {
+        const tags = optionalStringArrayForFilter(args, "tags");
+        if (isToolCallResult(tags)) return tags;
+        return readers.galleryList({
+          folderId: optionalStringOrNull(args, "folderId"),
+          tags,
+          query: typeof args.query === "string" ? args.query.trim() : undefined
+        });
+      }
     },
     {
       name: "crossgen_asset_inspect",


### PR DESCRIPTION
## Summary
- add job list status filtering for CLI and MCP
- add Gallery list folder/tag/query filtering for CLI and MCP
- add folder tree output for CLI and MCP

## Verification
- pnpm typecheck
- pnpm test -- src/cli/readonly.test.ts src/mcp/stdioServer.test.ts
- isolated Electron CLI smoke for job list --status, folder tree, gallery list filters
- pnpm package:dir