### PR TITLE
Add image core regression smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Verify Gallery mutation smoke
         run: pnpm verify:gallery-mutation-smoke
 
+      - name: Verify image core regression smoke
+        run: pnpm verify:image-core-regression-smoke
+
   mac-package:
     name: macOS package
     runs-on: macos-latest

--- a/docs/release/v0.3.1-image-core-regression.md
+++ b/docs/release/v0.3.1-image-core-regression.md
@@ -1,0 +1,38 @@
+# v0.3.1 Image Core Regression Smoke
+
+This candidate smoke is the automated release gate for the desktop image
+workflow regression checklist. It does not replace final real-provider
+acceptance; it proves that the desktop UI, provider adapters, image editor, and
+Gallery contracts still behave correctly under deterministic mock coverage.
+
+Run:
+
+```bash
+pnpm verify:image-core-regression-smoke
+```
+
+Coverage map:
+
+| Preflight item | Automated coverage |
+| --- | --- |
+| Text-to-image generation | `src/renderer/App.smoke.test.tsx`; `src/main/services/openaiImage.test.ts`; `src/main/services/geminiImageAdapter.test.ts` |
+| Image-to-image editing with one reference image | `src/renderer/App.smoke.test.tsx`; `src/main/services/openaiImage.test.ts`; `src/main/services/geminiImageAdapter.test.ts` |
+| Image-to-image editing with multiple reference images | `src/main/services/openaiImage.test.ts`; `src/renderer/App.smoke.test.tsx` Gallery reference chip tests |
+| Guided-region editing with a source image and mask-like reference | `src/main/services/openaiImage.test.ts`; `src/main/services/geminiImageAdapter.test.ts` |
+| OpenAI-compatible partial streaming defaults off and per-generation enablement | `src/renderer/App.smoke.test.tsx`; `src/main/services/openaiImage.test.ts` |
+| Gemini-compatible reference image generation | `src/renderer/App.smoke.test.tsx`; `src/main/services/geminiImageAdapter.test.ts` |
+| Provider switching preserves prompt text, references, saved keys, and selected models | `src/renderer/App.smoke.test.tsx` provider-switch and API config tests |
+| Gallery import, folder move, duplicate handling, download, and open-folder behavior | `src/core/gallery.test.ts`; `src/main/services/galleryDiskSync.test.ts`; `src/renderer/App.smoke.test.tsx` |
+| Image editor save-to-Gallery, overwrite-or-save-copy, and download behavior | `src/renderer/App.smoke.test.tsx` editor save/download/composited preview tests |
+
+Release evidence rules:
+
+- Record this gate as candidate evidence only after the command passes locally
+  and the CI `Verify image core regression smoke` step passes on the same
+  branch or final release commit.
+- Keep real OpenAI-compatible and real Gemini-compatible API acceptance in
+  their own gates. This smoke uses deterministic mock coverage and should not be
+  cited as proof that a live provider returned images.
+- If any visible UI failure is found during manual release testing, record the
+  exact visible error text and keep `image-core-regression` pending until the
+  failing workflow is fixed and this smoke is rerun.

--- a/docs/release/v0.3.1-preflight.md
+++ b/docs/release/v0.3.1-preflight.md
@@ -55,6 +55,7 @@ pnpm verify:cli-mcp-smoke
 pnpm verify:agent-integration-smoke
 pnpm verify:queue-concurrency-smoke
 pnpm verify:gallery-mutation-smoke
+pnpm verify:image-core-regression-smoke
 pnpm verify:release-evidence:v0.3.1
 ```
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "verify:agent-integration-smoke": "pnpm build:main && node scripts/verify-agent-integration-smoke.mjs",
     "verify:queue-concurrency-smoke": "vitest run src/core/queueStore.test.ts src/core/generationQueue.test.ts",
     "verify:gallery-mutation-smoke": "vitest run src/core/gallery.test.ts src/core/stateQueueTransaction.test.ts src/main/services/galleryDiskSync.test.ts",
+    "verify:image-core-regression-smoke": "vitest run src/renderer/App.smoke.test.tsx src/main/services/openaiImage.test.ts src/main/services/geminiImageAdapter.test.ts src/core/gallery.test.ts src/main/services/galleryDiskSync.test.ts",
     "verify:release:linux": "node scripts/verify-linux-release.mjs",
     "verify:release:mac": "node scripts/verify-mac-release.mjs",
     "verify:release:windows": "node scripts/verify-windows-release.mjs",


### PR DESCRIPTION
## Summary\n- adds a dedicated v0.3.1 image-core regression smoke command\n- wires the smoke into CI after queue and Gallery smoke gates\n- documents the coverage map from the preflight image workflow checklist to renderer/provider/Gallery tests\n\n## Validation\n- pnpm install --frozen-lockfile\n- pnpm verify:image-core-regression-smoke\n- pnpm verify:release-evidence:v0.3.1\n- pnpm build\n- git diff --check\n\n## Notes\n- this does not mark the image-core-regression release evidence gate passed yet; the gate should be recorded after CI proves this new smoke on main or the final release branch\n- real OpenAI/Gemini API gates remain separate and still require explicit cost-acceptance environment variables