### PR TITLE
Record v0.3.1 real aggregation API evidence

### DIFF
--- a/docs/release/v0.3.1-evidence.json
+++ b/docs/release/v0.3.1-evidence.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "releaseVersion": "0.3.1",
-  "lastUpdated": "2026-07-14T00:46:38.000Z",
+  "lastUpdated": "2026-07-14T01:08:53.589Z",
   "gates": [
     {
       "id": "real-openai-api",
       "title": "Real OpenAI-compatible GPT Image 2 acceptance",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Model discovery confirms gpt-image-2 is available to the tested key on the v0.3.1 release branch.",
         "GPT Image 2 text-to-image generation succeeds through the app-supported route.",
@@ -17,25 +17,44 @@
         "The release evidence records the selected provider route without exposing API keys or private base URLs."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T01:08:53.589Z",
+        "commit": "d7bb464a353b9fa88a05f64014bf09816a23faa5",
+        "environment": "macOS local release gate using an OpenAI-compatible aggregation endpoint through the app-supported chat-completions streaming route. API keys and the private base URL were loaded from local .env.local and are redacted from committed evidence.",
+        "commands": [
+          "set -a; . .env.local; set +a",
+          "IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api"
+        ],
         "references": [
           {
             "label": "Real OpenAI GPT Image 2 external acceptance tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/1"
+          },
+          {
+            "label": "v0.3.1 real aggregation API gate",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/release/v0.3.1-real-aggregation-api-gate.md"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 real OpenAI-compatible GPT Image 2 acceptance."
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api",
+            "description": "The real aggregation verifier passed after model discovery and returned savable GPT Image 2 images for text-to-image, reference-image editing, and guided-region editing."
+          },
+          {
+            "kind": "local-directory",
+            "path": "real-api-artifacts/aihub/2026-07-14T01-06-20-214Z/",
+            "public": false,
+            "description": "Local generated-image artifacts and uncommitted summary for v0.3.1 real-provider acceptance. OpenAI outputs: openai-generation-212c81621d5b.png, openai-reference-edit-23da564b005b.png, openai-guided-region-edit-e37372c122f4.png."
+          }
+        ],
+        "summary": "Passed via the app-supported chat-completions streaming route on an OpenAI-compatible aggregation endpoint. Model discovery confirmed gpt-image-2, and text-to-image, reference-image editing, and guided-region editing all returned savable PNG images within the explicit 420000ms release-test timeout. API keys and the private base URL are not recorded."
       }
     },
     {
       "id": "real-gemini-api",
       "title": "Real Gemini-compatible image acceptance",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Model discovery confirms a Gemini-compatible image model is available to the tested key on the v0.3.1 release branch.",
         "Gemini-compatible text-to-image generation succeeds through the app-supported route.",
@@ -45,18 +64,37 @@
         "The release evidence records the selected provider route without exposing API keys or private base URLs."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T01:08:53.589Z",
+        "commit": "d7bb464a353b9fa88a05f64014bf09816a23faa5",
+        "environment": "macOS local release gate using an OpenAI-compatible aggregation endpoint through the app-supported chat-completions streaming route. API keys and the private base URL were loaded from local .env.local and are redacted from committed evidence.",
+        "commands": [
+          "set -a; . .env.local; set +a",
+          "IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api"
+        ],
         "references": [
           {
             "label": "Real Gemini image external acceptance tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/102"
+          },
+          {
+            "label": "v0.3.1 real aggregation API gate",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/release/v0.3.1-real-aggregation-api-gate.md"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 real Gemini-compatible image acceptance."
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api",
+            "description": "The real aggregation verifier passed after model discovery and returned savable Gemini-compatible images for text-to-image, reference-image editing, and guided-region editing."
+          },
+          {
+            "kind": "local-directory",
+            "path": "real-api-artifacts/aihub/2026-07-14T01-06-20-214Z/",
+            "public": false,
+            "description": "Local generated-image artifacts and uncommitted summary for v0.3.1 real-provider acceptance. Gemini-compatible outputs: gemini-generation-1e6802e91931.jpg, gemini-reference-edit-423cbcabde4b.jpg, gemini-guided-region-edit-e1734ac6502b.jpg."
+          }
+        ],
+        "summary": "Passed via the app-supported chat-completions streaming route on an OpenAI-compatible aggregation endpoint. Model discovery confirmed gemini-3.1-flash-image, and text-to-image, reference-image editing, and guided-region editing all returned savable JPEG images within the explicit 420000ms release-test timeout. The guided-region check is recorded as provider-compatible guided editing, not exact-mask inpainting. API keys and the private base URL are not recorded."
       }
     },
     {

--- a/docs/release/v0.3.1-preflight.md
+++ b/docs/release/v0.3.1-preflight.md
@@ -29,9 +29,10 @@ pnpm verify:release-evidence:v0.3.1
 
 Current candidate automated gate progress:
 
+- Passed on `d7bb464a353b9fa88a05f64014bf09816a23faa5`: real OpenAI-compatible GPT Image 2 and Gemini-compatible image acceptance through the app-supported chat-completions streaming route.
 - Passed on `8fdc68741de2b5319189e1faa9c36f501e99a207`: build and mock verifiers, packaged CLI/MCP smoke, agent integration smoke, queue concurrency smoke, and Gallery mutation smoke.
 - Passed on `1b8d08c77d69ece4bcf1576175ec605af55c9cf7`: desktop image workflow regression smoke.
-- Still pending and must not be marked complete without fresh release evidence: real OpenAI-compatible acceptance, real Gemini-compatible acceptance, Developer ID signed macOS artifacts, native Windows artifacts, Linux v0.3.1 release artifacts, and public update manifest assets.
+- Still pending and must not be marked complete without fresh release evidence: Developer ID signed macOS artifacts, native Windows artifacts, Linux v0.3.1 release artifacts, and public update manifest assets.
 
 Before publishing v0.3.1, the final release branch must:
 

--- a/docs/release/v0.3.1-real-aggregation-api-gate.md
+++ b/docs/release/v0.3.1-real-aggregation-api-gate.md
@@ -1,0 +1,49 @@
+# v0.3.1 Real Aggregation API Gate
+
+This evidence records the real-provider acceptance run for the v0.3.1
+OpenAI-compatible GPT Image 2 and Gemini-compatible image gates.
+
+The run used an OpenAI-compatible aggregation endpoint through the
+app-supported chat-completions streaming route. API keys and the private base
+URL were loaded from local `.env.local` and are intentionally not recorded.
+
+## Result
+
+| Field | Value |
+| --- | --- |
+| Commit | `d7bb464a353b9fa88a05f64014bf09816a23faa5` |
+| Verified at | `2026-07-14T01:08:53.589Z` |
+| Acceptance id | `16ba35a3-b493-490b-9fc4-a545388d54b9` |
+| Timeout | `420000ms` |
+| Route | `POST /chat/completions`, `stream: true` |
+| Local artifacts | `real-api-artifacts/aihub/2026-07-14T01-06-20-214Z/` |
+
+Command:
+
+```bash
+set -a; . .env.local; set +a
+IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api
+```
+
+The accepted run returned six savable images:
+
+| Case | Model | MIME | Bytes | Elapsed |
+| --- | --- | --- | ---: | ---: |
+| OpenAI text-to-image | `gpt-image-2` | `image/png` | 912783 | 38798ms |
+| OpenAI reference-image edit | `gpt-image-2` | `image/png` | 1106708 | 37927ms |
+| OpenAI guided-region edit | `gpt-image-2` | `image/png` | 1288321 | 44999ms |
+| Gemini text-to-image | `gemini-3.1-flash-image` | `image/jpeg` | 446909 | 12221ms |
+| Gemini reference-image edit | `gemini-3.1-flash-image` | `image/jpeg` | 530835 | 8551ms |
+| Gemini guided-region edit | `gemini-3.1-flash-image` | `image/jpeg` | 194389 | 10827ms |
+
+Model discovery succeeded before generation. The summary file is kept in the
+local artifact directory for release audit, but it is not committed because it
+contains environment-specific endpoint metadata.
+
+## Notes
+
+An earlier attempt with the default `240000ms` verifier timeout saved the
+OpenAI text-to-image and reference-edit images, then timed out while waiting
+for the OpenAI guided-region result. That attempt is not used as passed release
+evidence. The accepted run above completed all required cases within the
+explicit release-test timeout.

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -131,10 +131,12 @@ describe("release evidence verifier", () => {
     const result = await run(["--file", "docs/release/v0.3.1-evidence.json", "--expected-version", "0.3.1"]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 6/12 required gate(s) passed.");
+    expect(result.stdout).toContain("Release evidence validated: 8/12 required gate(s) passed.");
     expect(result.stdout).toContain("Pending required gate(s):");
-    expect(result.stdout).toContain("real-openai-api");
+    expect(result.stdout).toContain("macos-signed");
     expect(result.stdout).toContain("update-manifest-assets");
+    expect(result.stdout).not.toContain("real-openai-api");
+    expect(result.stdout).not.toContain("real-gemini-api");
     expect(result.stdout).not.toContain("image-core-regression");
   });
 
@@ -149,8 +151,10 @@ describe("release evidence verifier", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Required release evidence gates are not passed");
-    expect(result.stderr).toContain("real-openai-api");
+    expect(result.stderr).toContain("macos-signed");
     expect(result.stderr).toContain("update-manifest-assets");
+    expect(result.stderr).not.toContain("real-openai-api");
+    expect(result.stderr).not.toContain("real-gemini-api");
     expect(result.stderr).not.toContain("image-core-regression");
   });
 
@@ -239,8 +243,8 @@ describe("release evidence verifier", () => {
       await writeFile(
         checklistPath,
         checklist.replace(
-          "- [ ] Complete real OpenAI-compatible GPT Image acceptance.",
-          "- [x] Complete real OpenAI-compatible GPT Image acceptance."
+          "- [ ] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.",
+          "- [x] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes."
         )
       );
 
@@ -250,8 +254,8 @@ describe("release evidence verifier", () => {
       );
 
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain("Complete real OpenAI-compatible GPT Image acceptance.");
-      expect(result.stderr).toContain("real-openai-api");
+      expect(result.stderr).toContain("Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.");
+      expect(result.stderr).toContain("update-manifest-assets");
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- mark real OpenAI-compatible GPT Image 2 acceptance as passed for v0.3.1
- mark real Gemini-compatible image acceptance as passed for v0.3.1
- add redacted real aggregation API evidence with route, models, elapsed times, and local artifact references
- update candidate release evidence verifier assertions from 6/12 to 8/12 gates passed

## Real API acceptance
- Command: IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api
- Route: app-supported chat-completions streaming route
- Accepted run returned six savable images: GPT Image 2 generation/edit/guided-region and Gemini-compatible generation/edit/guided-region
- API keys and private base URL are not recorded

## Verification
- pnpm install --frozen-lockfile
- pnpm exec vitest run scripts/verify-release-evidence.test.mjs
- pnpm verify:release-evidence:v0.3.1
- IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api
- pnpm build
- git diff --check