### PR TITLE
Unify state and queue lock path

### DIFF
--- a/src/core/dataDirs.test.ts
+++ b/src/core/dataDirs.test.ts
@@ -12,7 +12,7 @@ describe("dataDirs", () => {
     expect(dirs.statePath).toBe(path.join(path.resolve("/tmp/app-data"), DEFAULT_LEGACY_USER_DATA_NAME, DEFAULT_STATE_FILE_NAME));
     expect(dirs.lockPath).toBe(path.join(expectedUserDataDir, ".crossgen-state.lock"));
     expect(dirs.queuePath).toBe(path.join(expectedUserDataDir, "crossgen-queue.v1.json"));
-    expect(dirs.queueLockPath).toBe(path.join(expectedUserDataDir, ".crossgen-queue.lock"));
+    expect(dirs.queueLockPath).toBe(dirs.lockPath);
     expect(dirs.legacyImageRoots).toContain(path.join(expectedUserDataDir, "images"));
   });
 

--- a/src/core/dataDirs.ts
+++ b/src/core/dataDirs.ts
@@ -35,14 +35,15 @@ export function resolveDataDirs(input: DataDirResolutionInput): ResolvedDataDirs
   const userDataDir = resolveUserDataDir({ ...input, appDataDir });
   const statePath = path.join(userDataDir, DEFAULT_STATE_FILE_NAME);
   const backupStatePath = `${statePath}.bak`;
+  const lockPath = path.join(userDataDir, ".crossgen-state.lock");
   return {
     appDataDir,
     userDataDir,
     statePath,
     backupStatePath,
-    lockPath: path.join(userDataDir, ".crossgen-state.lock"),
+    lockPath,
     queuePath: path.join(userDataDir, DEFAULT_QUEUE_FILE_NAME),
-    queueLockPath: path.join(userDataDir, ".crossgen-queue.lock"),
+    queueLockPath: lockPath,
     imagesDir: path.join(userDataDir, "images"),
     galleryDir: path.join(userDataDir, "gallery"),
     galleryThumbnailCacheDir: path.join(userDataDir, "gallery-thumbnails"),

--- a/src/core/generationQueue.test.ts
+++ b/src/core/generationQueue.test.ts
@@ -190,6 +190,7 @@ describe("generationQueue", () => {
       historyJobId: "job-1"
     });
     await store.appendItem(item);
+    let cancelRequestSettled: Promise<void> = Promise.resolve();
 
     const result = await runNextGenerationQueueItem({
       queueStore: store,
@@ -197,9 +198,11 @@ describe("generationQueue", () => {
       host: { hostId: "host-1", kind: "desktop", processId: process.pid },
       leaseMs: 150,
       onStarted: () => {
-        setTimeout(() => {
-          void requestGenerationQueueItemCancel(store, item.queueId);
-        }, 20);
+        cancelRequestSettled = new Promise((resolve, reject) => {
+          setTimeout(() => {
+            void requestGenerationQueueItemCancel(store, item.queueId).then(() => resolve(), reject);
+          }, 20);
+        });
       },
       executeItem: async (_item, signal) => {
         await new Promise<void>((resolve, reject) => {
@@ -231,6 +234,7 @@ describe("generationQueue", () => {
       workerHeartbeatAt: undefined,
       workerLeaseExpiresAt: undefined
     });
+    await cancelRequestSettled;
 
     await rm(tempDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- resolve queue lock path to the same file lock used by app state
- keep the queueLockPath field for existing callers while serializing state, queue, and Gallery state writes behind one cross-process lock
- update data directory tests for the shared lock invariant

## Scope
This is the foundation step for the v0.3.1 shared critical-section requirement. It does not yet introduce a combined state+queue transaction helper.

## Verification
- pnpm test -- src/core/dataDirs.test.ts src/core/queueStore.test.ts src/core/generationQueue.test.ts
- pnpm typecheck
- pnpm build