### PR TITLE
Synchronize queue cancel and retry state

### DIFF
--- a/src/core/generationQueue.test.ts
+++ b/src/core/generationQueue.test.ts
@@ -7,7 +7,9 @@ import {
   completeGenerationQueueItemInQueue,
   recordGenerationQueuePartialOutput,
   requestGenerationQueueItemCancel,
+  requestGenerationQueueItemCancelInQueue,
   retryGenerationQueueItem,
+  retryGenerationQueueItemInQueue,
   runGenerationQueueItemToCompletion,
   runNextGenerationQueueItem
 } from "./generationQueue";
@@ -240,6 +242,32 @@ describe("generationQueue", () => {
     await removeTempDir(tempDir);
   });
 
+  it("builds queued cancel mutations without owning the queue lock", () => {
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-1"
+    });
+    const now = Date.parse("2026-01-01T00:00:00.000Z");
+    const result = requestGenerationQueueItemCancelInQueue({
+      schemaVersion: 1,
+      updatedAt: new Date(0).toISOString(),
+      workerHosts: [],
+      items: [item]
+    }, item.queueId, now);
+
+    expect(result.item).toMatchObject({
+      queueId: item.queueId,
+      historyJobId: "job-1",
+      status: "cancelled",
+      cancelRequested: true,
+      completedAt: "2026-01-01T00:00:00.000Z"
+    });
+    expect(result.queue.items[0]).toEqual(result.item);
+  });
+
   it("aborts running workers when durable cancel is requested", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-generation-queue-"));
     const queuePath = path.join(tempDir, "queue.json");
@@ -454,6 +482,49 @@ describe("generationQueue", () => {
     expect(result.item?.workerLeaseExpiresAt).toBeUndefined();
 
     await removeTempDir(tempDir);
+  });
+
+  it("builds retry mutations without owning the queue lock", () => {
+    const item = createGenerationQueueItem({
+      source: "desktop",
+      providerId: "provider-1",
+      request: request(),
+      costConfirmed: true,
+      historyJobId: "job-1"
+    });
+    const now = Date.parse("2026-01-01T00:02:00.000Z");
+    const result = retryGenerationQueueItemInQueue({
+      schemaVersion: 1,
+      updatedAt: new Date(0).toISOString(),
+      workerHosts: [],
+      items: [{
+        ...item,
+        status: "failed",
+        stage: "finalizing",
+        attempt: 2,
+        completedAt: "2026-01-01T00:00:10.000Z",
+        outputAssetIds: ["asset-old"],
+        partialAssetIds: ["partial-old"],
+        galleryAssetIds: ["gallery-old"],
+        cancelRequested: true
+      }]
+    }, "job-1", now);
+
+    expect(result.result).toMatchObject({
+      action: "retried",
+      item: {
+        queueId: item.queueId,
+        historyJobId: "job-1",
+        status: "queued",
+        attempt: 0,
+        outputAssetIds: [],
+        partialAssetIds: [],
+        galleryAssetIds: [],
+        cancelRequested: false,
+        updatedAt: "2026-01-01T00:02:00.000Z"
+      }
+    });
+    expect(result.queue.items[0]).toEqual(result.result.item);
   });
 
   it("does not retry non-terminal or succeeded items", async () => {

--- a/src/core/generationQueue.ts
+++ b/src/core/generationQueue.ts
@@ -470,78 +470,108 @@ export async function recordGenerationQueuePartialOutput(queueStore: QueueStore,
 export async function requestGenerationQueueItemCancel(queueStore: QueueStore, queueId: string, now = Date.now): Promise<GenerationQueueItem | undefined> {
   let updated: GenerationQueueItem | undefined;
   await queueStore.mutate((queue) => {
-    const nowIso = iso(now());
-    return {
-      ...queue,
-      updatedAt: nowIso,
-      items: queue.items.map((item) => {
-        if (item.queueId !== queueId) return item;
-        if (item.status === "queued") {
-          updated = {
-            ...item,
-            status: "cancelled",
-            cancelRequested: true,
-            completedAt: nowIso,
-            updatedAt: nowIso
-          };
-          return updated;
-        }
-        if (item.status === "running") {
-          updated = {
-            ...item,
-            cancelRequested: true,
-            updatedAt: nowIso
-          };
-          return updated;
-        }
-        updated = item;
-        return item;
-      })
-    };
+    const next = requestGenerationQueueItemCancelInQueue(queue, queueId, now());
+    updated = next.item;
+    return next.queue;
   });
   return updated;
+}
+
+export function requestGenerationQueueItemCancelInQueue(
+  queue: GenerationQueueFile,
+  queueId: string,
+  nowMs: number
+): { queue: GenerationQueueFile; item?: GenerationQueueItem } {
+  let updated: GenerationQueueItem | undefined;
+  const nowIso = iso(nowMs);
+  const nextQueue = {
+    ...queue,
+    updatedAt: nowIso,
+    items: queue.items.map((item) => {
+      if (item.queueId !== queueId) return item;
+      if (item.status === "queued") {
+        updated = {
+          ...item,
+          status: "cancelled",
+          cancelRequested: true,
+          completedAt: nowIso,
+          updatedAt: nowIso
+        };
+        return updated;
+      }
+      if (item.status === "running") {
+        updated = {
+          ...item,
+          cancelRequested: true,
+          updatedAt: nowIso
+        };
+        return updated;
+      }
+      updated = item;
+      return item;
+    })
+  };
+  return { queue: nextQueue, item: updated };
 }
 
 export async function retryGenerationQueueItem(queueStore: QueueStore, lookupId: string, now = Date.now): Promise<GenerationQueueRetryResult> {
   const normalizedLookupId = lookupId.trim();
   if (!normalizedLookupId) return { action: "not_found" };
+  let result: GenerationQueueRetryResult = { action: "not_found" };
+  await queueStore.mutate((queue) => {
+    const next = retryGenerationQueueItemInQueue(queue, normalizedLookupId, now());
+    result = next.result;
+    return next.queue;
+  });
+  return result;
+}
+
+export function retryGenerationQueueItemInQueue(
+  queue: GenerationQueueFile,
+  lookupId: string,
+  nowMs: number
+): { queue: GenerationQueueFile; result: GenerationQueueRetryResult } {
+  const normalizedLookupId = lookupId.trim();
+  if (!normalizedLookupId) {
+    return { queue, result: { action: "not_found" } };
+  }
+
   let found: GenerationQueueItem | undefined;
   let retried: GenerationQueueItem | undefined;
-  await queueStore.mutate((queue) => {
-    const nowIso = iso(now());
-    return {
-      ...queue,
-      updatedAt: nowIso,
-      items: queue.items.map((item) => {
-        if (item.queueId !== normalizedLookupId && item.historyJobId !== normalizedLookupId) return item;
-        found = item;
-        if (!RETRYABLE_TERMINAL_STATUSES.has(item.status)) return item;
-        retried = {
-          ...item,
-          status: "queued",
-          stage: "queued",
-          attempt: 0,
-          startedAt: undefined,
-          completedAt: undefined,
-          nextRunAt: undefined,
-          lastError: undefined,
-          lastErrorCategory: undefined,
-          lastErrorRetryable: undefined,
-          outputAssetIds: [],
-          partialAssetIds: [],
-          galleryAssetIds: [],
-          cancelRequested: false,
-          workerHostId: undefined,
-          workerProcessId: undefined,
-          workerHeartbeatAt: undefined,
-          workerLeaseExpiresAt: undefined,
-          updatedAt: nowIso
-        };
-        return retried;
-      })
-    };
-  });
-  if (retried) return { action: "retried", item: retried };
-  if (found) return { action: "not_retryable", item: found };
-  return { action: "not_found" };
+  const nowIso = iso(nowMs);
+  const nextQueue = {
+    ...queue,
+    updatedAt: nowIso,
+    items: queue.items.map((item) => {
+      if (item.queueId !== normalizedLookupId && item.historyJobId !== normalizedLookupId) return item;
+      found = item;
+      if (!RETRYABLE_TERMINAL_STATUSES.has(item.status)) return item;
+      retried = {
+        ...item,
+        status: "queued",
+        stage: "queued",
+        attempt: 0,
+        startedAt: undefined,
+        completedAt: undefined,
+        nextRunAt: undefined,
+        lastError: undefined,
+        lastErrorCategory: undefined,
+        lastErrorRetryable: undefined,
+        outputAssetIds: [],
+        partialAssetIds: [],
+        galleryAssetIds: [],
+        cancelRequested: false,
+        workerHostId: undefined,
+        workerProcessId: undefined,
+        workerHeartbeatAt: undefined,
+        workerLeaseExpiresAt: undefined,
+        updatedAt: nowIso
+      };
+      return retried;
+    })
+  };
+
+  if (retried) return { queue: nextQueue, result: { action: "retried", item: retried } };
+  if (found) return { queue: nextQueue, result: { action: "not_retryable", item: found } };
+  return { queue: nextQueue, result: { action: "not_found" } };
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -104,8 +104,8 @@ import {
 import {
   completeGenerationQueueItemInQueue,
   recordGenerationQueuePartialOutput,
-  requestGenerationQueueItemCancel,
-  retryGenerationQueueItem,
+  requestGenerationQueueItemCancelInQueue,
+  retryGenerationQueueItemInQueue,
   runGenerationQueueItemToCompletion,
   runNextGenerationQueueItem,
   type GenerationQueueExecutionResult
@@ -2538,6 +2538,90 @@ async function completeGenerationQueueItemWithState(
   return transaction.result;
 }
 
+function updateHistoryJobForQueueItem(
+  state: AppStateFile,
+  item: GenerationQueueItem,
+  updater: (job: GenerationJob) => GenerationJob
+): AppStateFile {
+  if (!item.historyJobId) return state;
+  const existing = state.history.find((job) => job.id === item.historyJobId);
+  if (!existing) return state;
+  return upsertJobInState(state, updater(existing));
+}
+
+function cancelledHistoryJob(job: GenerationJob, item: GenerationQueueItem): GenerationJob {
+  return {
+    ...job,
+    status: "cancelled",
+    error: job.error ?? "任务已取消。",
+    updatedAt: item.updatedAt
+  };
+}
+
+function queuedHistoryJobForRetry(job: GenerationJob, item: GenerationQueueItem): GenerationJob {
+  const { error: _error, durationMs: _durationMs, ...rest } = job;
+  return {
+    ...rest,
+    status: "queued",
+    updatedAt: item.updatedAt
+  };
+}
+
+async function cancelGenerationQueueItemWithState(queueId: string) {
+  const nowMs = Date.now();
+  const transaction = await mutateStateAndQueue<GenerationQueueItem | undefined>((currentState, queue) => {
+    const next = requestGenerationQueueItemCancelInQueue(queue, queueId, nowMs);
+    const cancelledItem = next.item?.status === "cancelled" ? next.item : undefined;
+    const nextState =
+      cancelledItem
+        ? updateHistoryJobForQueueItem(currentState, cancelledItem, (job) => cancelledHistoryJob(job, cancelledItem))
+        : currentState;
+    return {
+      state: nextState,
+      queue: next.queue,
+      result: next.item
+    };
+  });
+  return {
+    item: transaction.result,
+    state: transaction.state,
+    queue: transaction.queue
+  };
+}
+
+async function cancelGenerationQueueItemAndUpsertJob(queueId: string, job: GenerationJob): Promise<void> {
+  const nowMs = Date.now();
+  await mutateStateAndQueue((currentState, queue) => {
+    const next = requestGenerationQueueItemCancelInQueue(queue, queueId, nowMs);
+    return {
+      state: upsertJobInState(currentState, job),
+      queue: next.queue,
+      result: null
+    };
+  });
+}
+
+async function retryGenerationQueueItemWithState(jobId: string) {
+  const nowMs = Date.now();
+  const transaction = await mutateStateAndQueue((currentState, queue) => {
+    const next = retryGenerationQueueItemInQueue(queue, jobId, nowMs);
+    const retriedItem = next.result.action === "retried" ? next.result.item : undefined;
+    const nextState = retriedItem
+      ? updateHistoryJobForQueueItem(currentState, retriedItem, (job) => queuedHistoryJobForRetry(job, retriedItem))
+      : currentState;
+    return {
+      state: nextState,
+      queue: next.queue,
+      result: next.result
+    };
+  });
+  return {
+    ...transaction.result,
+    state: transaction.state,
+    queue: transaction.queue
+  };
+}
+
 async function executeGenerationQueueItem(item: GenerationQueueItem, abortSignal: AbortSignal) {
   const state = await readState();
   const provider = selectProviderForQueueItem(state, item);
@@ -2866,7 +2950,6 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
   }
 
   const message = result.status === "cancelled" ? "任务已终止。" : "任务等待超时。";
-  await requestGenerationQueueItemCancel(getGenerationQueueStore(), queueItem.queueId);
   job = {
     ...job,
     status: "failed",
@@ -2874,23 +2957,26 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
     error: message,
     updatedAt: new Date().toISOString()
   };
-  await upsertJob(job);
+  await cancelGenerationQueueItemAndUpsertJob(queueItem.queueId, job);
   sendJobEvent({ jobId: job.id, queueId: queueItem.queueId, type: "failed", error: message });
   queuedJobIds.delete(job.id);
   return job;
 }
 
-function handleCancelJob(jobId: string): boolean {
+async function handleCancelJob(jobId: string): Promise<boolean> {
   if (typeof jobId !== "string" || !jobId.trim()) return false;
   const queueId = queuedJobIds.get(jobId);
   const controller = runningJobControllers.get(jobId);
-  if (controller) {
-    if (queueId) void requestGenerationQueueItemCancel(getGenerationQueueStore(), queueId);
-    controller.abort();
-    return true;
-  }
   if (!queueId) return false;
-  void requestGenerationQueueItemCancel(getGenerationQueueStore(), queueId);
+  const result = await cancelGenerationQueueItemWithState(queueId);
+  if (!result.item) return false;
+  if (controller) {
+    controller.abort();
+  }
+  if (result.item.status === "cancelled") {
+    queuedJobIds.delete(jobId);
+    sendJobEvent({ jobId, queueId, type: "failed", error: "任务已取消。" });
+  }
   return true;
 }
 
@@ -3929,7 +4015,7 @@ async function cancelGenerationQueueItemForCli(queueId: string) {
   const before = queue.items.find((item) => item.queueId === queueId);
   if (!before) return null;
 
-  await requestGenerationQueueItemCancel(getGenerationQueueStore(), queueId);
+  await cancelGenerationQueueItemWithState(queueId);
   const controller = runningQueueControllers.get(queueId);
   if (controller) {
     controller.abort();
@@ -3962,11 +4048,11 @@ async function cancelGenerationQueueItemForCli(queueId: string) {
 }
 
 async function retryGenerationQueueItemForCli(jobId: string) {
-  const result = await retryGenerationQueueItem(getGenerationQueueStore(), jobId);
+  const result = await retryGenerationQueueItemWithState(jobId);
   if (result.action === "not_found") return { action: "not_found" as const };
 
   const lookupId = result.item?.queueId ?? jobId;
-  const job = buildCliJobStatus(await readExistingQueueForCli(), await readExistingStateForCli(), lookupId);
+  const job = buildCliJobStatus(result.queue, result.state, lookupId);
   if (result.action === "not_retryable") {
     return {
       action: "not_retryable" as const,


### PR DESCRIPTION
## Summary
- Add pure queue cancel/retry mutation helpers for state+queue transaction use.
- Synchronize queued cancellation and retry with history job status from Electron/CLI/MCP paths.
- Commit desktop wait timeout queue cancellation and failed history state in one transaction.

## Verification
- pnpm test -- src/core/generationQueue.test.ts src/core/stateQueueTransaction.test.ts src/mcp/stdioServer.test.ts src/cli/readonly.test.ts
- pnpm typecheck
- pnpm build
- pnpm package:dir
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm test -- src/core/generationQueue.test.ts src/mcp/stdioServer.test.ts