### PR TITLE
Add v0.3.1 release evidence gates

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -11,6 +11,13 @@ Validate the ledger after every evidence update:
 pnpm verify:release-evidence
 ```
 
+The next-release candidate ledger can be checked before the package version is
+bumped:
+
+```bash
+pnpm verify:release-evidence:v0.3.1
+```
+
 The verifier also checks guarded checklist and TODO items. External acceptance
 items must stay unchecked until their matching evidence gate is marked `passed`.
 
@@ -34,6 +41,8 @@ External gate trackers:
 
 Release-specific preparation:
 
+- `v0.3.1`: [v0.3.1-preflight.md](./v0.3.1-preflight.md)
+- `v0.3.1`: [v0.3.1-evidence.json](./v0.3.1-evidence.json)
 - `v0.3.0`: [v0.3.0-preflight.md](./v0.3.0-preflight.md)
 - `v0.3.0`: [v0.3.0-closeout.md](./v0.3.0-closeout.md)
 - `v0.3.0`: [v0.3.0-rc-macos-local-package.md](./v0.3.0-rc-macos-local-package.md)
@@ -49,3 +58,6 @@ Rules for updating evidence:
   they are explicitly approved public samples.
 - Do not change checklist items from pending to complete until the matching
   evidence gate is marked `passed` and the validator succeeds.
+- For v0.3.1, keep `docs/release/v0.3.1-evidence.json` as candidate evidence
+  until the final release branch bumps `package.json` to `0.3.1` and promotes
+  the candidate gate data to `docs/release/evidence.json`.

--- a/docs/release/v0.3.1-evidence.json
+++ b/docs/release/v0.3.1-evidence.json
@@ -1,0 +1,373 @@
+{
+  "schemaVersion": 1,
+  "releaseVersion": "0.3.1",
+  "lastUpdated": "2026-07-14T00:00:00.000Z",
+  "gates": [
+    {
+      "id": "real-openai-api",
+      "title": "Real OpenAI-compatible GPT Image 2 acceptance",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Model discovery confirms gpt-image-2 is available to the tested key on the v0.3.1 release branch.",
+        "GPT Image 2 text-to-image generation succeeds through the app-supported route.",
+        "GPT Image 2 reference-image editing succeeds through the app-supported route.",
+        "GPT Image 2 guided-region editing with a source image and mask-like reference succeeds through the app-supported route.",
+        "The tested endpoint returns savable image artifacts within the user-configured timeout.",
+        "The release evidence records the selected provider route without exposing API keys or private base URLs."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Real OpenAI GPT Image 2 external acceptance tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/1"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 real OpenAI-compatible GPT Image 2 acceptance."
+      }
+    },
+    {
+      "id": "real-gemini-api",
+      "title": "Real Gemini-compatible image acceptance",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Model discovery confirms a Gemini-compatible image model is available to the tested key on the v0.3.1 release branch.",
+        "Gemini-compatible text-to-image generation succeeds through the app-supported route.",
+        "Gemini-compatible reference-image editing succeeds through the app-supported route.",
+        "Gemini-compatible guided-region editing succeeds and is not described as exact-mask inpainting unless the provider proves exact mask support.",
+        "The tested endpoint returns savable image artifacts within the user-configured timeout.",
+        "The release evidence records the selected provider route without exposing API keys or private base URLs."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Real Gemini image external acceptance tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/102"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 real Gemini-compatible image acceptance."
+      }
+    },
+    {
+      "id": "macos-signed",
+      "title": "Developer ID signed macOS release package",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Developer ID signing is performed without exposing secret values.",
+        "macOS artifacts are built from the v0.3.1 release commit.",
+        "codesign verification passes against the signed app extracted from the release artifact.",
+        "macOS release verification passes against the signed artifact.",
+        "Apple notarization status is tracked separately in the macos-notarized gate."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Developer ID signed macOS distribution tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/3"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 Developer ID signed macOS package evidence."
+      }
+    },
+    {
+      "id": "macos-notarized",
+      "title": "Apple notarized macOS release package",
+      "required": false,
+      "status": "blocked",
+      "acceptanceCriteria": [
+        "Apple notarization credentials are available without exposing secret values.",
+        "macOS artifacts are submitted to Apple notary service successfully.",
+        "Notarization is stapled to the distributed DMG or app artifact.",
+        "spctl verification reports an accepted notarized Developer ID source."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Apple notarized macOS distribution tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/3"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Blocked until Apple notarization credentials are available in the release environment. Keep this gate separate from Developer ID signing so a signed artifact is not misreported as notarized."
+      }
+    },
+    {
+      "id": "windows-native-release",
+      "title": "Native Windows release package validation",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Windows package verifier runs against the v0.3.1 artifact.",
+        "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass in full-install evidence.",
+        "Packaged app can configure mock OpenAI-compatible and Gemini-compatible endpoints.",
+        "Download and open-folder behavior are checked on native Windows."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Native Windows release validation tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/4"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 native Windows release package validation."
+      }
+    },
+    {
+      "id": "linux-native-release",
+      "title": "CI Linux package and AppImage validation",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Linux release verifier runs in the GitHub Actions Linux package job against the v0.3.1 AppImage and unpacked Linux artifact.",
+        "Direct AppImage execution is best-effort when FUSE support is available; AppImage extraction and extracted app smoke verification cover CI environments without direct AppImage support.",
+        "The Linux package job runs the packaged CLI/MCP smoke against the packaged app.",
+        "Linux-specific release coverage focuses on package creation, AppImage verification, Linux launch smoke, and packaged command-mode behavior."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Linux package and AppImage validation tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/4"
+          },
+          {
+            "label": "CI workflow",
+            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 CI Linux package, AppImage, launch, and packaged CLI/MCP evidence."
+      }
+    },
+    {
+      "id": "update-manifest-assets",
+      "title": "Formal update manifest distribution assets",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Distribution artifacts are uploaded to a public HTTPS v0.3.1 release URL.",
+        "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata for v0.3.1.",
+        "Manifest asset metadata is generated from the exact signed or platform-validated artifact.",
+        "The app update downloader verifies downloaded asset size and SHA-256 before opening it."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Formal update manifest distribution asset tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/103"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 public release asset upload and update manifest evidence."
+      }
+    },
+    {
+      "id": "build-and-mock-verifiers",
+      "title": "Build and mock API verifier gate",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "pnpm build passes on the v0.3.1 release branch.",
+        "Mock OpenAI-compatible API verifier passes.",
+        "Mock Gemini-compatible API verifier passes.",
+        "Mock model discovery verifier passes.",
+        "The CI build job records the same verifier set for the final release commit."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          },
+          {
+            "label": "CI workflow",
+            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 build and mock API verifier evidence."
+      }
+    },
+    {
+      "id": "cli-mcp-packaged-smoke",
+      "title": "Packaged CLI and MCP smoke gate",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Packaged app command mode reports CLI version and doctor output.",
+        "Packaged CLI can list models, reject async generation without a live worker, run queue-backed generate --wait, return idempotent generation results, and report job status.",
+        "Packaged CLI can list Gallery assets, require explicit path confirmation, and export an asset.",
+        "Packaged MCP registers readonly/write/generate tools only in the requested modes.",
+        "Packaged MCP can run generate_image, edit_image, Gallery listing, and asset export against isolated mock data."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "CLI and MCP documentation",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/cli-mcp.md"
+          },
+          {
+            "label": "CI workflow",
+            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 packaged CLI and MCP smoke evidence."
+      }
+    },
+    {
+      "id": "agent-integration-smoke",
+      "title": "Agent integration smoke gate",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "crossgen mcp config emits usable snippets for Codex, Claude Code, and Cursor.",
+        "Readonly mode exposes inspection tools without write or generation tools.",
+        "Write mode exposes local Gallery mutation tools without generation tools.",
+        "Generate mode exposes generation tools only when explicit generate mode is requested.",
+        "Agent-facing JSON outputs preserve schemaVersion, requestId, data-or-error, stable error codes, and no secret or path leakage beyond explicit confirmation."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "CLI and MCP documentation",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/cli-mcp.md"
+          },
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 Codex, Claude Code, and Cursor agent integration smoke evidence."
+      }
+    },
+    {
+      "id": "queue-concurrency-smoke",
+      "title": "Durable queue concurrency smoke gate",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Default queue concurrency remains 1.",
+        "Explicit bounded concurrency 2 is honored.",
+        "Two worker hosts cannot claim the same queue item.",
+        "Stale running items recover to interrupted instead of blind retry.",
+        "Cancel and retry update queue and history consistently."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 durable queue concurrency smoke evidence."
+      }
+    },
+    {
+      "id": "gallery-mutation-smoke",
+      "title": "Gallery mutation smoke gate",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Folder create, rename, move, delete, and disk sync remain safe under the shared lock.",
+        "Asset import, update, move, remove, replace, and export remain safe under the shared lock.",
+        "Path traversal, symlink, illegal filename, and Windows reserved-name guards remain enforced.",
+        "Local path disclosure requires explicit confirmation.",
+        "Concurrent Gallery mutation smoke proves file mutation and matching state write happen in one critical section."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 Gallery mutation smoke evidence."
+      }
+    },
+    {
+      "id": "image-core-regression",
+      "title": "Desktop image workflow regression gate",
+      "required": true,
+      "status": "pending",
+      "acceptanceCriteria": [
+        "Desktop text-to-image generation remains functional.",
+        "Desktop image-to-image editing and guided-region editing remain functional.",
+        "OpenAI-compatible partial streaming remains available as a per-generation parameter and defaults off.",
+        "Gemini-compatible reference images remain functional.",
+        "Provider switching, Gallery import/move/download, and image editor save/download flows do not regress.",
+        "Manual checklist evidence records failures, blockers, and exact visible error text without secrets."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 desktop image workflow regression evidence."
+      }
+    }
+  ]
+}

--- a/docs/release/v0.3.1-preflight.md
+++ b/docs/release/v0.3.1-preflight.md
@@ -1,0 +1,128 @@
+# v0.3.1 Release Preflight
+
+Status: release planning checklist. Treat `docs/release/v0.3.1-evidence.json`
+as the candidate 0.3.1 evidence ledger until the final release branch bumps
+`package.json` and promotes the evidence to `docs/release/evidence.json`.
+
+v0.3.1 is an agent-ready local runtime release. It is not complete until a
+local agent can discover providers and models, submit generate and edit work
+through the durable queue, poll status, and manage or export Gallery assets
+without regressing the desktop image workflows.
+
+## Branch Discipline
+
+Use `origin/main` as the only source of truth. Each release fix must start from
+latest `origin/main` in its own worktree and branch, then go through PR, green
+CI, merge, local main sync, and worktree cleanup.
+
+Do not reuse old v0.3.0 release worktrees or historical UI follow-up branches as
+the v0.3.1 baseline. If a useful patch exists there, cherry-pick it into a fresh
+v0.3.1 branch and validate it again.
+
+## Candidate Evidence
+
+The candidate ledger can be validated before the version bump:
+
+```bash
+pnpm verify:release-evidence:v0.3.1
+```
+
+Before publishing v0.3.1, the final release branch must:
+
+1. Bump `package.json` to `0.3.1`.
+2. Promote the candidate gate content to `docs/release/evidence.json`.
+3. Replace pending evidence with real command output summaries, public URLs,
+   exact commit SHAs, artifact hashes, and byte sizes.
+4. Run `pnpm verify:release-evidence -- --require-complete`.
+
+## Required Commands
+
+Run from a clean v0.3.1 release worktree:
+
+```bash
+git fetch origin --prune --no-tags
+git status --short --branch
+pnpm build
+pnpm verify:mock-api
+pnpm verify:mock-gemini-api
+pnpm verify:mock-model-discovery
+pnpm verify:cli-mcp-smoke
+pnpm verify:release-evidence:v0.3.1
+```
+
+Package-level evidence must also include platform package jobs:
+
+```bash
+pnpm package:mac:signed
+pnpm package:win
+pnpm package
+```
+
+Only record a command as passed in evidence after it has actually completed on
+the intended release artifact or release branch.
+
+## Agent Acceptance
+
+Record agent-facing output only after checking that no API key, bearer token,
+private base URL, or local home-directory path is exposed.
+
+Required checks:
+
+1. `crossgen --version --json`
+2. `crossgen doctor --agent --json`
+3. `crossgen mcp config --client codex --mode readonly --json`
+4. `crossgen mcp config --client claude-code --mode readonly --json`
+5. `crossgen mcp config --client cursor --mode readonly --json`
+6. MCP readonly tool registration
+7. MCP write tool registration
+8. MCP generate tool registration
+9. CLI `generate --wait` through the queue
+10. MCP `generate_image` and `edit_image` through the queue
+11. Gallery list, export, and explicit path confirmation behavior
+
+## Image Regression Acceptance
+
+The desktop image workflow remains in scope. Record result, OS, commit SHA,
+provider category, redacted model ID when needed, exact visible error text, and
+whether the issue reproduces after restart.
+
+Required checks:
+
+1. Text-to-image generation.
+2. Image-to-image editing with one reference image.
+3. Image-to-image editing with multiple reference images.
+4. Guided-region editing with a source image and mask-like reference.
+5. OpenAI-compatible partial streaming parameter defaults off and can be
+   enabled per generation.
+6. Gemini-compatible reference image generation.
+7. Provider switching does not clear prompt text, reference images, saved keys,
+   or selected models silently.
+8. Gallery import, folder move, duplicate handling, download, and open-folder
+   behavior.
+9. Image editor save-to-Gallery, overwrite-or-save-copy, and download behavior.
+
+## Final Release Checklist
+
+- [ ] Create a clean `release/v0.3.1` branch/worktree from latest `origin/main`.
+- [ ] Confirm no preserved untracked release files need to be carried into this
+  worktree.
+- [ ] Bump `package.json` to `0.3.1`.
+- [ ] Promote `docs/release/v0.3.1-evidence.json` to
+  `docs/release/evidence.json` for the final release branch.
+- [ ] Run `pnpm build` from the v0.3.1 release branch.
+- [ ] Run `pnpm verify:mock-api`, `pnpm verify:mock-gemini-api`, and `pnpm verify:mock-model-discovery`.
+- [ ] Run packaged CLI and MCP smoke against the packaged app.
+- [ ] Run agent integration smoke for Codex, Claude Code, and Cursor configuration output.
+- [ ] Run queue concurrency smoke for default concurrency 1, explicit bounded concurrency 2, and two-host claim safety.
+- [ ] Run Gallery mutation smoke for folder, asset, export, path-confirmation, duplicate, and concurrent mutation behavior.
+- [ ] Run the image core regression checklist for generation, edit, inpaint, partial streaming, provider switching, Gallery, and editor workflows.
+- [ ] Complete real OpenAI-compatible GPT Image acceptance.
+- [ ] Complete real Gemini-compatible image acceptance.
+- [ ] Build and verify Developer ID signed macOS release assets.
+- [ ] Record Apple notarization status from actual notarization output.
+- [ ] Produce and validate native Windows release assets.
+- [ ] Produce and validate Linux release assets through CI.
+- [ ] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.
+- [ ] Run `pnpm verify:release-evidence -- --require-complete` on the final v0.3.1 release branch.
+- [ ] Create and push `v0.3.1` tag.
+- [ ] Create GitHub Release with assets matching the update manifest.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "verify:release:mac": "node scripts/verify-mac-release.mjs",
     "verify:release:windows": "node scripts/verify-windows-release.mjs",
     "verify:release-evidence": "node scripts/verify-release-evidence.mjs",
+    "verify:release-evidence:v0.3.1": "node scripts/verify-release-evidence.mjs --file docs/release/v0.3.1-evidence.json --expected-version 0.3.1",
     "verify:real-aihub-api": "node scripts/verify-real-aihub-api.mjs",
     "verify:real-api": "node scripts/verify-real-api.mjs",
     "verify:real-gemini-api": "node scripts/verify-real-gemini-api.mjs",

--- a/scripts/verify-release-evidence.mjs
+++ b/scripts/verify-release-evidence.mjs
@@ -8,7 +8,7 @@ const allowedStatuses = new Set(["pending", "passed", "failed", "blocked"]);
 // driven by its own `required` flag in the evidence file, not by this list.
 // macOS signing and notarization are tracked separately so a Developer ID signed
 // artifact is not misreported as Apple-notarized.
-const knownGateIds = [
+const baseGateIds = [
   "real-openai-api",
   "real-gemini-api",
   "macos-signed",
@@ -17,7 +17,17 @@ const knownGateIds = [
   "linux-native-release",
   "update-manifest-assets"
 ];
-const checklistGuards = [
+
+const v031GateIds = [
+  "build-and-mock-verifiers",
+  "cli-mcp-packaged-smoke",
+  "agent-integration-smoke",
+  "queue-concurrency-smoke",
+  "gallery-mutation-smoke",
+  "image-core-regression"
+];
+
+const v030ChecklistGuards = [
   {
     file: "docs/release/v0.3.0-preflight.md",
     text: "Build signed macOS assets.",
@@ -81,7 +91,137 @@ const checklistGuards = [
       "linux-native-release",
       "update-manifest-assets"
     ]
+  }
+];
+
+const v031ChecklistGuards = [
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run `pnpm build` from the v0.3.1 release branch.",
+    gateIds: ["build-and-mock-verifiers"]
   },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run `pnpm verify:mock-api`, `pnpm verify:mock-gemini-api`, and `pnpm verify:mock-model-discovery`.",
+    gateIds: ["build-and-mock-verifiers"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run packaged CLI and MCP smoke against the packaged app.",
+    gateIds: ["cli-mcp-packaged-smoke"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run agent integration smoke for Codex, Claude Code, and Cursor configuration output.",
+    gateIds: ["agent-integration-smoke"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run queue concurrency smoke for default concurrency 1, explicit bounded concurrency 2, and two-host claim safety.",
+    gateIds: ["queue-concurrency-smoke"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run Gallery mutation smoke for folder, asset, export, path-confirmation, duplicate, and concurrent mutation behavior.",
+    gateIds: ["gallery-mutation-smoke"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run the image core regression checklist for generation, edit, inpaint, partial streaming, provider switching, Gallery, and editor workflows.",
+    gateIds: ["image-core-regression"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Complete real OpenAI-compatible GPT Image acceptance.",
+    gateIds: ["real-openai-api"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Complete real Gemini-compatible image acceptance.",
+    gateIds: ["real-gemini-api"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Build and verify Developer ID signed macOS release assets.",
+    gateIds: ["macos-signed"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Record Apple notarization status from actual notarization output.",
+    gateIds: ["macos-notarized"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Produce and validate native Windows release assets.",
+    gateIds: ["windows-native-release"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Produce and validate Linux release assets through CI.",
+    gateIds: ["linux-native-release"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.",
+    gateIds: ["update-manifest-assets"]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Run `pnpm verify:release-evidence -- --require-complete` on the final v0.3.1 release branch.",
+    gateIds: [
+      "real-openai-api",
+      "real-gemini-api",
+      "macos-signed",
+      "windows-native-release",
+      "linux-native-release",
+      "update-manifest-assets",
+      "build-and-mock-verifiers",
+      "cli-mcp-packaged-smoke",
+      "agent-integration-smoke",
+      "queue-concurrency-smoke",
+      "gallery-mutation-smoke",
+      "image-core-regression"
+    ]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Create and push `v0.3.1` tag.",
+    gateIds: [
+      "real-openai-api",
+      "real-gemini-api",
+      "macos-signed",
+      "windows-native-release",
+      "linux-native-release",
+      "update-manifest-assets",
+      "build-and-mock-verifiers",
+      "cli-mcp-packaged-smoke",
+      "agent-integration-smoke",
+      "queue-concurrency-smoke",
+      "gallery-mutation-smoke",
+      "image-core-regression"
+    ]
+  },
+  {
+    file: "docs/release/v0.3.1-preflight.md",
+    text: "Create GitHub Release with assets matching the update manifest.",
+    gateIds: [
+      "real-openai-api",
+      "real-gemini-api",
+      "macos-signed",
+      "windows-native-release",
+      "linux-native-release",
+      "update-manifest-assets",
+      "build-and-mock-verifiers",
+      "cli-mcp-packaged-smoke",
+      "agent-integration-smoke",
+      "queue-concurrency-smoke",
+      "gallery-mutation-smoke",
+      "image-core-regression"
+    ]
+  }
+];
+
+const commonChecklistGuards = [
   {
     file: "CHECKLIST.md",
     text: "仅输入 prompt 生成一张图（需真实 API Key）",
@@ -154,18 +294,54 @@ const checklistGuards = [
   }
 ];
 
+function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3])
+  };
+}
+
+function isAtLeastVersion(value, minimum) {
+  const current = parseVersion(value);
+  const target = parseVersion(minimum);
+  if (!current || !target) return false;
+  for (const key of ["major", "minor", "patch"]) {
+    if (current[key] > target[key]) return true;
+    if (current[key] < target[key]) return false;
+  }
+  return true;
+}
+
+function knownGateIdsForRelease(releaseVersion) {
+  if (isAtLeastVersion(releaseVersion, "0.3.1")) {
+    return [...baseGateIds, ...v031GateIds];
+  }
+  return baseGateIds;
+}
+
+function checklistGuardsForRelease(releaseVersion) {
+  if (isAtLeastVersion(releaseVersion, "0.3.1")) {
+    return [...v031ChecklistGuards, ...commonChecklistGuards];
+  }
+  return [...v030ChecklistGuards, ...commonChecklistGuards];
+}
+
 function usage() {
   return [
     "Usage:",
-    "  node scripts/verify-release-evidence.mjs [--file <path>] [--require-complete]",
+    "  node scripts/verify-release-evidence.mjs [--file <path>] [--expected-version <version>] [--require-complete]",
     "",
     "Validates docs/release/evidence.json. By default pending required gates are allowed.",
+    "When --expected-version is omitted, package.json version is required.",
     "Use --require-complete before publishing a release."
   ].join("\n");
 }
 
 function parseArgs(argv) {
-  const args = { file: defaultEvidenceFile, requireComplete: false };
+  const args = { file: defaultEvidenceFile, expectedVersion: null, requireComplete: false };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--") continue;
@@ -179,6 +355,15 @@ function parseArgs(argv) {
         throw new Error(`Missing value for --file.\n${usage()}`);
       }
       args.file = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--expected-version") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`Missing value for --expected-version.\n${usage()}`);
+      }
+      args.expectedVersion = value;
       index += 1;
       continue;
     }
@@ -341,20 +526,22 @@ function validateEvidence(evidence, label, status) {
   }
 }
 
-function validateLedger(ledger, packageJson, { requireComplete }) {
+function validateLedger(ledger, expectedVersion, { requireComplete }) {
   assertObject(ledger, "release evidence");
   if (ledger.schemaVersion !== 1) {
     throw new Error("release evidence schemaVersion must be 1.");
   }
   assertNonEmptyString(ledger.releaseVersion, "release evidence releaseVersion");
-  if (ledger.releaseVersion !== packageJson.version) {
-    throw new Error(`release evidence releaseVersion ${ledger.releaseVersion} does not match package version ${packageJson.version}.`);
+  assertNonEmptyString(expectedVersion, "expected release version");
+  if (ledger.releaseVersion !== expectedVersion) {
+    throw new Error(`release evidence releaseVersion ${ledger.releaseVersion} does not match expected version ${expectedVersion}.`);
   }
   assertIsoTimestamp(ledger.lastUpdated, "release evidence lastUpdated");
   if (!Array.isArray(ledger.gates)) {
     throw new Error("release evidence gates must be an array.");
   }
 
+  const knownGateIds = knownGateIdsForRelease(ledger.releaseVersion);
   const gatesById = new Map();
   for (const [index, gate] of ledger.gates.entries()) {
     const label = `release evidence gates[${index}]`;
@@ -396,8 +583,9 @@ function validateLedger(ledger, packageJson, { requireComplete }) {
   };
 }
 
-async function validateChecklistAlignment(gatesById) {
+async function validateChecklistAlignment(gatesById, releaseVersion) {
   const fileCache = new Map();
+  const checklistGuards = checklistGuardsForRelease(releaseVersion);
   for (const guard of checklistGuards) {
     if (!fileCache.has(guard.file)) {
       fileCache.set(guard.file, await readFile(path.resolve(guard.file), "utf8"));
@@ -431,9 +619,10 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const evidencePath = path.resolve(args.file);
   const packageJson = await readJson(path.resolve("package.json"));
+  const expectedVersion = args.expectedVersion ?? packageJson.version;
   const ledger = await readJson(evidencePath);
-  const result = validateLedger(ledger, packageJson, { requireComplete: args.requireComplete });
-  await validateChecklistAlignment(result.gatesById);
+  const result = validateLedger(ledger, expectedVersion, { requireComplete: args.requireComplete });
+  await validateChecklistAlignment(result.gatesById, ledger.releaseVersion);
 
   console.log(`Release evidence validated: ${result.passedRequiredCount}/${result.requiredCount} required gate(s) passed.`);
   if (result.incompleteRequiredGates.length > 0) {

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -8,7 +8,12 @@ import { describe, expect, it } from "vitest";
 
 const scriptPath = path.resolve("scripts/verify-release-evidence.mjs");
 const execFileAsync = promisify(execFile);
-const checklistFiles = ["CHECKLIST.md", "MULTI_MODEL_CHECKLIST.md", "docs/release/v0.3.0-preflight.md"];
+const checklistFiles = [
+  "CHECKLIST.md",
+  "MULTI_MODEL_CHECKLIST.md",
+  "docs/release/v0.3.0-preflight.md",
+  "docs/release/v0.3.1-preflight.md"
+];
 
 async function run(args, options = {}) {
   try {
@@ -122,6 +127,31 @@ describe("release evidence verifier", () => {
     }
   });
 
+  it("validates the v0.3.1 candidate evidence ledger against the target version", async () => {
+    const result = await run(["--file", "docs/release/v0.3.1-evidence.json", "--expected-version", "0.3.1"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Release evidence validated: 0/12 required gate(s) passed.");
+    expect(result.stdout).toContain("Pending required gate(s):");
+    expect(result.stdout).toContain("cli-mcp-packaged-smoke");
+    expect(result.stdout).toContain("image-core-regression");
+  });
+
+  it("fails --require-complete for the pending v0.3.1 candidate evidence ledger", async () => {
+    const result = await run([
+      "--file",
+      "docs/release/v0.3.1-evidence.json",
+      "--expected-version",
+      "0.3.1",
+      "--require-complete"
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Required release evidence gates are not passed");
+    expect(result.stderr).toContain("build-and-mock-verifiers");
+    expect(result.stderr).toContain("gallery-mutation-smoke");
+  });
+
   it("rejects secret-looking values in evidence", async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), "image2tools-release-evidence-"));
     try {
@@ -181,6 +211,45 @@ describe("release evidence verifier", () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("Record Apple notarization status from actual notarization output.");
       expect(result.stderr).toContain("macos-notarized");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects v0.3.1 preflight completion before matching candidate evidence passes", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "image2tools-release-evidence-"));
+    try {
+      await copyChecklistFixture(tempRoot);
+      await copyFile(path.resolve("package.json"), path.join(tempRoot, "package.json"));
+      const scriptsDir = path.join(tempRoot, "scripts");
+      await mkdir(scriptsDir, { recursive: true });
+      await copyFile(scriptPath, path.join(scriptsDir, "verify-release-evidence.mjs"));
+
+      const docsReleaseDir = path.join(tempRoot, "docs", "release");
+      await mkdir(docsReleaseDir, { recursive: true });
+      await copyFile(
+        path.resolve("docs/release/v0.3.1-evidence.json"),
+        path.join(docsReleaseDir, "v0.3.1-evidence.json")
+      );
+
+      const checklistPath = path.join(tempRoot, "docs", "release", "v0.3.1-preflight.md");
+      const checklist = await readFile(checklistPath, "utf8");
+      await writeFile(
+        checklistPath,
+        checklist.replace(
+          "- [ ] Run packaged CLI and MCP smoke against the packaged app.",
+          "- [x] Run packaged CLI and MCP smoke against the packaged app."
+        )
+      );
+
+      const result = await run(
+        ["--file", "docs/release/v0.3.1-evidence.json", "--expected-version", "0.3.1"],
+        { cwd: tempRoot }
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Run packaged CLI and MCP smoke against the packaged app.");
+      expect(result.stderr).toContain("cli-mcp-packaged-smoke");
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add a v0.3.1 candidate release evidence ledger with explicit CLI/MCP, agent, queue, Gallery, image regression, platform, and real-provider gates
- extend the release evidence verifier with version-targeted gate sets and --expected-version for pre-bump candidate validation
- add v0.3.1 preflight docs plus tests guarding checklist completion against missing evidence

## Validation
- pnpm verify:release-evidence
- pnpm verify:release-evidence -- --require-complete
- pnpm verify:release-evidence:v0.3.1
- pnpm exec vitest run scripts/verify-release-evidence.test.mjs
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm verify:cli-mcp-smoke