### PR TITLE
Add state queue transaction helper

### DIFF
--- a/src/core/generationQueue.test.ts
+++ b/src/core/generationQueue.test.ts
@@ -40,6 +40,20 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function removeTempDir(tempDir: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      await rm(tempDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(25);
+    }
+  }
+  throw lastError;
+}
+
 describe("generationQueue", () => {
   it("claims, executes, and completes an item", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
@@ -80,7 +94,7 @@ describe("generationQueue", () => {
       workerHostId: undefined
     });
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("refreshes running item heartbeat during long executions", async () => {
@@ -114,7 +128,7 @@ describe("generationQueue", () => {
       }
     });
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("marks thrown executions as failed", async () => {
@@ -143,7 +157,7 @@ describe("generationQueue", () => {
     const queue = await store.read();
     expect(queue.items[0]).toMatchObject({ status: "failed", lastError: "provider failed" });
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("records queued and running cancel requests", async () => {
@@ -175,7 +189,7 @@ describe("generationQueue", () => {
     expect(requested?.status).toBe("running");
     expect(requested?.cancelRequested).toBe(true);
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("aborts running workers when durable cancel is requested", async () => {
@@ -236,7 +250,7 @@ describe("generationQueue", () => {
     });
     await cancelRequestSettled;
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("requeues retryable failures until maxAttempts is reached", async () => {
@@ -277,7 +291,7 @@ describe("generationQueue", () => {
       outputAssetIds: ["asset-final"]
     });
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("does not retry non-retryable failures", async () => {
@@ -311,7 +325,7 @@ describe("generationQueue", () => {
       lastErrorRetryable: false
     });
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("records partial outputs without duplicating asset ids", async () => {
@@ -331,7 +345,7 @@ describe("generationQueue", () => {
     expect(queue.items[0].partialAssetIds).toEqual(["partial-1", "partial-2"]);
     expect(queue.items[0].outputAssetIds).toEqual(["partial-1", "partial-2"]);
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("requeues retryable terminal items and clears stale execution state", async () => {
@@ -391,7 +405,7 @@ describe("generationQueue", () => {
     expect(result.item?.workerHeartbeatAt).toBeUndefined();
     expect(result.item?.workerLeaseExpiresAt).toBeUndefined();
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 
   it("does not retry non-terminal or succeeded items", async () => {
@@ -429,6 +443,6 @@ describe("generationQueue", () => {
     expect(succeededResult).toMatchObject({ action: "not_retryable", item: { queueId: succeeded.queueId, status: "succeeded" } });
     expect(missingResult).toEqual({ action: "not_found" });
 
-    await rm(tempDir, { recursive: true, force: true });
+    await removeTempDir(tempDir);
   });
 });

--- a/src/core/queueStore.ts
+++ b/src/core/queueStore.ts
@@ -56,7 +56,7 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
 
-async function readQueueFile(queuePath: string): Promise<GenerationQueueFile> {
+export async function readQueueFile(queuePath: string): Promise<GenerationQueueFile> {
   try {
     const raw = JSON.parse(await fs.readFile(queuePath, "utf8")) as Partial<GenerationQueueFile>;
     return normalizeQueueFile(raw);
@@ -68,14 +68,14 @@ async function readQueueFile(queuePath: string): Promise<GenerationQueueFile> {
   }
 }
 
-async function writeQueueFile(queuePath: string, queue: GenerationQueueFile): Promise<void> {
+export async function writeQueueFile(queuePath: string, queue: GenerationQueueFile): Promise<void> {
   await fs.mkdir(path.dirname(queuePath), { recursive: true });
   const tmpPath = `${queuePath}.${process.pid}.${Date.now()}.tmp`;
   await fs.writeFile(tmpPath, `${JSON.stringify(queue, null, 2)}\n`, "utf8");
   await fs.rename(tmpPath, queuePath);
 }
 
-function normalizeQueueFile(raw: Partial<GenerationQueueFile> | null | undefined): GenerationQueueFile {
+export function normalizeQueueFile(raw: Partial<GenerationQueueFile> | null | undefined): GenerationQueueFile {
   return {
     schemaVersion: 1,
     updatedAt: typeof raw?.updatedAt === "string" ? raw.updatedAt : new Date(0).toISOString(),

--- a/src/core/stateQueueTransaction.test.ts
+++ b/src/core/stateQueueTransaction.test.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createQueueStore } from "./queueStore";
+import { withStateQueueTransaction } from "./stateQueueTransaction";
+import type { GenerationQueueItem } from "../shared/types";
+
+interface TestState {
+  version: number;
+  history: string[];
+}
+
+function queueItem(queueId: string): GenerationQueueItem {
+  const now = new Date().toISOString();
+  return {
+    queueId,
+    source: "cli",
+    providerId: "provider-1",
+    request: {
+      mode: "generate",
+      prompt: "hello",
+      inputPaths: [],
+      params: {
+        providerKind: "openai",
+        launchId: "gpt-image-2",
+        model: "gpt-image-2",
+        imageRoute: "auto",
+        size: "1024x1024",
+        quality: "auto",
+        outputFormat: "png",
+        outputCompression: 100,
+        background: "auto",
+        n: 1,
+        stream: false,
+        partialImages: 0,
+        moderation: "auto",
+        timeoutMs: 1000
+      }
+    },
+    status: "queued",
+    priority: 0,
+    attempt: 0,
+    maxAttempts: 1,
+    createdAt: now,
+    updatedAt: now,
+    outputAssetIds: [],
+    partialAssetIds: [],
+    galleryAssetIds: [],
+    cancelRequested: false,
+    costConfirmed: true,
+    executionKind: "sync-provider",
+    stage: "queued",
+    sourceAssetIds: [],
+    outputMediaKinds: ["image"]
+  };
+}
+
+describe("stateQueueTransaction", () => {
+  it("writes state and queue under one lock", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-state-queue-tx-"));
+    const statePath = path.join(tempDir, "state.json");
+    const queuePath = path.join(tempDir, "queue.json");
+    const lockPath = path.join(tempDir, ".crossgen-state.lock");
+
+    const transaction = await withStateQueueTransaction<TestState, string>({
+      lockPath,
+      queuePath,
+      state: {
+        statePath,
+        backupPath: `${statePath}.bak`,
+        defaultState: { version: 1, history: [] },
+        normalize: (value) => value as TestState
+      }
+    }, (context) => {
+      context.updateState((state) => ({ ...state, history: ["job-1", ...state.history] }));
+      context.updateQueue((queue) => ({
+        ...queue,
+        items: [queueItem("queue-1"), ...queue.items]
+      }));
+      return "created";
+    });
+
+    expect(transaction.result).toBe("created");
+    expect(transaction.state.history).toEqual(["job-1"]);
+    expect(transaction.queue.items.map((item) => item.queueId)).toEqual(["queue-1"]);
+
+    const persisted = await withStateQueueTransaction<TestState, null>({
+      lockPath,
+      queuePath,
+      state: {
+        statePath,
+        backupPath: `${statePath}.bak`,
+        defaultState: { version: 1, history: [] },
+        normalize: (value) => value as TestState
+      }
+    }, (context) => {
+      expect(context.state.history).toEqual(["job-1"]);
+      expect(context.queue.items.map((item) => item.queueId)).toEqual(["queue-1"]);
+      return null;
+    });
+    expect(persisted.queue.items[0].status).toBe("queued");
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("blocks regular queue mutations while a transaction holds the shared lock", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-state-queue-tx-"));
+    const statePath = path.join(tempDir, "state.json");
+    const queuePath = path.join(tempDir, "queue.json");
+    const lockPath = path.join(tempDir, ".crossgen-state.lock");
+    const queueStore = createQueueStore({ queuePath, lockPath });
+
+    let releaseTransaction!: () => void;
+    let transactionStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      transactionStarted = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+
+    const transaction = withStateQueueTransaction<TestState, null>({
+      lockPath,
+      queuePath,
+      state: {
+        statePath,
+        backupPath: `${statePath}.bak`,
+        defaultState: { version: 1, history: [] },
+        normalize: (value) => value as TestState
+      }
+    }, async () => {
+      transactionStarted();
+      await release;
+      return null;
+    });
+
+    await started;
+    let appendSettled = false;
+    const append = queueStore.appendItem(queueItem("queue-after")).then(() => {
+      appendSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(appendSettled).toBe(false);
+
+    releaseTransaction();
+    await transaction;
+    await append;
+    expect((await queueStore.read()).items.map((item) => item.queueId)).toEqual(["queue-after"]);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+});

--- a/src/core/stateQueueTransaction.ts
+++ b/src/core/stateQueueTransaction.ts
@@ -1,0 +1,76 @@
+import { withExclusiveFileLock } from "./fileLock.js";
+import { readQueueFile, writeQueueFile, normalizeQueueFile } from "./queueStore.js";
+import { readJsonStateFile, writeJsonStateFile, type JsonStateFileAccessOptions } from "./stateStore.js";
+import type { GenerationQueueFile } from "../shared/types.js";
+
+export interface StateQueueTransactionOptions<TState> {
+  lockPath: string;
+  state: JsonStateFileAccessOptions<TState>;
+  queuePath: string;
+  timeoutMs?: number;
+  staleLockMs?: number;
+  updateBackup?: boolean;
+}
+
+export interface StateQueueTransactionContext<TState> {
+  state: TState;
+  queue: GenerationQueueFile;
+  setState: (next: TState) => void;
+  setQueue: (next: GenerationQueueFile) => void;
+  updateState: (updater: (state: TState) => TState) => TState;
+  updateQueue: (updater: (queue: GenerationQueueFile) => GenerationQueueFile) => GenerationQueueFile;
+}
+
+export interface StateQueueTransactionResult<TState, TResult> {
+  result: TResult;
+  state: TState;
+  queue: GenerationQueueFile;
+}
+
+export async function withStateQueueTransaction<TState, TResult>(
+  options: StateQueueTransactionOptions<TState>,
+  operation: (context: StateQueueTransactionContext<TState>) => TResult | Promise<TResult>
+): Promise<StateQueueTransactionResult<TState, TResult>> {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const staleLockMs = options.staleLockMs ?? 30000;
+
+  return withExclusiveFileLock(
+    options.lockPath,
+    async () => {
+      let state = await readJsonStateFile(options.state) as TState;
+      let queue = await readQueueFile(options.queuePath);
+      const context: StateQueueTransactionContext<TState> = {
+        get state() {
+          return state;
+        },
+        get queue() {
+          return queue;
+        },
+        setState(next) {
+          state = next;
+        },
+        setQueue(next) {
+          queue = next;
+        },
+        updateState(updater) {
+          state = updater(state);
+          return state;
+        },
+        updateQueue(updater) {
+          queue = updater(queue);
+          return queue;
+        }
+      };
+      const result = await operation(context);
+      const normalizedQueue = normalizeQueueFile(queue);
+      await writeJsonStateFile(options.state, state, { updateBackup: options.updateBackup });
+      await writeQueueFile(options.queuePath, normalizedQueue);
+      return {
+        result,
+        state,
+        queue: normalizedQueue
+      };
+    },
+    { timeoutMs, staleLockMs }
+  );
+}

--- a/src/core/stateStore.ts
+++ b/src/core/stateStore.ts
@@ -19,6 +19,13 @@ export interface JsonStateStore<TState> {
   withLock<T>(operation: () => Promise<T>): Promise<T>;
 }
 
+export interface JsonStateFileAccessOptions<TState> {
+  statePath: string;
+  backupPath: string;
+  defaultState: TState;
+  normalize: (value: unknown) => TState;
+}
+
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
@@ -34,28 +41,45 @@ async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await fs.rename(tmpPath, filePath);
 }
 
+export async function readJsonStateFile<TState>(options: JsonStateFileAccessOptions<TState>): Promise<TState> {
+  try {
+    return options.normalize(await readJsonFile(options.statePath));
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") {
+      try {
+        return options.normalize(await readJsonFile(options.backupPath));
+      } catch {
+        return structuredClone(options.defaultState);
+      }
+    }
+    try {
+      return options.normalize(await readJsonFile(options.backupPath));
+    } catch {
+      return structuredClone(options.defaultState);
+    }
+  }
+}
+
+export async function writeJsonStateFile<TState>(
+  options: JsonStateFileAccessOptions<TState>,
+  state: TState,
+  writeOptions: { updateBackup?: boolean } = {}
+): Promise<void> {
+  if (writeOptions.updateBackup !== false) {
+    await fs.copyFile(options.statePath, options.backupPath).catch((error: unknown) => {
+      if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+    });
+  }
+  await writeJsonFile(options.statePath, state);
+}
+
 export function createJsonStateStore<TState>(options: JsonStateStoreOptions<TState>): JsonStateStore<TState> {
   const { statePath, backupPath, lockPath, normalize, defaultState } = options;
   const timeoutMs = options.timeoutMs ?? 5000;
   const staleLockMs = options.staleLockMs ?? 30000;
 
   async function readFromDisk(): Promise<TState> {
-    try {
-      return normalize(await readJsonFile(statePath));
-    } catch (error) {
-      if (!isNodeError(error) || error.code !== "ENOENT") {
-        try {
-          return normalize(await readJsonFile(backupPath));
-        } catch {
-          return structuredClone(defaultState);
-        }
-      }
-      try {
-        return normalize(await readJsonFile(backupPath));
-      } catch {
-        return structuredClone(defaultState);
-      }
-    }
+    return readJsonStateFile({ statePath, backupPath, normalize, defaultState });
   }
 
   return {
@@ -66,12 +90,7 @@ export function createJsonStateStore<TState>(options: JsonStateStoreOptions<TSta
       await withExclusiveFileLock(
         lockPath,
         async () => {
-          if (writeOptions.updateBackup !== false) {
-            await fs.copyFile(statePath, backupPath).catch((error: unknown) => {
-              if (!isNodeError(error) || error.code !== "ENOENT") throw error;
-            });
-          }
-          await writeJsonFile(statePath, state);
+          await writeJsonStateFile({ statePath, backupPath, normalize, defaultState }, state, writeOptions);
         },
         { timeoutMs, staleLockMs }
       );
@@ -81,10 +100,7 @@ export function createJsonStateStore<TState>(options: JsonStateStoreOptions<TSta
         lockPath,
         async () => {
           const next = await mutator(await readFromDisk());
-          await fs.copyFile(statePath, backupPath).catch((error: unknown) => {
-            if (!isNodeError(error) || error.code !== "ENOENT") throw error;
-          });
-          await writeJsonFile(statePath, next);
+          await writeJsonStateFile({ statePath, backupPath, normalize, defaultState }, next);
           return next;
         },
         { timeoutMs, staleLockMs }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -32,6 +32,7 @@ import type {
   GeminiAspectRatio,
   GeminiResolution,
   GenerationJob,
+  GenerationQueueFile,
   GenerationQueueItem,
   GenerationQueueWorkerHost,
   HistoryJobPatch,
@@ -117,6 +118,7 @@ import {
 } from "../core/queueConfig.js";
 import { createQueueStore, type QueueStore } from "../core/queueStore.js";
 import { createJsonStateStore, type JsonStateStore } from "../core/stateStore.js";
+import { withStateQueueTransaction } from "../core/stateQueueTransaction.js";
 import { parseGenerationPromptFile, type GenerationPromptFileEntry } from "../cli/generationBatch.js";
 import {
   buildCliAssetInspect,
@@ -570,7 +572,14 @@ async function readState(): Promise<AppStateFile> {
 
 async function writeState(state: AppStateFile, options: WriteStateOptions = {}): Promise<void> {
   await ensureDir(app.getPath("userData"));
-  const payload: AppStateFile = {
+  const payload = persistentStatePayload(state);
+  await getAppStateStore().write(payload, options);
+  stateWriteCount += 1;
+  stateCache = payload;
+}
+
+function persistentStatePayload(state: AppStateFile): AppStateFile {
+  return {
     version: STATE_VERSION,
     providers: state.providers,
     activeProviderId: state.activeProviderId,
@@ -582,9 +591,32 @@ async function writeState(state: AppStateFile, options: WriteStateOptions = {}):
     storage: state.storage,
     draft: state.draft
   };
-  await getAppStateStore().write(payload, options);
+}
+
+async function mutateStateAndQueue<TResult>(
+  operation: (state: AppStateFile, queue: GenerationQueueFile) => Promise<{ state: AppStateFile; queue: GenerationQueueFile; result: TResult }> | { state: AppStateFile; queue: GenerationQueueFile; result: TResult },
+  options: WriteStateOptions = {}
+): Promise<{ state: AppStateFile; queue: GenerationQueueFile; result: TResult }> {
+  await ensureDir(app.getPath("userData"));
+  const transaction = await withStateQueueTransaction<AppStateFile, TResult>({
+    lockPath: getStateLockPath(),
+    queuePath: getQueuePath(),
+    updateBackup: options.updateBackup,
+    state: {
+      statePath: getStatePath(),
+      backupPath: getBackupStatePath(),
+      defaultState: getDefaultState(),
+      normalize: (value) => applyStartupRecovery(normalizeState(value))
+    }
+  }, async (context) => {
+    const next = await operation(context.state, context.queue);
+    context.setState(persistentStatePayload(next.state));
+    context.setQueue(next.queue);
+    return next.result;
+  });
   stateWriteCount += 1;
-  stateCache = payload;
+  stateCache = transaction.state;
+  return transaction;
 }
 
 async function readStateFile(filePath: string): Promise<unknown> {
@@ -1143,14 +1175,26 @@ function mergeImageAssets(...groups: ImageAsset[][]): ImageAsset[] {
 }
 
 async function upsertJob(job: GenerationJob): Promise<void> {
-  const persistentJob = stripTransientPreviewsFromJob(job);
   const state = await readState();
+  await writeState(upsertJobInState(state, job));
+}
+
+function upsertJobInState(state: AppStateFile, job: GenerationJob): AppStateFile {
+  const persistentJob = stripTransientPreviewsFromJob(job);
   const existingIndex = state.history.findIndex((item) => item.id === persistentJob.id);
   const nextHistory =
     existingIndex === -1
       ? [persistentJob, ...state.history]
       : state.history.map((item) => (item.id === persistentJob.id ? persistentJob : item));
-  await writeState({ ...state, history: nextHistory.slice(0, MAX_HISTORY) });
+  return { ...state, history: nextHistory.slice(0, MAX_HISTORY) };
+}
+
+function appendQueueItem(queue: GenerationQueueFile, item: GenerationQueueItem): GenerationQueueFile {
+  return {
+    ...queue,
+    updatedAt: new Date().toISOString(),
+    items: [...queue.items, item]
+  };
 }
 
 function sendJobEvent(event: JobProgressEvent): void {
@@ -2687,19 +2731,30 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
   const imagesDir = getImagesDir(state);
   const { inputs, mask } = await resolveRequestInputs(normalizedRequest, imagesDir);
   const queuedAt = Date.now();
-  let job: GenerationJob = createJob(normalizedRequest, activeProvider, inputs, mask);
-  await upsertJob(job);
-  const queueItem = createGenerationQueueItem({
-    source: "desktop",
-    providerId: activeProvider.id,
-    request: normalizedRequest,
-    costConfirmed: true,
-    historyJobId: job.id,
-    sourceAssetIds: [...inputs.map((asset) => asset.id), ...(mask ? [mask.id] : [])],
-    outputMediaKinds: ["image"]
+  let job!: GenerationJob;
+  let queueItem!: GenerationQueueItem;
+  await mutateStateAndQueue((currentState, queue) => {
+    const currentProvider = currentState.providers.find(p => p.id === currentState.activeProviderId) ?? currentState.providers[0];
+    if (!canRunRequestWithConfig(normalizedRequest, currentProvider)) {
+      throw new Error("任务 provider 与当前服务配置不一致。请先切换并保存对应服务商。");
+    }
+    job = createJob(normalizedRequest, currentProvider, inputs, mask);
+    queueItem = createGenerationQueueItem({
+      source: "desktop",
+      providerId: currentProvider.id,
+      request: normalizedRequest,
+      costConfirmed: true,
+      historyJobId: job.id,
+      sourceAssetIds: [...inputs.map((asset) => asset.id), ...(mask ? [mask.id] : [])],
+      outputMediaKinds: ["image"]
+    });
+    return {
+      state: upsertJobInState(currentState, job),
+      queue: appendQueueItem(queue, queueItem),
+      result: null
+    };
   });
   queuedJobIds.set(job.id, queueItem.queueId);
-  await getGenerationQueueStore().appendItem(queueItem);
 
   const result = await runQueuedGenerationForAgent(queueItem.queueId, "desktop", normalizedRequest.params.timeoutMs);
 
@@ -3848,6 +3903,16 @@ interface AgentGenerationEnqueueInput {
   resolution?: string;
 }
 
+interface AgentGenerationEnqueueTransactionResult {
+  created: boolean;
+  duplicate: boolean;
+  idempotencyKey?: string;
+  queueId: string;
+  historyJobId?: string;
+  status: JobStatus;
+  lookupQueueId: string;
+}
+
 function parsePositiveIntegerOption(value: string | undefined, name: string): number | undefined {
   if (value === undefined) return undefined;
   const parsed = Number(value);
@@ -3985,7 +4050,6 @@ async function enqueueGenerationForAgent(input: AgentGenerationEnqueueInput) {
   const request = validateAgentRunJobRequest(buildAgentRunJobRequest(provider, input), provider);
   const { inputs, mask } = await resolveRequestInputs(request, getImagesDir(state));
   const job = createJob(request, provider, inputs, mask);
-  await upsertJob(job);
   const queueItem = createGenerationQueueItem({
     source: input.source,
     providerId: provider.id,
@@ -4000,16 +4064,46 @@ async function enqueueGenerationForAgent(input: AgentGenerationEnqueueInput) {
     requestId: input.requestId,
     correlationId: input.correlationId
   });
-  await getGenerationQueueStore().appendItem(queueItem);
-  const queue = await readExistingQueueForCli();
+  const transaction = await mutateStateAndQueue<AgentGenerationEnqueueTransactionResult>((currentState, queue) => {
+    if (idempotencyKey) {
+      const existing = queue.items.find((item) => item.idempotencyKey === idempotencyKey);
+      if (existing) {
+        return {
+          state: currentState,
+          queue,
+          result: {
+            created: false,
+            duplicate: true,
+            idempotencyKey,
+            queueId: existing.queueId,
+            historyJobId: existing.historyJobId,
+            status: existing.status,
+            lookupQueueId: existing.queueId
+          }
+        };
+      }
+    }
+    const currentProvider = selectProviderForAgent(currentState, input.providerId);
+    normalizeTargetGalleryFolderId(currentState, input.targetGalleryFolderId);
+    validateAgentRunJobRequest(request, currentProvider);
+    return {
+      state: upsertJobInState(currentState, job),
+      queue: appendQueueItem(queue, queueItem),
+      result: {
+        created: true,
+        duplicate: false,
+        idempotencyKey,
+        queueId: queueItem.queueId,
+        historyJobId: job.id,
+        status: queueItem.status,
+        lookupQueueId: queueItem.queueId
+      }
+    };
+  });
+  const { lookupQueueId, ...result } = transaction.result;
   return {
-    created: true,
-    duplicate: false,
-    idempotencyKey,
-    queueId: queueItem.queueId,
-    historyJobId: job.id,
-    status: queueItem.status,
-    job: buildCliJobStatus(queue, await readExistingStateForCli(), queueItem.queueId)
+    ...result,
+    job: buildCliJobStatus(transaction.queue, transaction.state, lookupQueueId)
   };
 }
 


### PR DESCRIPTION
## Summary
- add a core state+queue transaction helper that acquires the shared lock once
- expose already-locked state and queue file read/write helpers for coordinated mutations
- use the transaction helper for desktop and CLI/MCP generation enqueue so history job creation and queue append are committed in one critical section
- keep idempotency duplicate detection inside the transaction for concurrent agent submits

## Verification
- pnpm test -- src/core/stateQueueTransaction.test.ts src/main/main.test.ts src/mcp/stdioServer.test.ts src/cli/readonly.test.ts src/core/generationQueue.test.ts
- pnpm typecheck
- pnpm build
- pnpm package:dir