### PR TITLE
Add crossgen CLI binary

### DIFF
--- a/docs/cli-mcp.md
+++ b/docs/cli-mcp.md
@@ -1,0 +1,98 @@
+# CrossGen CLI and MCP
+
+CrossGen exposes the same local app state to terminal workflows and MCP hosts. The CLI defaults to read-only inspection unless a command asks for explicit confirmation with `--yes`.
+
+## Runtime
+
+Install dependencies in the repository or use an installed CrossGen app:
+
+```bash
+pnpm install
+pnpm build:main
+node dist/cli/crossgen.js --version --json
+```
+
+The packaged npm binary is `crossgen`. It launches CrossGen through the first available runtime:
+
+1. `CROSSGEN_APP_EXECUTABLE`
+2. `CROSSGEN_ELECTRON_BIN`
+3. repository `node_modules/.bin/electron`
+4. common installed app locations
+
+Use `--data-dir <path>` when an agent needs an isolated CrossGen data directory. The wrapper maps it to both `CROSSGEN_DATA_DIR` and `CROSSGEN_USER_DATA_DIR`.
+
+## Agent Checks
+
+```bash
+crossgen --version --json
+crossgen doctor --agent --json
+crossgen config status --json
+crossgen provider list --json
+crossgen models list --json
+```
+
+`doctor --agent` reports readiness without disclosing saved API keys. `asset path` is the only command that returns a local absolute asset path, and it requires `--yes`.
+
+## Generate Flow
+
+```bash
+crossgen generate --prompt "A clean product photo" --folder null --yes --wait --json
+crossgen edit --prompt "Make the background white" --input ./reference.png --folder null --yes --wait --json
+crossgen job status <queue-id-or-history-job-id> --json
+crossgen asset export <asset-id> --to ./out.png --yes --json
+```
+
+For durable background work:
+
+```bash
+crossgen generate --prompt "Four icon concepts" --yes --enqueue-only --json
+crossgen queue status --json
+crossgen job list --status queued --status running --json
+crossgen job cancel <queue-id> --yes --json
+crossgen job retry <queue-id-or-history-job-id> --yes --json
+```
+
+Queue concurrency is local runtime configuration:
+
+```bash
+crossgen queue config get --json
+crossgen queue config set --max-global-running 1 --yes --json
+crossgen queue config set --provider-concurrency <provider-id>=1 --yes --json
+```
+
+## Gallery Flow
+
+```bash
+crossgen folder tree --json
+crossgen gallery list --folder null --json
+crossgen gallery list --tag generated --query product --json
+crossgen asset import ./reference.png --folder null --json
+crossgen asset update <asset-id> --name "Hero concept" --tag generated --json
+crossgen asset export <asset-id> --to ./hero.png --yes --json
+```
+
+Read-only list and inspect commands never include local absolute paths by default.
+
+## MCP Setup
+
+Generate host configuration with the CLI:
+
+```bash
+crossgen mcp config --client codex --mode readonly --json
+crossgen mcp config --client codex --mode write --json
+crossgen mcp config --client codex --mode generate --json
+```
+
+The server process is started with:
+
+```bash
+crossgen --mcp
+```
+
+Modes:
+
+- `readonly`: inspect config, providers, models, queue, jobs, folders, and gallery assets.
+- `write`: includes local Gallery and folder mutations.
+- `generate`: includes write mode plus image generation and edit submission.
+
+Generate mode can submit paid provider work. Commands that mutate state, disclose absolute paths, or export assets require explicit confirmation arguments.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "One-stop AI image generation manager for API access, model discovery, Gallery/history reuse, and lightweight image editing.",
   "author": "Nowo, Corgnitor, and CrossGen contributors",
   "license": "MIT",
+  "bin": {
+    "crossgen": "dist/cli/crossgen.js"
+  },
   "crossgen": {
     "updateManifestUrl": "https://raw.githubusercontent.com/Bliveren/CrossGen/main/docs/updates/latest.json"
   },

--- a/src/cli/crossgen.test.ts
+++ b/src/cli/crossgen.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { buildCrossGenCliLaunchPlan } from "./crossgen";
+
+function existsAt(paths: string[]) {
+  const existing = new Set(paths);
+  return (path: string) => existing.has(path);
+}
+
+describe("crossgen binary launcher", () => {
+  it("forwards CLI commands through a local Electron runtime", () => {
+    const plan = buildCrossGenCliLaunchPlan({
+      argv: ["--version", "--json"],
+      env: {},
+      platform: "darwin",
+      packageRoot: "/repo/crossgen",
+      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+    });
+
+    expect(plan).toMatchObject({
+      command: "/repo/crossgen/node_modules/.bin/electron",
+      args: ["/repo/crossgen", "--cli", "--version", "--json"],
+      source: "local-electron"
+    });
+  });
+
+  it("starts MCP mode without adding the CLI sentinel", () => {
+    const plan = buildCrossGenCliLaunchPlan({
+      argv: ["--mcp"],
+      env: {},
+      platform: "darwin",
+      packageRoot: "/repo/crossgen",
+      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+    });
+
+    expect(plan.args).toEqual(["/repo/crossgen", "--mcp"]);
+  });
+
+  it("maps --data-dir to both current and legacy runtime env aliases", () => {
+    const plan = buildCrossGenCliLaunchPlan({
+      argv: ["--data-dir", "/tmp/crossgen-agent", "doctor", "--agent", "--json"],
+      env: {},
+      platform: "darwin",
+      packageRoot: "/repo/crossgen",
+      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+    });
+
+    expect(plan.env.CROSSGEN_DATA_DIR).toBe("/tmp/crossgen-agent");
+    expect(plan.env.CROSSGEN_USER_DATA_DIR).toBe("/tmp/crossgen-agent");
+    expect(plan.args).toEqual(["/repo/crossgen", "--cli", "doctor", "--agent", "--json"]);
+  });
+
+  it("prefers an explicit installed app executable over Electron", () => {
+    const plan = buildCrossGenCliLaunchPlan({
+      argv: ["models", "list", "--json"],
+      env: {
+        CROSSGEN_APP_EXECUTABLE: " /Applications/CrossGen.app/Contents/MacOS/CrossGen "
+      },
+      platform: "darwin",
+      packageRoot: "/repo/crossgen",
+      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+    });
+
+    expect(plan).toMatchObject({
+      command: "/Applications/CrossGen.app/Contents/MacOS/CrossGen",
+      args: ["--cli", "models", "list", "--json"],
+      source: "env-app"
+    });
+  });
+
+  it("uses CROSSGEN_ELECTRON_BIN before repository and installed app discovery", () => {
+    const plan = buildCrossGenCliLaunchPlan({
+      argv: ["config", "status", "--json"],
+      env: {
+        CROSSGEN_ELECTRON_BIN: "/custom/electron"
+      },
+      platform: "darwin",
+      packageRoot: "/repo/crossgen",
+      fileExists: existsAt([])
+    });
+
+    expect(plan).toMatchObject({
+      command: "/custom/electron",
+      args: ["/repo/crossgen", "--cli", "config", "status", "--json"],
+      source: "env-electron"
+    });
+  });
+
+  it("throws a direct setup hint when no runtime can be found", () => {
+    expect(() => buildCrossGenCliLaunchPlan({
+      argv: ["--version", "--json"],
+      env: {},
+      platform: "darwin",
+      packageRoot: "/repo/crossgen",
+      fileExists: existsAt([])
+    })).toThrow(/pnpm install|CROSSGEN_ELECTRON_BIN|CROSSGEN_APP_EXECUTABLE/);
+  });
+
+  it("requires a value for --data-dir", () => {
+    expect(() => buildCrossGenCliLaunchPlan({
+      argv: ["--data-dir"],
+      env: {},
+      platform: "darwin",
+      packageRoot: "/repo/crossgen",
+      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+    })).toThrow("Missing value for --data-dir.");
+  });
+});

--- a/src/cli/crossgen.test.ts
+++ b/src/cli/crossgen.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { join } from "node:path";
 import { buildCrossGenCliLaunchPlan } from "./crossgen";
 
 function existsAt(paths: string[]) {
@@ -6,19 +7,22 @@ function existsAt(paths: string[]) {
   return (path: string) => existing.has(path);
 }
 
+const packageRoot = join("repo", "crossgen");
+const localElectron = join(packageRoot, "node_modules", ".bin", "electron");
+
 describe("crossgen binary launcher", () => {
   it("forwards CLI commands through a local Electron runtime", () => {
     const plan = buildCrossGenCliLaunchPlan({
       argv: ["--version", "--json"],
       env: {},
       platform: "darwin",
-      packageRoot: "/repo/crossgen",
-      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+      packageRoot,
+      fileExists: existsAt([localElectron])
     });
 
     expect(plan).toMatchObject({
-      command: "/repo/crossgen/node_modules/.bin/electron",
-      args: ["/repo/crossgen", "--cli", "--version", "--json"],
+      command: localElectron,
+      args: [packageRoot, "--cli", "--version", "--json"],
       source: "local-electron"
     });
   });
@@ -28,11 +32,11 @@ describe("crossgen binary launcher", () => {
       argv: ["--mcp"],
       env: {},
       platform: "darwin",
-      packageRoot: "/repo/crossgen",
-      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+      packageRoot,
+      fileExists: existsAt([localElectron])
     });
 
-    expect(plan.args).toEqual(["/repo/crossgen", "--mcp"]);
+    expect(plan.args).toEqual([packageRoot, "--mcp"]);
   });
 
   it("maps --data-dir to both current and legacy runtime env aliases", () => {
@@ -40,13 +44,13 @@ describe("crossgen binary launcher", () => {
       argv: ["--data-dir", "/tmp/crossgen-agent", "doctor", "--agent", "--json"],
       env: {},
       platform: "darwin",
-      packageRoot: "/repo/crossgen",
-      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+      packageRoot,
+      fileExists: existsAt([localElectron])
     });
 
     expect(plan.env.CROSSGEN_DATA_DIR).toBe("/tmp/crossgen-agent");
     expect(plan.env.CROSSGEN_USER_DATA_DIR).toBe("/tmp/crossgen-agent");
-    expect(plan.args).toEqual(["/repo/crossgen", "--cli", "doctor", "--agent", "--json"]);
+    expect(plan.args).toEqual([packageRoot, "--cli", "doctor", "--agent", "--json"]);
   });
 
   it("prefers an explicit installed app executable over Electron", () => {
@@ -56,8 +60,8 @@ describe("crossgen binary launcher", () => {
         CROSSGEN_APP_EXECUTABLE: " /Applications/CrossGen.app/Contents/MacOS/CrossGen "
       },
       platform: "darwin",
-      packageRoot: "/repo/crossgen",
-      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+      packageRoot,
+      fileExists: existsAt([localElectron])
     });
 
     expect(plan).toMatchObject({
@@ -74,13 +78,13 @@ describe("crossgen binary launcher", () => {
         CROSSGEN_ELECTRON_BIN: "/custom/electron"
       },
       platform: "darwin",
-      packageRoot: "/repo/crossgen",
+      packageRoot,
       fileExists: existsAt([])
     });
 
     expect(plan).toMatchObject({
       command: "/custom/electron",
-      args: ["/repo/crossgen", "--cli", "config", "status", "--json"],
+      args: [packageRoot, "--cli", "config", "status", "--json"],
       source: "env-electron"
     });
   });
@@ -90,7 +94,7 @@ describe("crossgen binary launcher", () => {
       argv: ["--version", "--json"],
       env: {},
       platform: "darwin",
-      packageRoot: "/repo/crossgen",
+      packageRoot,
       fileExists: existsAt([])
     })).toThrow(/pnpm install|CROSSGEN_ELECTRON_BIN|CROSSGEN_APP_EXECUTABLE/);
   });
@@ -100,8 +104,8 @@ describe("crossgen binary launcher", () => {
       argv: ["--data-dir"],
       env: {},
       platform: "darwin",
-      packageRoot: "/repo/crossgen",
-      fileExists: existsAt(["/repo/crossgen/node_modules/.bin/electron"])
+      packageRoot,
+      fileExists: existsAt([localElectron])
     })).toThrow("Missing value for --data-dir.");
   });
 });

--- a/src/cli/crossgen.ts
+++ b/src/cli/crossgen.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface CrossGenCliLaunchPlan {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  source: "env-app" | "env-electron" | "local-electron" | "installed-app";
+}
+
+export interface CrossGenCliLaunchOptions {
+  argv: string[];
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  packageRoot?: string;
+  fileExists?: (path: string) => boolean;
+}
+
+interface ParsedCrossGenArgs {
+  args: string[];
+  dataDir?: string;
+  mcpMode: boolean;
+}
+
+function defaultPackageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+}
+
+function parseCrossGenArgs(argv: string[]): ParsedCrossGenArgs {
+  const args: string[] = [];
+  let dataDir: string | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--data-dir") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("Missing value for --data-dir.");
+      dataDir = value;
+      index += 1;
+      continue;
+    }
+    args.push(arg);
+  }
+  return {
+    args,
+    dataDir,
+    mcpMode: args[0] === "--mcp"
+  };
+}
+
+function commandIfExists(path: string, fileExists: (path: string) => boolean): string | null {
+  return fileExists(path) ? path : null;
+}
+
+function localElectronCommand(packageRoot: string, platform: NodeJS.Platform, fileExists: (path: string) => boolean): string | null {
+  const executable = platform === "win32" ? "electron.cmd" : "electron";
+  return commandIfExists(join(packageRoot, "node_modules", ".bin", executable), fileExists);
+}
+
+function installedAppCommands(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string[] {
+  if (platform === "darwin") {
+    return ["/Applications/CrossGen.app/Contents/MacOS/CrossGen"];
+  }
+  if (platform === "win32") {
+    return [
+      env.LOCALAPPDATA ? join(env.LOCALAPPDATA, "Programs", "crossgen", "CrossGen.exe") : "",
+      env.ProgramFiles ? join(env.ProgramFiles, "crossgen", "CrossGen.exe") : "",
+      env["ProgramFiles(x86)"] ? join(env["ProgramFiles(x86)"]!, "crossgen", "CrossGen.exe") : ""
+    ].filter(Boolean);
+  }
+  return ["/usr/bin/crossgen", "/usr/local/bin/crossgen", "/opt/CrossGen/crossgen"].filter((candidate) => candidate !== process.argv[1]);
+}
+
+export function buildCrossGenCliLaunchPlan(options: CrossGenCliLaunchOptions): CrossGenCliLaunchPlan {
+  const env = { ...(options.env ?? process.env) };
+  const platform = options.platform ?? process.platform;
+  const packageRoot = options.packageRoot ?? defaultPackageRoot();
+  const fileExists = options.fileExists ?? existsSync;
+  const parsed = parseCrossGenArgs(options.argv);
+  if (parsed.dataDir) {
+    env.CROSSGEN_DATA_DIR = parsed.dataDir;
+    env.CROSSGEN_USER_DATA_DIR = parsed.dataDir;
+  }
+
+  const forwardedArgs = parsed.mcpMode ? parsed.args : ["--cli", ...parsed.args];
+  if (env.CROSSGEN_APP_EXECUTABLE?.trim()) {
+    return {
+      command: env.CROSSGEN_APP_EXECUTABLE.trim(),
+      args: forwardedArgs,
+      env,
+      source: "env-app"
+    };
+  }
+  if (env.CROSSGEN_ELECTRON_BIN?.trim()) {
+    return {
+      command: env.CROSSGEN_ELECTRON_BIN.trim(),
+      args: [packageRoot, ...forwardedArgs],
+      env,
+      source: "env-electron"
+    };
+  }
+
+  const electron = localElectronCommand(packageRoot, platform, fileExists);
+  if (electron) {
+    return {
+      command: electron,
+      args: [packageRoot, ...forwardedArgs],
+      env,
+      source: "local-electron"
+    };
+  }
+
+  for (const candidate of installedAppCommands(env, platform)) {
+    if (commandIfExists(candidate, fileExists)) {
+      return {
+        command: candidate,
+        args: forwardedArgs,
+        env,
+        source: "installed-app"
+      };
+    }
+  }
+
+  throw new Error(
+    "CrossGen CLI could not find an Electron runtime or installed CrossGen app. Run from the repository after pnpm install, set CROSSGEN_ELECTRON_BIN, or set CROSSGEN_APP_EXECUTABLE."
+  );
+}
+
+export async function runCrossGenCli(argv = process.argv.slice(2)): Promise<number> {
+  let plan: CrossGenCliLaunchPlan;
+  try {
+    plan = buildCrossGenCliLaunchPlan({ argv });
+  } catch (error) {
+    process.stderr.write(`crossgen failed to prepare: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+  return new Promise((resolve) => {
+    const child = spawn(plan.command, plan.args, {
+      stdio: "inherit",
+      env: plan.env
+    });
+    child.on("error", (error) => {
+      process.stderr.write(`crossgen failed to start: ${error instanceof Error ? error.message : String(error)}\n`);
+      resolve(1);
+    });
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        process.stderr.write(`crossgen exited due to signal ${signal}\n`);
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runCrossGenCli().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -197,6 +197,7 @@ const UPDATE_CHECK_TIMEOUT_MS = 30000;
 const UPDATE_DOWNLOAD_TIMEOUT_MS = 600000; // 10 minutes for large installer downloads
 const BRAND_NAME = "CrossGen";
 const LEGACY_USER_DATA_NAME = "Image2Tools";
+const DATA_DIR_ENV = "CROSSGEN_DATA_DIR";
 const USER_DATA_DIR_ENV = "CROSSGEN_USER_DATA_DIR";
 const LEGACY_USER_DATA_DIR_ENV = "IMAGE2TOOLS_USER_DATA_DIR";
 const PERF_RESULT_PATH_ENV = "CROSSGEN_PERF_RESULT_PATH";
@@ -339,7 +340,7 @@ function createWindow(): BrowserWindow {
 }
 
 function preserveLegacyUserDataPath(): void {
-  const userDataOverride = process.env[USER_DATA_DIR_ENV] || process.env[LEGACY_USER_DATA_DIR_ENV];
+  const userDataOverride = process.env[USER_DATA_DIR_ENV] || process.env[DATA_DIR_ENV] || process.env[LEGACY_USER_DATA_DIR_ENV];
   app.setPath(
     "userData",
     resolveUserDataDir({

--- a/src/shared/package-config.test.ts
+++ b/src/shared/package-config.test.ts
@@ -9,6 +9,7 @@ describe("package release configuration", () => {
     expect(packageJson.description).toContain("One-stop AI image generation manager");
     expect(packageJson.description).toContain("API access");
     expect(packageJson.description).toContain("Gallery/history reuse");
+    expect(packageJson.bin?.crossgen).toBe("dist/cli/crossgen.js");
     expect(packageJson.build.appId).toBe("com.bliveren.crossgen");
     expect(packageJson.build.productName).toBe("CrossGen");
     expect(packageJson.build.copyright).toContain("Nowo");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,16 @@
     "jsx": "react-jsx",
     "types": ["vitest/globals", "node"]
   },
-  "include": ["src/core", "src/renderer", "src/shared", "src/core/**/*.test.ts", "src/shared/**/*.test.ts", "src/renderer/**/*.test.ts", "src/renderer/**/*.test.tsx"],
+  "include": [
+    "src/cli",
+    "src/core",
+    "src/renderer",
+    "src/shared",
+    "src/cli/**/*.test.ts",
+    "src/core/**/*.test.ts",
+    "src/shared/**/*.test.ts",
+    "src/renderer/**/*.test.ts",
+    "src/renderer/**/*.test.tsx"
+  ],
   "references": []
 }


### PR DESCRIPTION
## Summary
- add a packaged crossgen CLI launcher that forwards to Electron CLI/MCP modes
- support --data-dir for isolated agent data directories
- document CLI/MCP setup and add tests for launch planning and package metadata

## Verification
- pnpm typecheck
- pnpm test -- src/cli/crossgen.test.ts src/shared/package-config.test.ts
- pnpm build
- pnpm package:dir
- node dist/cli/crossgen.js --version --json
- node dist/cli/crossgen.js --data-dir /tmp/crossgen-cli-smoke doctor --agent --json