### PR TITLE
Atomically finalize queued generation state

### DIFF
--- a/src/core/generationQueue.test.ts
+++ b/src/core/generationQueue.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createGenerationQueueItem } from "./generation";
 import {
+  completeGenerationQueueItemInQueue,
   recordGenerationQueuePartialOutput,
   requestGenerationQueueItemCancel,
   retryGenerationQueueItem,
@@ -91,6 +92,53 @@ describe("generationQueue", () => {
       status: "succeeded",
       historyJobId: "job-1",
       outputAssetIds: ["asset-1"],
+      workerHostId: undefined
+    });
+
+    await removeTempDir(tempDir);
+  });
+
+  it("delegates terminal completion to an injected committer", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({ queuePath, lockPath: `${queuePath}.lock` });
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-1"
+    });
+    await store.appendItem(item);
+
+    const result = await runNextGenerationQueueItem({
+      queueStore: store,
+      queueId: item.queueId,
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      executeItem: async () => ({
+        status: "succeeded",
+        historyJobId: "job-1",
+        outputAssetIds: ["asset-1"]
+      }),
+      completeItem: async (claimed, execution, nowMs) => {
+        const queue = await store.mutate((current) => completeGenerationQueueItemInQueue(current, claimed, {
+          ...execution,
+          galleryAssetIds: ["gallery-1"]
+        }, nowMs).queue);
+        return queue.items.find((candidate) => candidate.queueId === claimed.queueId) ?? claimed;
+      }
+    });
+
+    expect(result.item).toMatchObject({
+      status: "succeeded",
+      outputAssetIds: ["asset-1"],
+      galleryAssetIds: ["gallery-1"]
+    });
+    const queue = await store.read();
+    expect(queue.items[0]).toMatchObject({
+      status: "succeeded",
+      outputAssetIds: ["asset-1"],
+      galleryAssetIds: ["gallery-1"],
       workerHostId: undefined
     });
 

--- a/src/core/generationQueue.ts
+++ b/src/core/generationQueue.ts
@@ -1,4 +1,4 @@
-import type { GenerationQueueItem, GenerationQueueWorkerHost, JobStatus, QueueErrorCategory } from "../shared/types.js";
+import type { GenerationQueueFile, GenerationQueueItem, GenerationQueueWorkerHost, JobStatus, QueueErrorCategory } from "../shared/types.js";
 import type { QueueHostIdentity, QueueStore } from "./queueStore.js";
 
 export interface GenerationQueueFailureClassification {
@@ -38,6 +38,7 @@ export interface RunNextGenerationQueueItemOptions<TValue = unknown> {
   createAbortController?: () => AbortController;
   onStarted?: (item: GenerationQueueItem, controller: AbortController) => void;
   onFinished?: (item: GenerationQueueItem) => void;
+  completeItem?: (item: GenerationQueueItem, result: GenerationQueueExecutionResult<TValue>, nowMs: number) => Promise<GenerationQueueItem>;
 }
 
 export interface GenerationQueueRunResult<TValue = unknown> {
@@ -177,16 +178,64 @@ async function claimedItemCancelRequested(queueStore: QueueStore, item: Generati
   return Boolean(current?.cancelRequested);
 }
 
-function cancelledExecution<TValue = unknown>(item: GenerationQueueItem, error = "Generation cancelled."): GenerationQueueExecutionResult<TValue> {
+function cancelledExecution<TValue = unknown>(
+  item: GenerationQueueItem,
+  error = "Generation cancelled.",
+  result?: GenerationQueueExecutionResult<TValue>
+): GenerationQueueExecutionResult<TValue> {
   return {
+    ...result,
     status: "cancelled",
     error,
     errorCategory: "cancelled",
     retryable: false,
-    historyJobId: item.historyJobId,
-    outputAssetIds: item.outputAssetIds,
-    partialAssetIds: item.partialAssetIds,
-    galleryAssetIds: item.galleryAssetIds
+    historyJobId: result?.historyJobId ?? item.historyJobId,
+    outputAssetIds: result?.outputAssetIds ?? item.outputAssetIds,
+    partialAssetIds: result?.partialAssetIds ?? item.partialAssetIds,
+    galleryAssetIds: result?.galleryAssetIds ?? item.galleryAssetIds
+  };
+}
+
+export function completeGenerationQueueItemInQueue(
+  queue: GenerationQueueFile,
+  item: GenerationQueueItem,
+  result: GenerationQueueExecutionResult,
+  nowMs: number
+): { queue: GenerationQueueFile; item: GenerationQueueItem } {
+  let completed: GenerationQueueItem | undefined;
+  const nowIso = iso(nowMs);
+  const nextQueue = {
+    ...queue,
+    updatedAt: nowIso,
+    items: queue.items.map((current) => {
+      if (current.queueId !== item.queueId) return current;
+      const status = normalizeTerminalStatus(result.status);
+      completed = {
+        ...current,
+        status,
+        stage: "finalizing",
+        completedAt: nowIso,
+        nextRunAt: undefined,
+        updatedAt: nowIso,
+        lastError: result.error,
+        lastErrorCategory: result.errorCategory,
+        lastErrorRetryable: result.retryable,
+        historyJobId: result.historyJobId ?? current.historyJobId,
+        outputAssetIds: result.outputAssetIds ?? current.outputAssetIds,
+        partialAssetIds: result.partialAssetIds ?? current.partialAssetIds,
+        galleryAssetIds: result.galleryAssetIds ?? current.galleryAssetIds,
+        cancelRequested: status === "cancelled" ? true : current.cancelRequested,
+        workerHostId: undefined,
+        workerProcessId: undefined,
+        workerHeartbeatAt: undefined,
+        workerLeaseExpiresAt: undefined
+      };
+      return completed;
+    })
+  };
+  return {
+    queue: nextQueue,
+    item: completed ?? item
   };
 }
 
@@ -198,38 +247,23 @@ async function completeClaimedItem(
 ): Promise<GenerationQueueItem> {
   let completed: GenerationQueueItem | undefined;
   await queueStore.mutate((queue) => {
-    const next = {
-      ...queue,
-      updatedAt: iso(nowMs),
-      items: queue.items.map((current) => {
-        if (current.queueId !== item.queueId) return current;
-        const status = normalizeTerminalStatus(result.status);
-        completed = {
-          ...current,
-          status,
-          stage: "finalizing",
-          completedAt: iso(nowMs),
-          nextRunAt: undefined,
-          updatedAt: iso(nowMs),
-          lastError: result.error,
-          lastErrorCategory: result.errorCategory,
-          lastErrorRetryable: result.retryable,
-          historyJobId: result.historyJobId ?? current.historyJobId,
-          outputAssetIds: result.outputAssetIds ?? current.outputAssetIds,
-          partialAssetIds: result.partialAssetIds ?? current.partialAssetIds,
-          galleryAssetIds: result.galleryAssetIds ?? current.galleryAssetIds,
-          cancelRequested: status === "cancelled" ? true : current.cancelRequested,
-          workerHostId: undefined,
-          workerProcessId: undefined,
-          workerHeartbeatAt: undefined,
-          workerLeaseExpiresAt: undefined
-        };
-        return completed;
-      })
-    };
-    return next;
+    const next = completeGenerationQueueItemInQueue(queue, item, result, nowMs);
+    completed = next.item;
+    return next.queue;
   });
   return completed ?? item;
+}
+
+async function completeClaimedItemWithOptions<TValue>(
+  options: RunNextGenerationQueueItemOptions<TValue>,
+  item: GenerationQueueItem,
+  result: GenerationQueueExecutionResult<TValue>,
+  nowMs: number
+): Promise<GenerationQueueItem> {
+  if (options.completeItem) {
+    return options.completeItem(item, result, nowMs);
+  }
+  return completeClaimedItem(options.queueStore, item, result, nowMs);
 }
 
 async function scheduleRetry(
@@ -269,29 +303,14 @@ async function scheduleRetry(
 }
 
 async function failClaimedItem<TValue = unknown>(
-  queueStore: QueueStore,
+  options: RunNextGenerationQueueItemOptions<TValue>,
   item: GenerationQueueItem,
   error: unknown,
   nowMs: number,
   classification: GenerationQueueFailureClassification
-): Promise<GenerationQueueExecutionResult<TValue>> {
+): Promise<{ item: GenerationQueueItem; execution: GenerationQueueExecutionResult<TValue> }> {
   const message = error instanceof Error ? error.message : String(error);
-  await completeClaimedItem(
-    queueStore,
-    item,
-    {
-      status: "failed",
-      error: message,
-      errorCategory: classification.category,
-      retryable: classification.retryable,
-      historyJobId: item.historyJobId,
-      outputAssetIds: item.outputAssetIds,
-      partialAssetIds: item.partialAssetIds,
-      galleryAssetIds: item.galleryAssetIds
-    },
-    nowMs
-  );
-  return {
+  const execution: GenerationQueueExecutionResult<TValue> = {
     status: "failed",
     error: message,
     errorCategory: classification.category,
@@ -301,6 +320,13 @@ async function failClaimedItem<TValue = unknown>(
     partialAssetIds: item.partialAssetIds,
     galleryAssetIds: item.galleryAssetIds
   };
+  const completed = await completeClaimedItemWithOptions(
+    options,
+    item,
+    execution,
+    nowMs
+  );
+  return { item: completed, execution };
 }
 
 export async function runNextGenerationQueueItem<TValue = unknown>(
@@ -325,7 +351,7 @@ export async function runNextGenerationQueueItem<TValue = unknown>(
     await markClaimedItemStage(options.queueStore, item.queueId, now());
     let execution = await options.executeItem(item, controller.signal);
     if (execution.status !== "cancelled" && (await claimedItemCancelRequested(options.queueStore, item))) {
-      execution = cancelledExecution(item, execution.error ?? "Generation cancelled.");
+      execution = cancelledExecution(item, execution.error ?? "Generation cancelled.", execution);
     }
     if (execution.status === "failed") {
       const classification = options.classifyFailure?.({ item, result: execution }) ?? defaultFailureClassification();
@@ -351,12 +377,12 @@ export async function runNextGenerationQueueItem<TValue = unknown>(
       execution.errorCategory = execution.errorCategory ?? classification.category;
       execution.retryable = execution.retryable ?? classification.retryable;
     }
-    const completed = await completeClaimedItem(options.queueStore, item, execution, now());
+    const completed = await completeClaimedItemWithOptions(options, item, execution, now());
     return { claimed: true, item: completed, execution };
   } catch (error) {
     if (await claimedItemCancelRequested(options.queueStore, item)) {
       const execution = cancelledExecution<TValue>(item, error instanceof Error ? error.message : "Generation cancelled.");
-      const completed = await completeClaimedItem(options.queueStore, item, execution, now());
+      const completed = await completeClaimedItemWithOptions(options, item, execution, now());
       return { claimed: true, item: completed, execution };
     }
     const classification = options.classifyFailure?.({ item, error }) ?? defaultFailureClassification();
@@ -385,8 +411,8 @@ export async function runNextGenerationQueueItem<TValue = unknown>(
         }
       };
     }
-    const execution = await failClaimedItem<TValue>(options.queueStore, item, error, now(), classification);
-    return { claimed: true, item, execution };
+    const failed = await failClaimedItem<TValue>(options, item, error, now(), classification);
+    return { claimed: true, item: failed.item, execution: failed.execution };
   } finally {
     stopHeartbeat();
     options.onFinished?.(item);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -102,11 +102,13 @@ import {
   type GalleryMutationContext
 } from "../core/gallery.js";
 import {
+  completeGenerationQueueItemInQueue,
   recordGenerationQueuePartialOutput,
   requestGenerationQueueItemCancel,
   retryGenerationQueueItem,
   runGenerationQueueItemToCompletion,
-  runNextGenerationQueueItem
+  runNextGenerationQueueItem,
+  type GenerationQueueExecutionResult
 } from "../core/generationQueue.js";
 import { getProviderEnvKeyNames } from "../core/keyring.js";
 import {
@@ -2404,30 +2406,136 @@ async function getOrCreateHistoryJobForQueueItem(
   return job;
 }
 
-async function importGenerationResultOutputsToGallery(job: GenerationJob, item: GenerationQueueItem): Promise<GalleryAsset[]> {
-  if (item.targetGalleryFolderId === undefined) return [];
+function mergeStringIds(...groups: Array<string[] | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of groups.flatMap((group) => group ?? [])) {
+    if (!value.trim() || seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+async function importGenerationResultOutputsToGalleryState(
+  state: AppStateFile,
+  job: GenerationJob,
+  item: GenerationQueueItem
+): Promise<{ state: AppStateFile; galleryAssets: GalleryAsset[] }> {
+  if (item.targetGalleryFolderId === undefined) return { state, galleryAssets: [] };
   const outputs = job.outputs.filter((asset) => asset.sourceType === "result");
-  if (outputs.length === 0) return [];
+  if (outputs.length === 0) return { state, galleryAssets: [] };
 
   const importedAssets: GalleryAsset[] = [];
-  const nextState = await getAppStateStore().mutate(async (state) => {
-    let nextStateForImport = state;
-    const context = galleryMutationContext(state, { duplicateAction: "copy" });
-    for (const output of outputs) {
-      const outcome = await importCoreGalleryAssets(nextStateForImport, context, [output.path], item.targetGalleryFolderId ?? null, {
-        source: "result",
-        sourceJobId: job.id,
-        sourceAssetId: output.id,
-        tags: job.tags
-      });
-      importedAssets.push(...outcome.result.assets);
-      nextStateForImport = mergeGalleryState(nextStateForImport, outcome.state);
+  let nextState = state;
+  const context = galleryMutationContext(state, { duplicateAction: "copy" });
+  for (const output of outputs) {
+    const outcome = await importCoreGalleryAssets(nextState, context, [output.path], item.targetGalleryFolderId ?? null, {
+      source: "result",
+      sourceJobId: job.id,
+      sourceAssetId: output.id,
+      tags: job.tags
+    });
+    importedAssets.push(...outcome.result.assets);
+    nextState = mergeGalleryState(nextState, outcome.state);
+  }
+  return { state: nextState, galleryAssets: importedAssets };
+}
+
+function terminalJobForQueueExecution(job: GenerationJob, execution: GenerationQueueExecutionResult<GenerationJob>, nowIso: string): GenerationJob {
+  if (execution.status === "cancelled" && job.status !== "cancelled") {
+    return {
+      ...job,
+      status: "cancelled",
+      error: execution.error ?? job.error ?? "任务已终止。",
+      updatedAt: nowIso
+    };
+  }
+  if (execution.status === "failed" && job.status !== "failed") {
+    return {
+      ...job,
+      status: "failed",
+      error: execution.error ?? job.error ?? "任务失败。",
+      updatedAt: nowIso
+    };
+  }
+  return job;
+}
+
+async function completeGenerationQueueItemWithState(
+  item: GenerationQueueItem,
+  execution: GenerationQueueExecutionResult<GenerationJob>,
+  nowMs: number
+): Promise<GenerationQueueItem> {
+  let eventJob: GenerationJob | undefined;
+  let importedGalleryAssets: GalleryAsset[] = [];
+  const transaction = await mutateStateAndQueue<GenerationQueueItem>(async (currentState, queue) => {
+    const nowIso = new Date(nowMs).toISOString();
+    let nextState = currentState;
+    let nextExecution: GenerationQueueExecutionResult<GenerationJob> = execution;
+    const executionJob = execution.value;
+
+    if (executionJob) {
+      let jobToPersist = terminalJobForQueueExecution(executionJob, execution, nowIso);
+      let galleryAssetIds = execution.galleryAssetIds ?? item.galleryAssetIds;
+
+      if (jobToPersist.status === "succeeded") {
+        try {
+          const imported = await importGenerationResultOutputsToGalleryState(nextState, jobToPersist, item);
+          nextState = imported.state;
+          importedGalleryAssets = imported.galleryAssets;
+          galleryAssetIds = mergeStringIds(galleryAssetIds, imported.galleryAssets.map((asset) => asset.id));
+        } catch (error) {
+          const message = normalizeError(error);
+          jobToPersist = {
+            ...jobToPersist,
+            status: "failed",
+            error: message,
+            updatedAt: nowIso
+          };
+          nextExecution = {
+            ...nextExecution,
+            status: "failed",
+            error: message,
+            errorCategory: "unknown",
+            retryable: false
+          };
+          galleryAssetIds = item.galleryAssetIds;
+          importedGalleryAssets = [];
+        }
+      }
+
+      eventJob = jobToPersist;
+      nextState = upsertJobInState(nextState, jobToPersist);
+      nextExecution = {
+        ...nextExecution,
+        historyJobId: jobToPersist.id,
+        outputAssetIds: mergeStringIds(nextExecution.outputAssetIds, jobToPersist.outputs.map((asset) => asset.id)),
+        partialAssetIds: mergeStringIds(nextExecution.partialAssetIds, jobToPersist.outputs.filter((asset) => asset.sourceType === "partial").map((asset) => asset.id)),
+        galleryAssetIds
+      };
     }
-    return mergeGalleryState(state, nextStateForImport);
+
+    const completed = completeGenerationQueueItemInQueue(queue, item, nextExecution, nowMs);
+    return {
+      state: nextState,
+      queue: completed.queue,
+      result: completed.item
+    };
   });
-  stateCache = nextState;
-  if (importedAssets.length > 0) sendGalleryEvent(nextState, "mutation");
-  return importedAssets;
+
+  if (importedGalleryAssets.length > 0) {
+    sendGalleryEvent(transaction.state, "mutation");
+  }
+  if (eventJob) {
+    if (eventJob.status === "succeeded") {
+      sendJobEvent({ jobId: eventJob.id, queueId: item.queueId, type: "completed" });
+    } else {
+      sendJobEvent({ jobId: eventJob.id, queueId: item.queueId, type: "failed", error: eventJob.error });
+    }
+  }
+
+  return transaction.result;
 }
 
 async function executeGenerationQueueItem(item: GenerationQueueItem, abortSignal: AbortSignal) {
@@ -2474,36 +2582,28 @@ async function executeGenerationQueueItem(item: GenerationQueueItem, abortSignal
       durationMs: Date.now() - startedAt,
       updatedAt: new Date().toISOString()
     };
-    await upsertJob(job);
-    const galleryAssets = job.status === "succeeded" ? await importGenerationResultOutputsToGallery(job, item) : [];
-    if (job.status === "succeeded") {
-      sendQueuedJobEvent({ jobId: job.id, queueId: item.queueId, type: "completed" });
-    } else {
-      sendQueuedJobEvent({ jobId: job.id, queueId: item.queueId, type: "failed", error: job.error });
-    }
     return {
       status: job.status === "succeeded" ? "succeeded" as const : "failed" as const,
       value: job,
       historyJobId: job.id,
       outputAssetIds: job.outputs.map((asset) => asset.id),
-      galleryAssetIds: galleryAssets.map((asset) => asset.id),
+      galleryAssetIds: item.galleryAssetIds,
       partialAssetIds: job.outputs.filter((asset) => asset.sourceType === "partial").map((asset) => asset.id),
       error: job.status === "failed" ? job.error : undefined
     };
   } catch (error) {
     const message = abortSignal.aborted ? "任务已终止。" : normalizeError(error);
+    const status = abortSignal.aborted ? "cancelled" as const : "failed" as const;
     job = {
       ...job,
-      status: "failed",
+      status,
       durationMs: Date.now() - startedAt,
       error: message,
       outputs: mergeImageAssets(job.outputs, partialAssets),
       updatedAt: new Date().toISOString()
     };
-    await upsertJob(job);
-    sendQueuedJobEvent({ jobId: job.id, queueId: item.queueId, type: "failed", error: message });
     return {
-      status: "failed" as const,
+      status,
       value: job,
       historyJobId: job.id,
       outputAssetIds: job.outputs.map((asset) => asset.id),
@@ -2562,6 +2662,7 @@ async function runQueuedGenerationForAgent(
     providerConcurrency: queueConfig.providerConcurrency,
     waitTimeoutMs,
     executeItem: executeGenerationQueueItem,
+    completeItem: completeGenerationQueueItemWithState,
     onStarted: trackQueuedGenerationStart,
     onFinished: trackQueuedGenerationFinish
   }).finally(() => {
@@ -2618,6 +2719,7 @@ async function runNextDesktopQueuedGeneration(): Promise<boolean> {
     providerConcurrency: queueConfig.providerConcurrency,
     leaseMs: DESKTOP_QUEUE_WORKER_LEASE_MS,
     executeItem: executeGenerationQueueItem,
+    completeItem: completeGenerationQueueItemWithState,
     onStarted: trackQueuedGenerationStart,
     onFinished: trackQueuedGenerationFinish
   });


### PR DESCRIPTION
## Summary
- Add a queue completion hook so worker hosts can commit terminal queue state through a shared state+queue transaction.
- Move queued generation final history updates and Gallery result imports into one transaction with queue terminal status.
- Preserve default queue behavior and add a core test for injected terminal committers.

## Verification
- pnpm test -- src/core/generationQueue.test.ts src/core/stateQueueTransaction.test.ts
- pnpm typecheck
- pnpm build
- pnpm package:dir
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery