### PR TITLE
Record image core regression release evidence

### DIFF
--- a/docs/release/v0.3.1-evidence.json
+++ b/docs/release/v0.3.1-evidence.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "releaseVersion": "0.3.1",
-  "lastUpdated": "2026-07-14T00:15:21.000Z",
+  "lastUpdated": "2026-07-14T00:46:38.000Z",
   "gates": [
     {
       "id": "real-openai-api",
@@ -442,7 +442,7 @@
       "id": "image-core-regression",
       "title": "Desktop image workflow regression gate",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Desktop text-to-image generation remains functional.",
         "Desktop image-to-image editing and guided-region editing remain functional.",
@@ -452,18 +452,42 @@
         "Manual checklist evidence records failures, blockers, and exact visible error text without secrets."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T00:46:38.000Z",
+        "commit": "1b8d08c77d69ece4bcf1576175ec605af55c9cf7",
+        "environment": "Local macOS candidate verification plus GitHub Actions main CI run 29296515328.",
+        "commands": [
+          "pnpm verify:image-core-regression-smoke",
+          "pnpm verify:release-evidence:v0.3.1",
+          "pnpm build"
+        ],
         "references": [
           {
             "label": "v0.3.1 plan",
             "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          },
+          {
+            "label": "Image core regression smoke documentation",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/release/v0.3.1-image-core-regression.md"
+          },
+          {
+            "label": "main CI run 29296515328",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29296515328"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 desktop image workflow regression evidence."
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: pnpm verify:image-core-regression-smoke",
+            "description": "Local image core regression smoke passed: 5 test files and 175 tests covering desktop generation, edit, guided-region edit, partial streaming parameter behavior, provider switching, Gallery workflows, and editor save/download contracts."
+          },
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29296515328",
+            "public": true,
+            "description": "Merge-to-main CI build job ran Verify image core regression smoke successfully for commit 1b8d08c77d69ece4bcf1576175ec605af55c9cf7."
+          }
+        ],
+        "summary": "Candidate image-core regression smoke gate passed on commit 1b8d08c77d69ece4bcf1576175ec605af55c9cf7. This evidence is deterministic mock coverage only; real OpenAI-compatible and Gemini-compatible provider acceptance remain separate pending gates."
       }
     }
   ]

--- a/docs/release/v0.3.1-preflight.md
+++ b/docs/release/v0.3.1-preflight.md
@@ -30,7 +30,8 @@ pnpm verify:release-evidence:v0.3.1
 Current candidate automated gate progress:
 
 - Passed on `8fdc68741de2b5319189e1faa9c36f501e99a207`: build and mock verifiers, packaged CLI/MCP smoke, agent integration smoke, queue concurrency smoke, and Gallery mutation smoke.
-- Still pending and must not be marked complete without fresh release evidence: real OpenAI-compatible acceptance, real Gemini-compatible acceptance, Developer ID signed macOS artifacts, native Windows artifacts, Linux v0.3.1 release artifacts, public update manifest assets, and desktop image workflow regression evidence.
+- Passed on `1b8d08c77d69ece4bcf1576175ec605af55c9cf7`: desktop image workflow regression smoke.
+- Still pending and must not be marked complete without fresh release evidence: real OpenAI-compatible acceptance, real Gemini-compatible acceptance, Developer ID signed macOS artifacts, native Windows artifacts, Linux v0.3.1 release artifacts, and public update manifest assets.
 
 Before publishing v0.3.1, the final release branch must:
 

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -131,10 +131,11 @@ describe("release evidence verifier", () => {
     const result = await run(["--file", "docs/release/v0.3.1-evidence.json", "--expected-version", "0.3.1"]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 5/12 required gate(s) passed.");
+    expect(result.stdout).toContain("Release evidence validated: 6/12 required gate(s) passed.");
     expect(result.stdout).toContain("Pending required gate(s):");
     expect(result.stdout).toContain("real-openai-api");
-    expect(result.stdout).toContain("image-core-regression");
+    expect(result.stdout).toContain("update-manifest-assets");
+    expect(result.stdout).not.toContain("image-core-regression");
   });
 
   it("fails --require-complete for the pending v0.3.1 candidate evidence ledger", async () => {
@@ -149,7 +150,8 @@ describe("release evidence verifier", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Required release evidence gates are not passed");
     expect(result.stderr).toContain("real-openai-api");
-    expect(result.stderr).toContain("image-core-regression");
+    expect(result.stderr).toContain("update-manifest-assets");
+    expect(result.stderr).not.toContain("image-core-regression");
   });
 
   it("rejects secret-looking values in evidence", async () => {
@@ -237,8 +239,8 @@ describe("release evidence verifier", () => {
       await writeFile(
         checklistPath,
         checklist.replace(
-          "- [ ] Run the image core regression checklist for generation, edit, inpaint, partial streaming, provider switching, Gallery, and editor workflows.",
-          "- [x] Run the image core regression checklist for generation, edit, inpaint, partial streaming, provider switching, Gallery, and editor workflows."
+          "- [ ] Complete real OpenAI-compatible GPT Image acceptance.",
+          "- [x] Complete real OpenAI-compatible GPT Image acceptance."
         )
       );
 
@@ -248,8 +250,8 @@ describe("release evidence verifier", () => {
       );
 
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain("Run the image core regression checklist");
-      expect(result.stderr).toContain("image-core-regression");
+      expect(result.stderr).toContain("Complete real OpenAI-compatible GPT Image acceptance.");
+      expect(result.stderr).toContain("real-openai-api");
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- mark the v0.3.1 image-core regression gate as passed using PR #192/main CI evidence
- update candidate preflight progress to 6/12 required gates passed
- adjust release evidence verifier tests for the remaining pending gates

## Verification
- pnpm install --frozen-lockfile
- pnpm exec vitest run scripts/verify-release-evidence.test.mjs
- pnpm verify:release-evidence:v0.3.1
- pnpm verify:image-core-regression-smoke
- pnpm build
- git diff --check