### PR TITLE
Add release package artifact workflows

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,77 @@
+name: Release Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to publish, for example v0.3.1
+        required: true
+        type: string
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  linux-appimage:
+    name: Build and publish Linux AppImage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.25.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Linux smoke-test dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends xvfb xauth libnss3 libatk-bridge2.0-0 libgtk-3-0 libxss1 libasound2t64 libgbm1 libdrm2 libxkbcommon0
+
+      - name: Package Linux app
+        run: pnpm package
+
+      - name: Verify CLI and MCP smoke
+        run: |
+          app_executable="$(find release -maxdepth 2 -type f -path '*/linux*-unpacked/crossgen' -print -quit)"
+          test -n "$app_executable"
+          CROSSGEN_APP_EXECUTABLE="$app_executable" CROSSGEN_APP_EXTRA_ARGS="--no-sandbox" xvfb-run -a node scripts/verify-cli-mcp-smoke.mjs
+
+      - name: Verify agent integration smoke
+        run: |
+          app_executable="$(find release -maxdepth 2 -type f -path '*/linux*-unpacked/crossgen' -print -quit)"
+          test -n "$app_executable"
+          CROSSGEN_APP_EXECUTABLE="$app_executable" CROSSGEN_APP_EXTRA_ARGS="--no-sandbox" xvfb-run -a node scripts/verify-agent-integration-smoke.mjs
+
+      - name: Verify Linux package
+        run: pnpm verify:release:linux
+
+      - name: Upload Linux release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: crossgen-linux-${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+          path: release/*.AppImage
+          if-no-files-found: error
+
+      - name: Publish GitHub Release asset
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+          make_latest: true
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: release/*.AppImage

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -42,8 +44,17 @@ jobs:
 
       - name: Verify Windows package
         env:
-          IMAGE2TOOLS_WINDOWS_VERIFY_MODE: package-smoke
+          IMAGE2TOOLS_WINDOWS_VERIFY_MODE: full-install
         run: pnpm verify:release:windows
+
+      - name: Upload Windows release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: crossgen-windows-${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+          path: |
+            release/CrossGen-Setup.exe
+            release/CrossGen-Setup.exe.blockmap
+          if-no-files-found: error
 
       - name: Publish GitHub Release asset
         uses: softprops/action-gh-release@v3
@@ -52,4 +63,6 @@ jobs:
           make_latest: true
           generate_release_notes: true
           fail_on_unmatched_files: true
-          files: release/CrossGen-Setup.exe
+          files: |
+            release/CrossGen-Setup.exe
+            release/CrossGen-Setup.exe.blockmap

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -27,6 +27,18 @@ Before publishing a release, require every required gate to be passed:
 pnpm verify:release-evidence -- --require-complete
 ```
 
+Release package workflows:
+
+- `.github/workflows/release-windows.yml` builds the Windows installer, runs
+  `pnpm verify:release:windows` in `full-install` mode, uploads the installer
+  artifact, and publishes the installer plus blockmap to the matching GitHub
+  Release.
+- `.github/workflows/release-linux.yml` builds the Linux AppImage, runs
+  packaged CLI/MCP smoke, agent integration smoke, and
+  `pnpm verify:release:linux`, then uploads and publishes the AppImage.
+- macOS Developer ID signing remains a local release-shell gate unless signing
+  certificates are configured in GitHub Actions secrets.
+
 External gate trackers:
 
 | Gate | Tracker |


### PR DESCRIPTION
## Summary
- add a Linux release workflow that builds, verifies, uploads, and publishes the AppImage for version tags
- update the Windows release workflow to use full-install verification and upload both installer and blockmap artifacts
- document release package workflow responsibilities for v0.3.1 evidence

## Verification
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release-windows.yml .github/workflows/release-linux.yml
- pnpm install --frozen-lockfile
- pnpm verify:release-evidence:v0.3.1
- pnpm exec vitest run scripts/verify-release-evidence.test.mjs
- pnpm build
- git diff --check