### PR TITLE
Add queue and Gallery release smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Verify mock model discovery
         run: pnpm verify:mock-model-discovery
 
+      - name: Verify queue concurrency smoke
+        run: pnpm verify:queue-concurrency-smoke
+
+      - name: Verify Gallery mutation smoke
+        run: pnpm verify:gallery-mutation-smoke
+
   mac-package:
     name: macOS package
     runs-on: macos-latest

--- a/docs/release/v0.3.1-evidence.json
+++ b/docs/release/v0.3.1-evidence.json
@@ -293,6 +293,7 @@
       "required": true,
       "status": "pending",
       "acceptanceCriteria": [
+        "pnpm verify:queue-concurrency-smoke passes on the v0.3.1 release branch.",
         "Default queue concurrency remains 1.",
         "Explicit bounded concurrency 2 is honored.",
         "Two worker hosts cannot claim the same queue item.",
@@ -320,6 +321,7 @@
       "required": true,
       "status": "pending",
       "acceptanceCriteria": [
+        "pnpm verify:gallery-mutation-smoke passes on the v0.3.1 release branch.",
         "Folder create, rename, move, delete, and disk sync remain safe under the shared lock.",
         "Asset import, update, move, remove, replace, and export remain safe under the shared lock.",
         "Path traversal, symlink, illegal filename, and Windows reserved-name guards remain enforced.",

--- a/docs/release/v0.3.1-preflight.md
+++ b/docs/release/v0.3.1-preflight.md
@@ -47,6 +47,8 @@ pnpm verify:mock-api
 pnpm verify:mock-gemini-api
 pnpm verify:mock-model-discovery
 pnpm verify:cli-mcp-smoke
+pnpm verify:queue-concurrency-smoke
+pnpm verify:gallery-mutation-smoke
 pnpm verify:release-evidence:v0.3.1
 ```
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "verify:mock-model-discovery": "node scripts/verify-mock-model-discovery.mjs",
     "verify:mock-api": "node scripts/verify-mock-api.mjs",
     "verify:cli-mcp-smoke": "pnpm build:main && node scripts/verify-cli-mcp-smoke.mjs",
+    "verify:queue-concurrency-smoke": "vitest run src/core/queueStore.test.ts src/core/generationQueue.test.ts",
+    "verify:gallery-mutation-smoke": "vitest run src/core/gallery.test.ts src/core/stateQueueTransaction.test.ts src/main/services/galleryDiskSync.test.ts",
     "verify:release:linux": "node scripts/verify-linux-release.mjs",
     "verify:release:mac": "node scripts/verify-mac-release.mjs",
     "verify:release:windows": "node scripts/verify-windows-release.mjs",

--- a/src/core/queueStore.test.ts
+++ b/src/core/queueStore.test.ts
@@ -119,6 +119,81 @@ describe("queueStore", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  it("keeps release default concurrency at one claim", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({
+      queuePath,
+      lockPath: `${queuePath}.lock`,
+      now: () => Date.parse("2026-07-13T00:00:00.000Z"),
+      staleRunningAfterMs: 30000,
+      leaseMs: 30000
+    });
+
+    await store.appendItem(queueItem({ queueId: "queue-1", providerId: "provider-1" }));
+    await store.appendItem(queueItem({ queueId: "queue-2", providerId: "provider-2" }));
+
+    const claimed = await store.claimRunnableItems({
+      host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+      limit: 2,
+      maxGlobalRunning: 1
+    });
+
+    expect(claimed.map((item) => item.queueId)).toEqual(["queue-1"]);
+    const queue = await store.read();
+    expect(queue.items.map((item) => [item.queueId, item.status])).toEqual([
+      ["queue-1", "running"],
+      ["queue-2", "queued"]
+    ]);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("serializes concurrent claims so two hosts cannot claim the same item", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const store = createQueueStore({
+      queuePath,
+      lockPath: `${queuePath}.lock`,
+      now: () => Date.parse("2026-07-13T00:00:00.000Z"),
+      staleRunningAfterMs: 30000,
+      leaseMs: 30000
+    });
+
+    await store.appendItem(queueItem({ queueId: "queue-shared", providerId: "provider-1" }));
+
+    const [hostOne, hostTwo] = await Promise.all([
+      store.claimRunnableItems({
+        host: { hostId: "host-1", kind: "desktop", processId: process.pid },
+        limit: 1,
+        queueId: "queue-shared",
+        maxGlobalRunning: 2
+      }),
+      store.claimRunnableItems({
+        host: { hostId: "host-2", kind: "mcp", processId: process.pid },
+        limit: 1,
+        queueId: "queue-shared",
+        maxGlobalRunning: 2
+      })
+    ]);
+
+    const claimed = [...hostOne, ...hostTwo];
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0].queueId).toBe("queue-shared");
+    expect(["host-1", "host-2"]).toContain(claimed[0].workerHostId);
+
+    const queue = await store.read();
+    expect(queue.items).toHaveLength(1);
+    expect(queue.items[0]).toMatchObject({
+      queueId: "queue-shared",
+      status: "running",
+      attempt: 1
+    });
+    expect(["host-1", "host-2"]).toContain(queue.items[0].workerHostId);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
   it("can claim a specific queued item by id", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
     const queuePath = path.join(tempDir, "queue.json");

--- a/src/core/stateQueueTransaction.test.ts
+++ b/src/core/stateQueueTransaction.test.ts
@@ -1,14 +1,20 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { importGalleryAssets } from "./gallery";
 import { createQueueStore } from "./queueStore";
 import { withStateQueueTransaction } from "./stateQueueTransaction";
-import type { GenerationQueueItem } from "../shared/types";
+import type { GalleryAsset, GalleryFolder, GenerationQueueItem } from "../shared/types";
 
 interface TestState {
   version: number;
   history: string[];
+}
+
+interface GallerySmokeState {
+  galleryFolders: GalleryFolder[];
+  galleryAssets: GalleryAsset[];
 }
 
 function queueItem(queueId: string): GenerationQueueItem {
@@ -147,6 +153,74 @@ describe("stateQueueTransaction", () => {
     await transaction;
     await append;
     expect((await queueStore.read()).items.map((item) => item.queueId)).toEqual(["queue-after"]);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("serializes concurrent Gallery mutations without losing state or files", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-gallery-tx-"));
+    const statePath = path.join(tempDir, "state.json");
+    const queuePath = path.join(tempDir, "queue.json");
+    const lockPath = path.join(tempDir, ".crossgen-state.lock");
+    const galleryDir = path.join(tempDir, "gallery");
+    const sourceOne = path.join(tempDir, "source-one.png");
+    const sourceTwo = path.join(tempDir, "source-two.png");
+    await writeFile(sourceOne, "image-one");
+    await writeFile(sourceTwo, "image-two");
+
+    const transactionOptions = {
+      lockPath,
+      queuePath,
+      state: {
+        statePath,
+        backupPath: `${statePath}.bak`,
+        defaultState: { galleryFolders: [], galleryAssets: [] },
+        normalize: (value: unknown) => {
+          const raw = value as Partial<GallerySmokeState> | null | undefined;
+          return {
+            galleryFolders: Array.isArray(raw?.galleryFolders) ? raw.galleryFolders : [],
+            galleryAssets: Array.isArray(raw?.galleryAssets) ? raw.galleryAssets : []
+          };
+        }
+      }
+    };
+
+    async function importInsideTransaction(sourcePath: string, assetId: string, contentLabel: string): Promise<string> {
+      const transaction = await withStateQueueTransaction<GallerySmokeState, string>(
+        transactionOptions,
+        async (context) => {
+          const imported = await importGalleryAssets(
+            context.state,
+            {
+              galleryDir,
+              now: () => "2026-07-14T00:00:00.000Z",
+              createAssetId: () => assetId
+            },
+            [sourcePath],
+            null,
+            { tags: [contentLabel] }
+          );
+          context.setState(imported.state);
+          return imported.result.assets[0]?.id ?? "";
+        }
+      );
+      return transaction.result;
+    }
+
+    const [assetOne, assetTwo] = await Promise.all([
+      importInsideTransaction(sourceOne, "asset-one", "one"),
+      importInsideTransaction(sourceTwo, "asset-two", "two")
+    ]);
+
+    expect([assetOne, assetTwo].sort()).toEqual(["asset-one", "asset-two"]);
+    const final = await withStateQueueTransaction<GallerySmokeState, GallerySmokeState>(
+      transactionOptions,
+      (context) => context.state
+    );
+    expect(final.state.galleryAssets.map((asset) => asset.id).sort()).toEqual(["asset-one", "asset-two"]);
+    expect(final.state.galleryAssets.map((asset) => asset.originalName).sort()).toEqual(["source-one.png", "source-two.png"]);
+    await expect(readFile(path.join(galleryDir, "source-one.png"), "utf8")).resolves.toBe("image-one");
+    await expect(readFile(path.join(galleryDir, "source-two.png"), "utf8")).resolves.toBe("image-two");
 
     await rm(tempDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- add explicit release smoke scripts for durable queue concurrency and Gallery mutation coverage
- wire both smoke scripts into the CI build job
- strengthen queue claim tests for default concurrency 1 and concurrent two-host claim safety
- add a shared-lock Gallery transaction test proving concurrent imports preserve both state and files
- reference the new smoke commands in v0.3.1 release preflight and candidate evidence

## Validation
- pnpm verify:queue-concurrency-smoke
- pnpm verify:gallery-mutation-smoke
- pnpm verify:release-evidence:v0.3.1
- pnpm build
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery