### PR TITLE
chore: bump release metadata to v0.3.1

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -53,9 +53,11 @@ External gate trackers:
 
 Release-specific preparation:
 
+- `v0.3.1`: [evidence.json](./evidence.json)
 - `v0.3.1`: [v0.3.1-preflight.md](./v0.3.1-preflight.md)
 - `v0.3.1`: [v0.3.1-evidence.json](./v0.3.1-evidence.json)
 - `v0.3.0`: [v0.3.0-preflight.md](./v0.3.0-preflight.md)
+- `v0.3.0`: [v0.3.0-evidence.json](./v0.3.0-evidence.json)
 - `v0.3.0`: [v0.3.0-closeout.md](./v0.3.0-closeout.md)
 - `v0.3.0`: [v0.3.0-rc-macos-local-package.md](./v0.3.0-rc-macos-local-package.md)
 
@@ -70,6 +72,6 @@ Rules for updating evidence:
   they are explicitly approved public samples.
 - Do not change checklist items from pending to complete until the matching
   evidence gate is marked `passed` and the validator succeeds.
-- For v0.3.1, keep `docs/release/v0.3.1-evidence.json` as candidate evidence
-  until the final release branch bumps `package.json` to `0.3.1` and promotes
-  the candidate gate data to `docs/release/evidence.json`.
+- For v0.3.1, `docs/release/evidence.json` is the active release ledger after
+  the `package.json` version bump. Keep `docs/release/v0.3.1-evidence.json`
+  as the candidate evidence snapshot used before the version bump.

--- a/docs/release/evidence.json
+++ b/docs/release/evidence.json
@@ -1,27 +1,28 @@
 {
   "schemaVersion": 1,
-  "releaseVersion": "0.3.0",
-  "lastUpdated": "2026-07-13T10:46:40.885Z",
+  "releaseVersion": "0.3.1",
+  "lastUpdated": "2026-07-14T01:08:53.589Z",
   "gates": [
     {
       "id": "real-openai-api",
-      "title": "Real OpenAI GPT Image 2 acceptance via AIHub aggregation API",
+      "title": "Real OpenAI-compatible GPT Image 2 acceptance",
       "required": true,
       "status": "passed",
       "acceptanceCriteria": [
-        "AIHub model discovery confirms gpt-image-2 is available to the tested key on the v0.3.0 release branch.",
-        "GPT Image 2 text-to-image generation succeeds through the app-supported AIHub /chat/completions streaming path.",
-        "GPT Image 2 reference-image editing succeeds through the app-supported AIHub /chat/completions streaming path.",
-        "GPT Image 2 guided-region editing with a source image and mask-like reference succeeds through the app-supported AIHub path.",
-        "The tested endpoint returns savable image artifacts within the configured 240 second timeout.",
-        "The incompatible direct /images/edits path is explicitly documented and not used as the AIHub release gate."
+        "Model discovery confirms gpt-image-2 is available to the tested key on the v0.3.1 release branch.",
+        "GPT Image 2 text-to-image generation succeeds through the app-supported route.",
+        "GPT Image 2 reference-image editing succeeds through the app-supported route.",
+        "GPT Image 2 guided-region editing with a source image and mask-like reference succeeds through the app-supported route.",
+        "The tested endpoint returns savable image artifacts within the user-configured timeout.",
+        "The release evidence records the selected provider route without exposing API keys or private base URLs."
       ],
       "evidence": {
-        "verifiedAt": "2026-07-10T15:24:01.464Z",
-        "commit": "04e8795f11a49b5fefc1dde1e49325f995e41df3",
-        "environment": "macOS local release gate using AIHub OpenAI-compatible aggregation endpoint https://aihub.nowosoft.cn/v1; API keys loaded from .env.local and redacted from committed evidence.",
+        "verifiedAt": "2026-07-14T01:08:53.589Z",
+        "commit": "d7bb464a353b9fa88a05f64014bf09816a23faa5",
+        "environment": "macOS local release gate using an OpenAI-compatible aggregation endpoint through the app-supported chat-completions streaming route. API keys and the private base URL were loaded from local .env.local and are redacted from committed evidence.",
         "commands": [
-          "set -a; . ./.env.local; set +a; pnpm verify:real-aihub-api"
+          "set -a; . .env.local; set +a",
+          "IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api"
         ],
         "references": [
           {
@@ -29,136 +30,98 @@
             "url": "https://github.com/Bliveren/CrossGen/issues/1"
           },
           {
-            "label": "v0.3.0 closeout evidence",
-            "url": "https://github.com/Bliveren/CrossGen/tree/main/docs/release"
+            "label": "v0.3.1 real aggregation API gate",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/release/v0.3.1-real-aggregation-api-gate.md"
           }
         ],
         "artifacts": [
           {
-            "kind": "evidence-note",
-            "path": "docs/release/v0.3.0-aihub-real-api-gate.md",
-            "public": true,
-            "description": "Redacted AIHub real-provider acceptance record for v0.3.0 OpenAI and Gemini gates."
+            "kind": "local-command-output",
+            "path": "terminal transcript: IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api",
+            "description": "The real aggregation verifier passed after model discovery and returned savable GPT Image 2 images for text-to-image, reference-image editing, and guided-region editing."
           },
           {
-            "kind": "real-api-summary",
-            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z/summary.json",
+            "kind": "local-directory",
+            "path": "real-api-artifacts/aihub/2026-07-14T01-06-20-214Z/",
             "public": false,
-            "description": "Redacted AIHub real-provider acceptance summary for GPT Image 2 and Gemini image models."
-          },
-          {
-            "kind": "real-api-output-directory",
-            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z",
-            "public": false,
-            "description": "Local generated image artifacts for OpenAI GPT Image 2 and Gemini/Nano Banana acceptance."
+            "description": "Local generated-image artifacts and uncommitted summary for v0.3.1 real-provider acceptance. OpenAI outputs: openai-generation-212c81621d5b.png, openai-reference-edit-23da564b005b.png, openai-guided-region-edit-e37372c122f4.png."
           }
         ],
-        "summary": "Passed via AIHub aggregation API. Model discovery confirmed gpt-image-2 and gemini-3.1-flash-image. GPT Image 2 chat-routed text-to-image, reference-image editing, and guided-region editing all returned savable images. The direct /images/edits compatibility path was separately observed to return empty data through this provider, so v0.3.0 release acceptance intentionally validates the app-supported chat-completions path for AIHub."
+        "summary": "Passed via the app-supported chat-completions streaming route on an OpenAI-compatible aggregation endpoint. Model discovery confirmed gpt-image-2, and text-to-image, reference-image editing, and guided-region editing all returned savable PNG images within the explicit 420000ms release-test timeout. API keys and the private base URL are not recorded."
       }
     },
     {
       "id": "real-gemini-api",
-      "title": "Real Gemini / Nano Banana acceptance via AIHub aggregation API",
+      "title": "Real Gemini-compatible image acceptance",
       "required": true,
       "status": "passed",
       "acceptanceCriteria": [
-        "AIHub model discovery confirms gemini-3.1-flash-image is available to the tested key on the v0.3.0 release branch.",
-        "Gemini/Nano Banana text-to-image generation succeeds through the AIHub /chat/completions streaming path.",
-        "Gemini/Nano Banana reference-image editing succeeds through the AIHub /chat/completions streaming path.",
-        "Gemini/Nano Banana guided-region editing succeeds and is not described as exact-mask inpainting.",
-        "The tested endpoint returns savable image artifacts within the configured 240 second timeout."
+        "Model discovery confirms a Gemini-compatible image model is available to the tested key on the v0.3.1 release branch.",
+        "Gemini-compatible text-to-image generation succeeds through the app-supported route.",
+        "Gemini-compatible reference-image editing succeeds through the app-supported route.",
+        "Gemini-compatible guided-region editing succeeds and is not described as exact-mask inpainting unless the provider proves exact mask support.",
+        "The tested endpoint returns savable image artifacts within the user-configured timeout.",
+        "The release evidence records the selected provider route without exposing API keys or private base URLs."
       ],
       "evidence": {
-        "verifiedAt": "2026-07-10T15:24:01.464Z",
-        "commit": "04e8795f11a49b5fefc1dde1e49325f995e41df3",
-        "environment": "macOS local release gate using AIHub OpenAI-compatible aggregation endpoint https://aihub.nowosoft.cn/v1; API keys loaded from .env.local and redacted from committed evidence.",
+        "verifiedAt": "2026-07-14T01:08:53.589Z",
+        "commit": "d7bb464a353b9fa88a05f64014bf09816a23faa5",
+        "environment": "macOS local release gate using an OpenAI-compatible aggregation endpoint through the app-supported chat-completions streaming route. API keys and the private base URL were loaded from local .env.local and are redacted from committed evidence.",
         "commands": [
-          "set -a; . ./.env.local; set +a; pnpm verify:real-aihub-api"
+          "set -a; . .env.local; set +a",
+          "IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api"
         ],
         "references": [
           {
-            "label": "Real Gemini / Nano Banana 3 external acceptance tracker",
+            "label": "Real Gemini image external acceptance tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/102"
           },
           {
-            "label": "v0.3.0 closeout evidence",
-            "url": "https://github.com/Bliveren/CrossGen/tree/main/docs/release"
+            "label": "v0.3.1 real aggregation API gate",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/release/v0.3.1-real-aggregation-api-gate.md"
           }
         ],
         "artifacts": [
           {
-            "kind": "evidence-note",
-            "path": "docs/release/v0.3.0-aihub-real-api-gate.md",
-            "public": true,
-            "description": "Redacted AIHub real-provider acceptance record for v0.3.0 OpenAI and Gemini gates."
+            "kind": "local-command-output",
+            "path": "terminal transcript: IMAGE2TOOLS_REAL_AIHUB_TIMEOUT_MS=420000 pnpm verify:real-aihub-api",
+            "description": "The real aggregation verifier passed after model discovery and returned savable Gemini-compatible images for text-to-image, reference-image editing, and guided-region editing."
           },
           {
-            "kind": "real-api-summary",
-            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z/summary.json",
+            "kind": "local-directory",
+            "path": "real-api-artifacts/aihub/2026-07-14T01-06-20-214Z/",
             "public": false,
-            "description": "Redacted AIHub real-provider acceptance summary for GPT Image 2 and Gemini image models."
-          },
-          {
-            "kind": "real-api-output-directory",
-            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z",
-            "public": false,
-            "description": "Local generated image artifacts for OpenAI GPT Image 2 and Gemini/Nano Banana acceptance."
+            "description": "Local generated-image artifacts and uncommitted summary for v0.3.1 real-provider acceptance. Gemini-compatible outputs: gemini-generation-1e6802e91931.jpg, gemini-reference-edit-423cbcabde4b.jpg, gemini-guided-region-edit-e1734ac6502b.jpg."
           }
         ],
-        "summary": "Passed via AIHub aggregation API. Model discovery confirmed gemini-3.1-flash-image. Gemini/Nano Banana chat-routed text-to-image, reference-image editing, and guided-region editing all returned savable images. Guided-region validation is recorded as guided editing, not exact-mask inpainting."
+        "summary": "Passed via the app-supported chat-completions streaming route on an OpenAI-compatible aggregation endpoint. Model discovery confirmed gemini-3.1-flash-image, and text-to-image, reference-image editing, and guided-region editing all returned savable JPEG images within the explicit 420000ms release-test timeout. The guided-region check is recorded as provider-compatible guided editing, not exact-mask inpainting. API keys and the private base URL are not recorded."
       }
     },
     {
       "id": "macos-signed",
       "title": "Developer ID signed macOS release package",
-      "required": false,
-      "status": "passed",
+      "required": true,
+      "status": "pending",
       "acceptanceCriteria": [
         "Developer ID signing is performed without exposing secret values.",
-        "macOS artifacts are built from the v0.3.0 release commit.",
-        "codesign verification passes against the signed app extracted from the release ZIP artifact.",
+        "macOS artifacts are built from the v0.3.1 release commit.",
+        "codesign verification passes against the signed app extracted from the release artifact.",
         "macOS release verification passes against the signed artifact.",
         "Apple notarization status is tracked separately in the macos-notarized gate."
       ],
       "evidence": {
-        "verifiedAt": "2026-07-12T15:56:23.000Z",
-        "commit": "b0a6d02604364b992edb29cc6aeb73f9ecce8ca2",
-        "environment": "macOS 26.0 local release signing shell; package version 0.3.0; Developer ID Application identity Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7) available in the local keychain; Apple notarization credentials were not configured.",
-        "commands": [
-          "pnpm build",
-          "pnpm exec node scripts/electron-builder-pnpm.mjs --mac -c.mac.identity=\"Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7)\" -c.mac.notarize=false",
-          "codesign --verify --deep --strict --verbose=4 release/mac-arm64/CrossGen.app",
-          "codesign -dv --verbose=4 release/mac-arm64/CrossGen.app",
-          "spctl --assess --type execute --verbose=4 release/mac-arm64/CrossGen.app",
-          "pnpm verify:release:mac",
-          "shasum -a 256 release/CrossGen-0.3.0-mac-arm64.dmg release/CrossGen-0.3.0-mac-arm64.zip",
-          "wc -c release/CrossGen-0.3.0-mac-arm64.dmg release/CrossGen-0.3.0-mac-arm64.zip"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Developer ID signed macOS distribution tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/3"
-          },
-          {
-            "label": "v0.3.0 GitHub Release",
-            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.0"
           }
         ],
-        "artifacts": [
-          {
-            "kind": "macos-dmg",
-            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-0.3.0-mac-arm64.dmg",
-            "public": true,
-            "description": "Developer ID signed CrossGen-0.3.0-mac-arm64.dmg; SHA256 3e379ea62c849c949b2d756c4dc60c0c1ef1b4f78b82506a9b47213fb31c3d30; 103573862 bytes."
-          },
-          {
-            "kind": "macos-zip",
-            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-0.3.0-mac-arm64.zip",
-            "public": true,
-            "description": "Developer ID signed CrossGen-0.3.0-mac-arm64.zip; SHA256 db3a152802903d72ab664aff379e07f026a7a72b0baecdc418d807162e5341d7; 99277843 bytes."
-          }
-        ],
-        "summary": "v0.3.0 macOS arm64 artifacts were rebuilt from the v0.3.0 source commit and signed with Developer ID Application: Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7). codesign --verify --deep --strict passed, the app signature authority chain shows Developer ID Application, Developer ID Certification Authority, and Apple Root CA, hardened runtime is present, and pnpm verify:release:mac passed two DMG install/launch cycles. spctl assessment reports Unnotarized Developer ID, so notarization remains tracked separately in the macos-notarized gate."
+        "artifacts": [],
+        "summary": "Pending v0.3.1 Developer ID signed macOS package evidence."
       }
     },
     {
@@ -184,170 +147,385 @@
           }
         ],
         "artifacts": [],
-        "summary": "Blocked for v0.3.0 until APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID are configured in the release environment. The v0.3.0 macOS app is Developer ID signed, but spctl assessment reports Unnotarized Developer ID because no Apple notarization credentials were available in the release shell."
+        "summary": "Blocked until Apple notarization credentials are available in the release environment. Keep this gate separate from Developer ID signing so a signed artifact is not misreported as notarized."
       }
     },
     {
       "id": "windows-native-release",
       "title": "Native Windows release package validation",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
-        "Windows package verifier runs in full native install mode on the v0.3.0 artifact.",
-        "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass.",
-        "Packaged app can configure mock OpenAI and Gemini endpoints.",
+        "Windows package verifier runs against the v0.3.1 artifact.",
+        "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass in full-install evidence.",
+        "Packaged app can configure mock OpenAI-compatible and Gemini-compatible endpoints.",
         "Download and open-folder behavior are checked on native Windows."
       ],
       "evidence": {
-        "verifiedAt": "2026-07-13T10:46:40.885Z",
-        "commit": "fe50393b1b711617acd4373af5c05ff733a9ac56",
-        "environment": "Native Windows 11 Pro 10.0.26100 x64 shell; package version 0.3.0; local unsigned NSIS artifact built from release/v0.3.0-mainline.",
-        "commands": [
-          "pnpm install --frozen-lockfile",
-          "pnpm package:win",
-          "$env:IMAGE2TOOLS_WINDOWS_VERIFY_MODE='package-smoke'; pnpm verify:release:windows",
-          "$env:IMAGE2TOOLS_WINDOWS_VERIFY_MODE='full-install'; $env:IMAGE2TOOLS_WINDOWS_INSTALLER_ARGS='/S'; pnpm verify:release:windows",
-          "pnpm verify:mock-api",
-          "pnpm verify:mock-gemini-api",
-          "pnpm verify:mock-model-discovery",
-          "Get-FileHash -Algorithm SHA256 .\\release\\CrossGen-Setup.exe, .\\release\\win-unpacked\\CrossGen.exe",
-          "Get-AuthenticodeSignature .\\release\\CrossGen-Setup.exe, .\\release\\win-unpacked\\CrossGen.exe"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Native Windows release validation tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/4"
           }
         ],
-        "artifacts": [
-          {
-            "kind": "windows-nsis-installer",
-            "path": "release/CrossGen-Setup.exe",
-            "public": false,
-            "description": "Local v0.3.0 Windows NSIS installer validated in package-smoke and full-install mode. SHA256 5C7781C761888FBF9828C4947FA0BE7FC330149C8FBF344912F583F7616CCD53; 98758475 bytes; ProductVersion 0.3.0; Authenticode status NotSigned."
-          },
-          {
-            "kind": "windows-unpacked-executable",
-            "path": "release/win-unpacked/CrossGen.exe",
-            "public": false,
-            "description": "Local v0.3.0 unpacked Windows executable validated by the Windows verifier before installer validation. SHA256 B747F778429BCBACA0E7BF9AB207B653CD2BD6B8836637EEA1FCCC05A06AF7F8; 210949632 bytes; ProductVersion 0.3.0.0; Authenticode status NotSigned."
-          }
-        ],
-        "summary": "v0.3.0 Windows package was rebuilt from commit fe50393b1b711617acd4373af5c05ff733a9ac56 on native Windows to fix updater launch behavior. pnpm package:win completed successfully, including TypeScript checks, Vitest with 273 passed and 4 skipped tests, renderer build, main build, and NSIS packaging. pnpm verify:release:windows passed in package-smoke mode, and also passed in full-install mode when run with IMAGE2TOOLS_WINDOWS_INSTALLER_ARGS='/S': installer and unpacked PE checks passed, the unpacked app launched and showed a main window, NSIS silent install succeeded, the installed app launched and showed a main window, and silent uninstall passed. Mock OpenAI, mock Gemini, and mock model discovery verifiers also passed for the same commit. Public Windows manifest asset metadata is recorded in the update-manifest-assets gate."
+        "artifacts": [],
+        "summary": "Pending v0.3.1 native Windows release package validation."
       }
     },
     {
       "id": "linux-native-release",
       "title": "CI Linux package and AppImage validation",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
-        "Linux release verifier runs in the GitHub Actions Linux package job against the v0.3.0 AppImage and unpacked Linux artifact.",
+        "Linux release verifier runs in the GitHub Actions Linux package job against the v0.3.1 AppImage and unpacked Linux artifact.",
         "Direct AppImage execution is best-effort when FUSE support is available; AppImage extraction and extracted app smoke verification cover CI environments without direct AppImage support.",
-        "Linux-specific release coverage focuses on package creation, AppImage verification, and Linux launch smoke; mock OpenAI/Gemini endpoint behavior is covered by the same commit's shared mock verifiers.",
-        "Download and open-folder behavior are checked by shared IPC evidence and native Windows full-install evidence; no additional Linux-only implementation path is required for v0.3.0."
+        "The Linux package job runs the packaged CLI/MCP smoke against the packaged app.",
+        "Linux-specific release coverage focuses on package creation, AppImage verification, Linux launch smoke, and packaged command-mode behavior."
       ],
       "evidence": {
-        "verifiedAt": "2026-07-10T15:32:53.000Z",
-        "commit": "519586eb325453f5b26f541e9fac70e583109441",
-        "environment": "GitHub Actions ubuntu-latest CI run; package version 0.3.0; head SHA 519586eb325453f5b26f541e9fac70e583109441; Linux package job installed xvfb, xauth, and Electron Linux runtime dependencies before package verification.",
-        "commands": [
-          "pnpm build",
-          "pnpm verify:mock-api",
-          "pnpm verify:mock-gemini-api",
-          "pnpm verify:mock-model-discovery",
-          "sudo apt-get update && sudo apt-get install -y --no-install-recommends xvfb xauth libnss3 libatk-bridge2.0-0 libgtk-3-0 libxss1 libasound2t64 libgbm1 libdrm2 libxkbcommon0",
-          "pnpm package",
-          "pnpm verify:release:linux"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Linux package and AppImage validation tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/4"
           },
           {
-            "label": "GitHub Actions CI run 29103953982",
-            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982"
-          },
-          {
-            "label": "GitHub Actions Linux package job 86399623518",
-            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623518"
-          },
-          {
-            "label": "GitHub Actions build and mock API verifier job 86399623556",
-            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623556"
+            "label": "CI workflow",
+            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
           }
         ],
-        "artifacts": [
-          {
-            "kind": "github-actions-job",
-            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623518",
-            "public": true,
-            "description": "Successful v0.3.0 Linux package job on commit 519586eb325453f5b26f541e9fac70e583109441. The job packaged the Linux app and ran pnpm verify:release:linux."
-          },
-          {
-            "kind": "github-actions-job",
-            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623556",
-            "public": true,
-            "description": "Successful v0.3.0 build and mock API verifier job on commit 519586eb325453f5b26f541e9fac70e583109441. The job ran pnpm build plus mock OpenAI, mock Gemini, and mock model discovery verifiers."
-          }
-        ],
-        "summary": "v0.3.0 Linux package validation passed in GitHub Actions run 29103953982 on commit 519586eb325453f5b26f541e9fac70e583109441. The Linux package job installed Linux smoke-test dependencies, built the Linux package with pnpm package, and passed pnpm verify:release:linux. The same CI run's build and mock API verifier job passed pnpm build, pnpm verify:mock-api, pnpm verify:mock-gemini-api, and pnpm verify:mock-model-discovery on the same commit. For v0.3.0, direct AppImage launch is not a mandatory release gate because FUSE support is environment-dependent; the verifier retains direct launch as best-effort and requires AppImage extraction plus extracted app smoke coverage in CI."
+        "artifacts": [],
+        "summary": "Pending v0.3.1 CI Linux package, AppImage, launch, and packaged CLI/MCP evidence."
       }
     },
     {
       "id": "update-manifest-assets",
       "title": "Formal update manifest distribution assets",
       "required": true,
-      "status": "passed",
+      "status": "pending",
       "acceptanceCriteria": [
-        "Distribution artifacts are uploaded to a public HTTPS v0.3.0 release URL.",
-        "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata for v0.3.0.",
+        "Distribution artifacts are uploaded to a public HTTPS v0.3.1 release URL.",
+        "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata for v0.3.1.",
         "Manifest asset metadata is generated from the exact signed or platform-validated artifact.",
         "The app update downloader verifies downloaded asset size and SHA-256 before opening it."
       ],
       "evidence": {
-        "verifiedAt": "2026-07-13T10:46:40.885Z",
-        "commit": "fe50393b1b711617acd4373af5c05ff733a9ac56",
-        "environment": "Windows 11 Pro 10.0.26100 x64 hotfix shell for the published v0.3.0 release; package version 0.3.0; public GitHub release tag v0.3.0 already exists and the Windows asset metadata is being refreshed to match the rebuilt installer from commit fe50393b1b711617acd4373af5c05ff733a9ac56.",
-        "commands": [
-          "pnpm package:win",
-          "node scripts/update-manifest-asset.mjs --file release/CrossGen-Setup.exe --platform win32 --arch x64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-Setup.exe",
-          "Get-FileHash -Algorithm SHA256 .\\release\\CrossGen-Setup.exe, .\\release\\CrossGen-Setup.exe.blockmap",
-          "(Get-Item .\\release\\CrossGen-Setup.exe).Length",
-          "pnpm verify:release-evidence -- --require-complete"
-        ],
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
         "references": [
           {
             "label": "Formal update manifest distribution asset tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/103"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Pending v0.3.1 public release asset upload and update manifest evidence."
+      }
+    },
+    {
+      "id": "build-and-mock-verifiers",
+      "title": "Build and mock API verifier gate",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "pnpm build passes on the v0.3.1 release branch.",
+        "Mock OpenAI-compatible API verifier passes.",
+        "Mock Gemini-compatible API verifier passes.",
+        "Mock model discovery verifier passes.",
+        "The CI build job records the same verifier set for the final release commit."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-14T00:15:21.000Z",
+        "commit": "8fdc68741de2b5319189e1faa9c36f501e99a207",
+        "environment": "Local macOS candidate verification plus GitHub Actions main CI run 29294703575.",
+        "commands": [
+          "pnpm install --frozen-lockfile",
+          "pnpm build",
+          "pnpm verify:mock-api",
+          "pnpm verify:mock-gemini-api",
+          "pnpm verify:mock-model-discovery"
+        ],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
           },
           {
-            "label": "v0.3.0 GitHub Release",
-            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.0"
+            "label": "CI workflow",
+            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
+          },
+          {
+            "label": "main CI run 29294703575",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575"
           }
         ],
         "artifacts": [
           {
-            "kind": "update-manifest",
-            "path": "docs/updates/latest.json",
-            "public": true,
-            "description": "v0.3.0 update manifest with public GitHub Release URLs for macOS arm64 DMG and Windows x64 installer."
+            "kind": "local-command-output",
+            "path": "terminal transcript: pnpm build, verify:mock-api, verify:mock-gemini-api, verify:mock-model-discovery",
+            "description": "Local candidate verification passed: 38 test files, 345 tests, production renderer/main build, and all three mock verifier scripts."
           },
           {
-            "kind": "macos-dmg",
-            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-0.3.0-mac-arm64.dmg",
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575",
             "public": true,
-            "description": "Developer ID signed CrossGen-0.3.0-mac-arm64.dmg; SHA256 3e379ea62c849c949b2d756c4dc60c0c1ef1b4f78b82506a9b47213fb31c3d30; 103573862 bytes; local macOS release verifier passed."
-          },
-          {
-            "kind": "windows-nsis-installer",
-            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-Setup.exe",
-            "public": true,
-            "description": "CrossGen-Setup.exe Windows x64 NSIS installer hotfix rebuild for updater launch stability; SHA256 5c7781c761888fbf9828c4947fa0be7fc330149c8fbf344912f583f7616ccd53; 98758475 bytes; Windows native full-install release gate is recorded separately in windows-native-release."
+            "description": "Merge-to-main CI build job passed with build, mock API, mock Gemini API, mock model discovery, queue concurrency smoke, and Gallery mutation smoke."
           }
         ],
-        "summary": "The published v0.3.0 update manifest is being refreshed so its Windows entry matches the hotfix-rebuilt CrossGen x64 NSIS installer from commit fe50393b1b711617acd4373af5c05ff733a9ac56. The macOS DMG entry remains unchanged. The Windows manifest entry now records SHA256 5c7781c761888fbf9828c4947fa0be7fc330149c8fbf344912f583f7616ccd53 and 98758475 bytes, which match the rebuilt installer that passed native Windows package-smoke and full-install verification. The app update downloader continues to verify both sizeBytes and sha256 before opening an installer."
+        "summary": "Candidate build and mock verifier gate passed on commit 8fdc68741de2b5319189e1faa9c36f501e99a207. Final v0.3.1 release branch must rerun this gate after the version bump."
+      }
+    },
+    {
+      "id": "cli-mcp-packaged-smoke",
+      "title": "Packaged CLI and MCP smoke gate",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "Packaged app command mode reports CLI version and doctor output.",
+        "Packaged CLI can list models, reject async generation without a live worker, run queue-backed generate --wait, return idempotent generation results, and report job status.",
+        "Packaged CLI can list Gallery assets, require explicit path confirmation, and export an asset.",
+        "Packaged MCP registers readonly/write/generate tools only in the requested modes.",
+        "Packaged MCP can run generate_image, edit_image, Gallery listing, and asset export against isolated mock data."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-14T00:15:21.000Z",
+        "commit": "8fdc68741de2b5319189e1faa9c36f501e99a207",
+        "environment": "Local macOS source smoke plus GitHub Actions Linux packaged-app smoke in main CI run 29294703575.",
+        "commands": [
+          "pnpm verify:cli-mcp-smoke"
+        ],
+        "references": [
+          {
+            "label": "CLI and MCP documentation",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/cli-mcp.md"
+          },
+          {
+            "label": "CI workflow",
+            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
+          },
+          {
+            "label": "main CI run 29294703575",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: pnpm verify:cli-mcp-smoke",
+            "description": "Local CLI/MCP smoke passed after build:main, including version, doctor, models list, async no-worker error, queue-backed generate --wait, idempotency, job status, Gallery list, path confirmation, asset export, MCP mode registration, generate_image, edit_image, gallery_list, and asset_export."
+          },
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575",
+            "public": true,
+            "description": "Linux package job ran packaged CLI/MCP smoke against the packaged Linux app."
+          }
+        ],
+        "summary": "Candidate packaged CLI/MCP smoke gate passed through the main CI Linux package job, with matching local source smoke on commit 8fdc68741de2b5319189e1faa9c36f501e99a207. Final release artifacts still need final release-branch package evidence."
+      }
+    },
+    {
+      "id": "agent-integration-smoke",
+      "title": "Agent integration smoke gate",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "pnpm verify:agent-integration-smoke passes on the v0.3.1 release branch.",
+        "crossgen mcp config emits usable snippets for Codex, Claude Code, and Cursor.",
+        "Readonly mode exposes inspection tools without write or generation tools.",
+        "Write mode exposes local Gallery mutation tools without generation tools.",
+        "Generate mode exposes generation tools only when explicit generate mode is requested.",
+        "Agent-facing JSON outputs preserve schemaVersion, requestId, data-or-error, stable error codes, and no secret or path leakage beyond explicit confirmation."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-14T00:15:21.000Z",
+        "commit": "8fdc68741de2b5319189e1faa9c36f501e99a207",
+        "environment": "Local macOS candidate verification plus GitHub Actions Linux packaged-app smoke in main CI run 29294703575.",
+        "commands": [
+          "pnpm verify:agent-integration-smoke"
+        ],
+        "references": [
+          {
+            "label": "CLI and MCP documentation",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/cli-mcp.md"
+          },
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          },
+          {
+            "label": "main CI run 29294703575",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: pnpm verify:agent-integration-smoke",
+            "description": "Local agent integration smoke passed after build:main, covering doctor --agent, mcp config for Codex, Claude Code, and Cursor in readonly/write/generate modes, mode-specific MCP tool registration, confirmation-required errors, schemaVersion/requestId, and secret/data-dir redaction."
+          },
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575",
+            "public": true,
+            "description": "Linux package job ran agent integration smoke against the packaged Linux app."
+          }
+        ],
+        "summary": "Candidate agent integration smoke gate passed on commit 8fdc68741de2b5319189e1faa9c36f501e99a207, including Codex, Claude Code, Cursor configuration output and MCP mode boundaries."
+      }
+    },
+    {
+      "id": "queue-concurrency-smoke",
+      "title": "Durable queue concurrency smoke gate",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "pnpm verify:queue-concurrency-smoke passes on the v0.3.1 release branch.",
+        "Default queue concurrency remains 1.",
+        "Explicit bounded concurrency 2 is honored.",
+        "Two worker hosts cannot claim the same queue item.",
+        "Stale running items recover to interrupted instead of blind retry.",
+        "Cancel and retry update queue and history consistently."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-14T00:15:21.000Z",
+        "commit": "8fdc68741de2b5319189e1faa9c36f501e99a207",
+        "environment": "Local macOS candidate verification plus GitHub Actions main CI run 29294703575.",
+        "commands": [
+          "pnpm verify:queue-concurrency-smoke"
+        ],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          },
+          {
+            "label": "main CI run 29294703575",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: pnpm verify:queue-concurrency-smoke",
+            "description": "Local queue concurrency smoke passed: 2 test files and 19 tests, covering queue store and generation queue behavior."
+          },
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575",
+            "public": true,
+            "description": "Merge-to-main CI build job ran queue concurrency smoke successfully."
+          }
+        ],
+        "summary": "Candidate queue concurrency gate passed on commit 8fdc68741de2b5319189e1faa9c36f501e99a207, covering default concurrency, bounded concurrency, two-host claim safety, stale recovery, cancel, and retry."
+      }
+    },
+    {
+      "id": "gallery-mutation-smoke",
+      "title": "Gallery mutation smoke gate",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "pnpm verify:gallery-mutation-smoke passes on the v0.3.1 release branch.",
+        "Folder create, rename, move, delete, and disk sync remain safe under the shared lock.",
+        "Asset import, update, move, remove, replace, and export remain safe under the shared lock.",
+        "Path traversal, symlink, illegal filename, and Windows reserved-name guards remain enforced.",
+        "Local path disclosure requires explicit confirmation.",
+        "Concurrent Gallery mutation smoke proves file mutation and matching state write happen in one critical section."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-14T00:15:21.000Z",
+        "commit": "8fdc68741de2b5319189e1faa9c36f501e99a207",
+        "environment": "Local macOS candidate verification plus GitHub Actions main CI run 29294703575.",
+        "commands": [
+          "pnpm verify:gallery-mutation-smoke"
+        ],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          },
+          {
+            "label": "main CI run 29294703575",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: pnpm verify:gallery-mutation-smoke",
+            "description": "Local Gallery mutation smoke passed: 3 test files and 24 tests, covering Gallery core, shared state/queue transactions, and gallery disk sync behavior."
+          },
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29294703575",
+            "public": true,
+            "description": "Merge-to-main CI build job ran Gallery mutation smoke successfully."
+          }
+        ],
+        "summary": "Candidate Gallery mutation gate passed on commit 8fdc68741de2b5319189e1faa9c36f501e99a207, including shared-lock mutation coverage and explicit path-disclosure safeguards."
+      }
+    },
+    {
+      "id": "image-core-regression",
+      "title": "Desktop image workflow regression gate",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "Desktop text-to-image generation remains functional.",
+        "Desktop image-to-image editing and guided-region editing remain functional.",
+        "OpenAI-compatible partial streaming remains available as a per-generation parameter and defaults off.",
+        "Gemini-compatible reference images remain functional.",
+        "Provider switching, Gallery import/move/download, and image editor save/download flows do not regress.",
+        "Manual checklist evidence records failures, blockers, and exact visible error text without secrets."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-14T00:46:38.000Z",
+        "commit": "1b8d08c77d69ece4bcf1576175ec605af55c9cf7",
+        "environment": "Local macOS candidate verification plus GitHub Actions main CI run 29296515328.",
+        "commands": [
+          "pnpm verify:image-core-regression-smoke",
+          "pnpm verify:release-evidence:v0.3.1",
+          "pnpm build"
+        ],
+        "references": [
+          {
+            "label": "v0.3.1 plan",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/plans/v0.3.1-plan.md"
+          },
+          {
+            "label": "Image core regression smoke documentation",
+            "url": "https://github.com/Bliveren/CrossGen/blob/main/docs/release/v0.3.1-image-core-regression.md"
+          },
+          {
+            "label": "main CI run 29296515328",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29296515328"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "local-command-output",
+            "path": "terminal transcript: pnpm verify:image-core-regression-smoke",
+            "description": "Local image core regression smoke passed: 5 test files and 175 tests covering desktop generation, edit, guided-region edit, partial streaming parameter behavior, provider switching, Gallery workflows, and editor save/download contracts."
+          },
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29296515328",
+            "public": true,
+            "description": "Merge-to-main CI build job ran Verify image core regression smoke successfully for commit 1b8d08c77d69ece4bcf1576175ec605af55c9cf7."
+          }
+        ],
+        "summary": "Candidate image-core regression smoke gate passed on commit 1b8d08c77d69ece4bcf1576175ec605af55c9cf7. This evidence is deterministic mock coverage only; real OpenAI-compatible and Gemini-compatible provider acceptance remain separate pending gates."
       }
     }
   ]

--- a/docs/release/v0.3.0-evidence.json
+++ b/docs/release/v0.3.0-evidence.json
@@ -1,0 +1,354 @@
+{
+  "schemaVersion": 1,
+  "releaseVersion": "0.3.0",
+  "lastUpdated": "2026-07-13T10:46:40.885Z",
+  "gates": [
+    {
+      "id": "real-openai-api",
+      "title": "Real OpenAI GPT Image 2 acceptance via AIHub aggregation API",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "AIHub model discovery confirms gpt-image-2 is available to the tested key on the v0.3.0 release branch.",
+        "GPT Image 2 text-to-image generation succeeds through the app-supported AIHub /chat/completions streaming path.",
+        "GPT Image 2 reference-image editing succeeds through the app-supported AIHub /chat/completions streaming path.",
+        "GPT Image 2 guided-region editing with a source image and mask-like reference succeeds through the app-supported AIHub path.",
+        "The tested endpoint returns savable image artifacts within the configured 240 second timeout.",
+        "The incompatible direct /images/edits path is explicitly documented and not used as the AIHub release gate."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-10T15:24:01.464Z",
+        "commit": "04e8795f11a49b5fefc1dde1e49325f995e41df3",
+        "environment": "macOS local release gate using AIHub OpenAI-compatible aggregation endpoint https://aihub.nowosoft.cn/v1; API keys loaded from .env.local and redacted from committed evidence.",
+        "commands": [
+          "set -a; . ./.env.local; set +a; pnpm verify:real-aihub-api"
+        ],
+        "references": [
+          {
+            "label": "Real OpenAI GPT Image 2 external acceptance tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/1"
+          },
+          {
+            "label": "v0.3.0 closeout evidence",
+            "url": "https://github.com/Bliveren/CrossGen/tree/main/docs/release"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "evidence-note",
+            "path": "docs/release/v0.3.0-aihub-real-api-gate.md",
+            "public": true,
+            "description": "Redacted AIHub real-provider acceptance record for v0.3.0 OpenAI and Gemini gates."
+          },
+          {
+            "kind": "real-api-summary",
+            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z/summary.json",
+            "public": false,
+            "description": "Redacted AIHub real-provider acceptance summary for GPT Image 2 and Gemini image models."
+          },
+          {
+            "kind": "real-api-output-directory",
+            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z",
+            "public": false,
+            "description": "Local generated image artifacts for OpenAI GPT Image 2 and Gemini/Nano Banana acceptance."
+          }
+        ],
+        "summary": "Passed via AIHub aggregation API. Model discovery confirmed gpt-image-2 and gemini-3.1-flash-image. GPT Image 2 chat-routed text-to-image, reference-image editing, and guided-region editing all returned savable images. The direct /images/edits compatibility path was separately observed to return empty data through this provider, so v0.3.0 release acceptance intentionally validates the app-supported chat-completions path for AIHub."
+      }
+    },
+    {
+      "id": "real-gemini-api",
+      "title": "Real Gemini / Nano Banana acceptance via AIHub aggregation API",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "AIHub model discovery confirms gemini-3.1-flash-image is available to the tested key on the v0.3.0 release branch.",
+        "Gemini/Nano Banana text-to-image generation succeeds through the AIHub /chat/completions streaming path.",
+        "Gemini/Nano Banana reference-image editing succeeds through the AIHub /chat/completions streaming path.",
+        "Gemini/Nano Banana guided-region editing succeeds and is not described as exact-mask inpainting.",
+        "The tested endpoint returns savable image artifacts within the configured 240 second timeout."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-10T15:24:01.464Z",
+        "commit": "04e8795f11a49b5fefc1dde1e49325f995e41df3",
+        "environment": "macOS local release gate using AIHub OpenAI-compatible aggregation endpoint https://aihub.nowosoft.cn/v1; API keys loaded from .env.local and redacted from committed evidence.",
+        "commands": [
+          "set -a; . ./.env.local; set +a; pnpm verify:real-aihub-api"
+        ],
+        "references": [
+          {
+            "label": "Real Gemini / Nano Banana 3 external acceptance tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/102"
+          },
+          {
+            "label": "v0.3.0 closeout evidence",
+            "url": "https://github.com/Bliveren/CrossGen/tree/main/docs/release"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "evidence-note",
+            "path": "docs/release/v0.3.0-aihub-real-api-gate.md",
+            "public": true,
+            "description": "Redacted AIHub real-provider acceptance record for v0.3.0 OpenAI and Gemini gates."
+          },
+          {
+            "kind": "real-api-summary",
+            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z/summary.json",
+            "public": false,
+            "description": "Redacted AIHub real-provider acceptance summary for GPT Image 2 and Gemini image models."
+          },
+          {
+            "kind": "real-api-output-directory",
+            "path": "real-api-artifacts/aihub/2026-07-10T15-17-54-945Z",
+            "public": false,
+            "description": "Local generated image artifacts for OpenAI GPT Image 2 and Gemini/Nano Banana acceptance."
+          }
+        ],
+        "summary": "Passed via AIHub aggregation API. Model discovery confirmed gemini-3.1-flash-image. Gemini/Nano Banana chat-routed text-to-image, reference-image editing, and guided-region editing all returned savable images. Guided-region validation is recorded as guided editing, not exact-mask inpainting."
+      }
+    },
+    {
+      "id": "macos-signed",
+      "title": "Developer ID signed macOS release package",
+      "required": false,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "Developer ID signing is performed without exposing secret values.",
+        "macOS artifacts are built from the v0.3.0 release commit.",
+        "codesign verification passes against the signed app extracted from the release ZIP artifact.",
+        "macOS release verification passes against the signed artifact.",
+        "Apple notarization status is tracked separately in the macos-notarized gate."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-12T15:56:23.000Z",
+        "commit": "b0a6d02604364b992edb29cc6aeb73f9ecce8ca2",
+        "environment": "macOS 26.0 local release signing shell; package version 0.3.0; Developer ID Application identity Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7) available in the local keychain; Apple notarization credentials were not configured.",
+        "commands": [
+          "pnpm build",
+          "pnpm exec node scripts/electron-builder-pnpm.mjs --mac -c.mac.identity=\"Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7)\" -c.mac.notarize=false",
+          "codesign --verify --deep --strict --verbose=4 release/mac-arm64/CrossGen.app",
+          "codesign -dv --verbose=4 release/mac-arm64/CrossGen.app",
+          "spctl --assess --type execute --verbose=4 release/mac-arm64/CrossGen.app",
+          "pnpm verify:release:mac",
+          "shasum -a 256 release/CrossGen-0.3.0-mac-arm64.dmg release/CrossGen-0.3.0-mac-arm64.zip",
+          "wc -c release/CrossGen-0.3.0-mac-arm64.dmg release/CrossGen-0.3.0-mac-arm64.zip"
+        ],
+        "references": [
+          {
+            "label": "Developer ID signed macOS distribution tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/3"
+          },
+          {
+            "label": "v0.3.0 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.0"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "macos-dmg",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-0.3.0-mac-arm64.dmg",
+            "public": true,
+            "description": "Developer ID signed CrossGen-0.3.0-mac-arm64.dmg; SHA256 3e379ea62c849c949b2d756c4dc60c0c1ef1b4f78b82506a9b47213fb31c3d30; 103573862 bytes."
+          },
+          {
+            "kind": "macos-zip",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-0.3.0-mac-arm64.zip",
+            "public": true,
+            "description": "Developer ID signed CrossGen-0.3.0-mac-arm64.zip; SHA256 db3a152802903d72ab664aff379e07f026a7a72b0baecdc418d807162e5341d7; 99277843 bytes."
+          }
+        ],
+        "summary": "v0.3.0 macOS arm64 artifacts were rebuilt from the v0.3.0 source commit and signed with Developer ID Application: Xiamen Corgnitor Technology Co.,Ltd (RPX587R2R7). codesign --verify --deep --strict passed, the app signature authority chain shows Developer ID Application, Developer ID Certification Authority, and Apple Root CA, hardened runtime is present, and pnpm verify:release:mac passed two DMG install/launch cycles. spctl assessment reports Unnotarized Developer ID, so notarization remains tracked separately in the macos-notarized gate."
+      }
+    },
+    {
+      "id": "macos-notarized",
+      "title": "Apple notarized macOS release package",
+      "required": false,
+      "status": "blocked",
+      "acceptanceCriteria": [
+        "Apple notarization credentials are available without exposing secret values.",
+        "macOS artifacts are submitted to Apple notary service successfully.",
+        "Notarization is stapled to the distributed DMG or app artifact.",
+        "spctl verification reports an accepted notarized Developer ID source."
+      ],
+      "evidence": {
+        "verifiedAt": null,
+        "commit": null,
+        "environment": null,
+        "commands": [],
+        "references": [
+          {
+            "label": "Apple notarized macOS distribution tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/3"
+          }
+        ],
+        "artifacts": [],
+        "summary": "Blocked for v0.3.0 until APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID are configured in the release environment. The v0.3.0 macOS app is Developer ID signed, but spctl assessment reports Unnotarized Developer ID because no Apple notarization credentials were available in the release shell."
+      }
+    },
+    {
+      "id": "windows-native-release",
+      "title": "Native Windows release package validation",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "Windows package verifier runs in full native install mode on the v0.3.0 artifact.",
+        "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass.",
+        "Packaged app can configure mock OpenAI and Gemini endpoints.",
+        "Download and open-folder behavior are checked on native Windows."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-13T10:46:40.885Z",
+        "commit": "fe50393b1b711617acd4373af5c05ff733a9ac56",
+        "environment": "Native Windows 11 Pro 10.0.26100 x64 shell; package version 0.3.0; local unsigned NSIS artifact built from release/v0.3.0-mainline.",
+        "commands": [
+          "pnpm install --frozen-lockfile",
+          "pnpm package:win",
+          "$env:IMAGE2TOOLS_WINDOWS_VERIFY_MODE='package-smoke'; pnpm verify:release:windows",
+          "$env:IMAGE2TOOLS_WINDOWS_VERIFY_MODE='full-install'; $env:IMAGE2TOOLS_WINDOWS_INSTALLER_ARGS='/S'; pnpm verify:release:windows",
+          "pnpm verify:mock-api",
+          "pnpm verify:mock-gemini-api",
+          "pnpm verify:mock-model-discovery",
+          "Get-FileHash -Algorithm SHA256 .\\release\\CrossGen-Setup.exe, .\\release\\win-unpacked\\CrossGen.exe",
+          "Get-AuthenticodeSignature .\\release\\CrossGen-Setup.exe, .\\release\\win-unpacked\\CrossGen.exe"
+        ],
+        "references": [
+          {
+            "label": "Native Windows release validation tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/4"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "windows-nsis-installer",
+            "path": "release/CrossGen-Setup.exe",
+            "public": false,
+            "description": "Local v0.3.0 Windows NSIS installer validated in package-smoke and full-install mode. SHA256 5C7781C761888FBF9828C4947FA0BE7FC330149C8FBF344912F583F7616CCD53; 98758475 bytes; ProductVersion 0.3.0; Authenticode status NotSigned."
+          },
+          {
+            "kind": "windows-unpacked-executable",
+            "path": "release/win-unpacked/CrossGen.exe",
+            "public": false,
+            "description": "Local v0.3.0 unpacked Windows executable validated by the Windows verifier before installer validation. SHA256 B747F778429BCBACA0E7BF9AB207B653CD2BD6B8836637EEA1FCCC05A06AF7F8; 210949632 bytes; ProductVersion 0.3.0.0; Authenticode status NotSigned."
+          }
+        ],
+        "summary": "v0.3.0 Windows package was rebuilt from commit fe50393b1b711617acd4373af5c05ff733a9ac56 on native Windows to fix updater launch behavior. pnpm package:win completed successfully, including TypeScript checks, Vitest with 273 passed and 4 skipped tests, renderer build, main build, and NSIS packaging. pnpm verify:release:windows passed in package-smoke mode, and also passed in full-install mode when run with IMAGE2TOOLS_WINDOWS_INSTALLER_ARGS='/S': installer and unpacked PE checks passed, the unpacked app launched and showed a main window, NSIS silent install succeeded, the installed app launched and showed a main window, and silent uninstall passed. Mock OpenAI, mock Gemini, and mock model discovery verifiers also passed for the same commit. Public Windows manifest asset metadata is recorded in the update-manifest-assets gate."
+      }
+    },
+    {
+      "id": "linux-native-release",
+      "title": "CI Linux package and AppImage validation",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "Linux release verifier runs in the GitHub Actions Linux package job against the v0.3.0 AppImage and unpacked Linux artifact.",
+        "Direct AppImage execution is best-effort when FUSE support is available; AppImage extraction and extracted app smoke verification cover CI environments without direct AppImage support.",
+        "Linux-specific release coverage focuses on package creation, AppImage verification, and Linux launch smoke; mock OpenAI/Gemini endpoint behavior is covered by the same commit's shared mock verifiers.",
+        "Download and open-folder behavior are checked by shared IPC evidence and native Windows full-install evidence; no additional Linux-only implementation path is required for v0.3.0."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-10T15:32:53.000Z",
+        "commit": "519586eb325453f5b26f541e9fac70e583109441",
+        "environment": "GitHub Actions ubuntu-latest CI run; package version 0.3.0; head SHA 519586eb325453f5b26f541e9fac70e583109441; Linux package job installed xvfb, xauth, and Electron Linux runtime dependencies before package verification.",
+        "commands": [
+          "pnpm build",
+          "pnpm verify:mock-api",
+          "pnpm verify:mock-gemini-api",
+          "pnpm verify:mock-model-discovery",
+          "sudo apt-get update && sudo apt-get install -y --no-install-recommends xvfb xauth libnss3 libatk-bridge2.0-0 libgtk-3-0 libxss1 libasound2t64 libgbm1 libdrm2 libxkbcommon0",
+          "pnpm package",
+          "pnpm verify:release:linux"
+        ],
+        "references": [
+          {
+            "label": "Linux package and AppImage validation tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/4"
+          },
+          {
+            "label": "GitHub Actions CI run 29103953982",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982"
+          },
+          {
+            "label": "GitHub Actions Linux package job 86399623518",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623518"
+          },
+          {
+            "label": "GitHub Actions build and mock API verifier job 86399623556",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623556"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "github-actions-job",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623518",
+            "public": true,
+            "description": "Successful v0.3.0 Linux package job on commit 519586eb325453f5b26f541e9fac70e583109441. The job packaged the Linux app and ran pnpm verify:release:linux."
+          },
+          {
+            "kind": "github-actions-job",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29103953982/job/86399623556",
+            "public": true,
+            "description": "Successful v0.3.0 build and mock API verifier job on commit 519586eb325453f5b26f541e9fac70e583109441. The job ran pnpm build plus mock OpenAI, mock Gemini, and mock model discovery verifiers."
+          }
+        ],
+        "summary": "v0.3.0 Linux package validation passed in GitHub Actions run 29103953982 on commit 519586eb325453f5b26f541e9fac70e583109441. The Linux package job installed Linux smoke-test dependencies, built the Linux package with pnpm package, and passed pnpm verify:release:linux. The same CI run's build and mock API verifier job passed pnpm build, pnpm verify:mock-api, pnpm verify:mock-gemini-api, and pnpm verify:mock-model-discovery on the same commit. For v0.3.0, direct AppImage launch is not a mandatory release gate because FUSE support is environment-dependent; the verifier retains direct launch as best-effort and requires AppImage extraction plus extracted app smoke coverage in CI."
+      }
+    },
+    {
+      "id": "update-manifest-assets",
+      "title": "Formal update manifest distribution assets",
+      "required": true,
+      "status": "passed",
+      "acceptanceCriteria": [
+        "Distribution artifacts are uploaded to a public HTTPS v0.3.0 release URL.",
+        "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata for v0.3.0.",
+        "Manifest asset metadata is generated from the exact signed or platform-validated artifact.",
+        "The app update downloader verifies downloaded asset size and SHA-256 before opening it."
+      ],
+      "evidence": {
+        "verifiedAt": "2026-07-13T10:46:40.885Z",
+        "commit": "fe50393b1b711617acd4373af5c05ff733a9ac56",
+        "environment": "Windows 11 Pro 10.0.26100 x64 hotfix shell for the published v0.3.0 release; package version 0.3.0; public GitHub release tag v0.3.0 already exists and the Windows asset metadata is being refreshed to match the rebuilt installer from commit fe50393b1b711617acd4373af5c05ff733a9ac56.",
+        "commands": [
+          "pnpm package:win",
+          "node scripts/update-manifest-asset.mjs --file release/CrossGen-Setup.exe --platform win32 --arch x64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-Setup.exe",
+          "Get-FileHash -Algorithm SHA256 .\\release\\CrossGen-Setup.exe, .\\release\\CrossGen-Setup.exe.blockmap",
+          "(Get-Item .\\release\\CrossGen-Setup.exe).Length",
+          "pnpm verify:release-evidence -- --require-complete"
+        ],
+        "references": [
+          {
+            "label": "Formal update manifest distribution asset tracker",
+            "url": "https://github.com/Bliveren/CrossGen/issues/103"
+          },
+          {
+            "label": "v0.3.0 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.0"
+          }
+        ],
+        "artifacts": [
+          {
+            "kind": "update-manifest",
+            "path": "docs/updates/latest.json",
+            "public": true,
+            "description": "v0.3.0 update manifest with public GitHub Release URLs for macOS arm64 DMG and Windows x64 installer."
+          },
+          {
+            "kind": "macos-dmg",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-0.3.0-mac-arm64.dmg",
+            "public": true,
+            "description": "Developer ID signed CrossGen-0.3.0-mac-arm64.dmg; SHA256 3e379ea62c849c949b2d756c4dc60c0c1ef1b4f78b82506a9b47213fb31c3d30; 103573862 bytes; local macOS release verifier passed."
+          },
+          {
+            "kind": "windows-nsis-installer",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-Setup.exe",
+            "public": true,
+            "description": "CrossGen-Setup.exe Windows x64 NSIS installer hotfix rebuild for updater launch stability; SHA256 5c7781c761888fbf9828c4947fa0be7fc330149c8fbf344912f583f7616ccd53; 98758475 bytes; Windows native full-install release gate is recorded separately in windows-native-release."
+          }
+        ],
+        "summary": "The published v0.3.0 update manifest is being refreshed so its Windows entry matches the hotfix-rebuilt CrossGen x64 NSIS installer from commit fe50393b1b711617acd4373af5c05ff733a9ac56. The macOS DMG entry remains unchanged. The Windows manifest entry now records SHA256 5c7781c761888fbf9828c4947fa0be7fc330149c8fbf344912f583f7616ccd53 and 98758475 bytes, which match the rebuilt installer that passed native Windows package-smoke and full-install verification. The app update downloader continues to verify both sizeBytes and sha256 before opening an installer."
+      }
+    }
+  ]
+}

--- a/docs/release/v0.3.1-preflight.md
+++ b/docs/release/v0.3.1-preflight.md
@@ -1,8 +1,9 @@
 # v0.3.1 Release Preflight
 
-Status: release planning checklist. Treat `docs/release/v0.3.1-evidence.json`
-as the candidate 0.3.1 evidence ledger until the final release branch bumps
-`package.json` and promotes the evidence to `docs/release/evidence.json`.
+Status: release planning checklist. `docs/release/v0.3.1-evidence.json`
+records the candidate 0.3.1 evidence gathered before the version bump;
+`docs/release/evidence.json` is the active 0.3.1 release ledger once
+`package.json` is bumped to `0.3.1`.
 
 v0.3.1 is an agent-ready local runtime release. It is not complete until a
 local agent can discover providers and models, submit generate and edit work

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crossgen",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "One-stop AI image generation manager for API access, model discovery, Gallery/history reuse, and lightweight image editing.",
   "author": "Nowo, Corgnitor, and CrossGen contributors",
   "license": "MIT",

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -69,19 +69,23 @@ function completeLedger() {
 }
 
 describe("release evidence verifier", () => {
-  it("validates the completed release evidence ledger", async () => {
+  it("validates the default v0.3.1 release evidence ledger", async () => {
     const result = await run([]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 5/5 required gate(s) passed.");
-    expect(result.stdout).not.toContain("Pending required gate(s):");
+    expect(result.stdout).toContain("Release evidence validated: 8/12 required gate(s) passed.");
+    expect(result.stdout).toContain("Pending required gate(s):");
+    expect(result.stdout).toContain("macos-signed");
+    expect(result.stdout).toContain("update-manifest-assets");
   });
 
-  it("passes --require-complete for the completed release ledger", async () => {
+  it("fails --require-complete for the default pending v0.3.1 release ledger", async () => {
     const result = await run(["--require-complete"]);
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 5/5 required gate(s) passed.");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Required release evidence gates are not passed");
+    expect(result.stderr).toContain("macos-signed");
+    expect(result.stderr).toContain("update-manifest-assets");
   });
 
   it("fails --require-complete when a required gate is still pending", async () => {
@@ -102,7 +106,7 @@ describe("release evidence verifier", () => {
       const filePath = path.join(tempRoot, "evidence.json");
       await writeFile(filePath, JSON.stringify(ledger, null, 2));
 
-      const result = await run(["--file", filePath, "--require-complete"]);
+      const result = await run(["--file", filePath, "--expected-version", "0.3.0", "--require-complete"]);
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("Required release evidence gates are not passed");
@@ -118,7 +122,7 @@ describe("release evidence verifier", () => {
       const filePath = path.join(tempRoot, "evidence.json");
       await writeFile(filePath, JSON.stringify(completeLedger(), null, 2));
 
-      const result = await run(["--file", filePath, "--require-complete"]);
+      const result = await run(["--file", filePath, "--expected-version", "0.3.0", "--require-complete"]);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Release evidence validated: 7/7 required gate(s) passed.");
@@ -212,7 +216,7 @@ describe("release evidence verifier", () => {
         )
       );
 
-      const result = await run([], { cwd: tempRoot });
+      const result = await run(["--expected-version", "0.3.0"], { cwd: tempRoot });
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("Record Apple notarization status from actual notarization output.");

--- a/src/shared/package-config.test.ts
+++ b/src/shared/package-config.test.ts
@@ -3,9 +3,9 @@ import packageJson from "../../package.json";
 import updateManifest from "../../docs/updates/latest.json";
 
 describe("package release configuration", () => {
-  it("stages the v0.3.0 release metadata", () => {
+  it("stages the v0.3.1 release metadata", () => {
     expect(packageJson.name).toBe("crossgen");
-    expect(packageJson.version).toBe("0.3.0");
+    expect(packageJson.version).toBe("0.3.1");
     expect(packageJson.description).toContain("One-stop AI image generation manager");
     expect(packageJson.description).toContain("API access");
     expect(packageJson.description).toContain("Gallery/history reuse");
@@ -18,7 +18,7 @@ describe("package release configuration", () => {
   });
 
   it("keeps a published update manifest with verifiable size and sha256", () => {
-    // The manifest describes the latest published assets until the 0.3.0
+    // The manifest describes the latest published assets until the 0.3.1
     // artifacts are uploaded and verified. Validate shape, not version equality.
     expect(typeof updateManifest.version).toBe("string");
     expect(updateManifest.version.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- bump package release metadata to v0.3.1
- promote the active release evidence ledger to v0.3.1
- archive the v0.3.0 release evidence ledger

## Validation
- pnpm exec vitest run src/shared/package-config.test.ts scripts/verify-release-evidence.test.mjs scripts/verify-mac-release.test.mjs
- pnpm verify:release-evidence
- git diff --check