### PR TITLE
docs: record final v0.3.1 release evidence

### DIFF
--- a/docs/release/evidence.json
+++ b/docs/release/evidence.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "releaseVersion": "0.3.1",
-  "lastUpdated": "2026-07-14T02:11:19.000Z",
+  "lastUpdated": "2026-07-14T02:58:04.000Z",
   "gates": [
     {
       "id": "real-openai-api",
@@ -275,7 +275,7 @@
       "id": "windows-native-release",
       "title": "Native Windows release package validation",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Windows package verifier runs against the v0.3.1 artifact.",
         "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass in full-install evidence.",
@@ -283,25 +283,65 @@
         "Download and open-folder behavior are checked on native Windows."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T02:58:04.000Z",
+        "commit": "20cb2f9fff350910fa2bd89b237347fc218f6d56",
+        "environment": "GitHub-hosted native Windows release runner on tag v0.3.1. The workflow built the x64 NSIS installer, ran Windows package verification in full-install mode, uploaded workflow artifacts, and published the installer plus blockmap to the v0.3.1 GitHub Release.",
+        "commands": [
+          "git push --force origin v0.3.1",
+          "Release Windows workflow run 29301942374",
+          "pnpm package:win",
+          "IMAGE2TOOLS_WINDOWS_VERIFY_MODE=full-install pnpm verify:release:windows",
+          "gh release download v0.3.1 -D /tmp/crossgen-v031-release-assets --clobber",
+          "shasum -a 256 /tmp/crossgen-v031-release-assets/CrossGen-Setup.exe /tmp/crossgen-v031-release-assets/CrossGen-Setup.exe.blockmap"
+        ],
         "references": [
           {
             "label": "Native Windows release validation tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/4"
+          },
+          {
+            "label": "Release Windows run 29301942374",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942374"
+          },
+          {
+            "label": "CrossGen v0.3.1 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.1"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 native Windows release package validation."
+        "artifacts": [
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942374",
+            "public": true,
+            "description": "Release Windows run passed Package Windows app, Verify Windows package in full-install mode, Upload Windows release artifact, and Publish GitHub Release asset."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe",
+            "fileName": "CrossGen-Setup.exe",
+            "sha256": "54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0",
+            "size": 98816143,
+            "public": true,
+            "description": "Windows x64 NSIS installer published by Release Windows run 29301942374."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe.blockmap",
+            "fileName": "CrossGen-Setup.exe.blockmap",
+            "sha256": "aa67ba2771dd666a3614fcaafb56940b6a4e6762f8e022e2e402964fdf0e24be",
+            "size": 103792,
+            "public": true,
+            "description": "Windows NSIS blockmap published with the v0.3.1 Windows installer."
+          }
+        ],
+        "summary": "Passed on native Windows release workflow run 29301942374 from tag v0.3.1 at commit 20cb2f9fff350910fa2bd89b237347fc218f6d56. The verifier confirmed the installer PE, unpacked x64 app PE, unpacked app launch and main-window detection, NSIS silent install with fallback-compatible args, installed app launch, and silent uninstall. The published Windows installer is 98816143 bytes with SHA-256 54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0."
       }
     },
     {
       "id": "linux-native-release",
       "title": "CI Linux package and AppImage validation",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Linux release verifier runs in the GitHub Actions Linux package job against the v0.3.1 AppImage and unpacked Linux artifact.",
         "Direct AppImage execution is best-effort when FUSE support is available; AppImage extraction and extracted app smoke verification cover CI environments without direct AppImage support.",
@@ -309,29 +349,58 @@
         "Linux-specific release coverage focuses on package creation, AppImage verification, Linux launch smoke, and packaged command-mode behavior."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T02:58:04.000Z",
+        "commit": "20cb2f9fff350910fa2bd89b237347fc218f6d56",
+        "environment": "GitHub-hosted Ubuntu release runner on tag v0.3.1. The workflow built the Linux AppImage, ran packaged CLI/MCP and agent integration smoke through xvfb, verified the Linux package, uploaded workflow artifacts, and published the AppImage to the v0.3.1 GitHub Release.",
+        "commands": [
+          "git push --force origin v0.3.1",
+          "Release Linux workflow run 29301942367",
+          "pnpm package",
+          "CROSSGEN_APP_EXECUTABLE=<packaged linux executable> CROSSGEN_APP_EXTRA_ARGS=--no-sandbox xvfb-run -a node scripts/verify-cli-mcp-smoke.mjs",
+          "CROSSGEN_APP_EXECUTABLE=<packaged linux executable> CROSSGEN_APP_EXTRA_ARGS=--no-sandbox xvfb-run -a node scripts/verify-agent-integration-smoke.mjs",
+          "pnpm verify:release:linux",
+          "gh release download v0.3.1 -D /tmp/crossgen-v031-release-assets --clobber",
+          "shasum -a 256 /tmp/crossgen-v031-release-assets/CrossGen-0.3.1-linux-x86_64.AppImage"
+        ],
         "references": [
           {
-            "label": "Linux package and AppImage validation tracker",
+            "label": "CI Linux package and AppImage validation tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/4"
           },
           {
-            "label": "CI workflow",
-            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
+            "label": "Release Linux run 29301942367",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942367"
+          },
+          {
+            "label": "CrossGen v0.3.1 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.1"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 CI Linux package, AppImage, launch, and packaged CLI/MCP evidence."
+        "artifacts": [
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942367",
+            "public": true,
+            "description": "Release Linux run passed Linux packaging, packaged CLI/MCP smoke, agent integration smoke, Linux package verification, artifact upload, and GitHub Release publishing."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-linux-x86_64.AppImage",
+            "fileName": "CrossGen-0.3.1-linux-x86_64.AppImage",
+            "sha256": "ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb",
+            "size": 120565331,
+            "public": true,
+            "description": "Linux x64 AppImage published by Release Linux run 29301942367."
+          }
+        ],
+        "summary": "Passed on Release Linux workflow run 29301942367 from tag v0.3.1 at commit 20cb2f9fff350910fa2bd89b237347fc218f6d56. The published Linux AppImage is 120565331 bytes with SHA-256 ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb."
       }
     },
     {
       "id": "update-manifest-assets",
       "title": "Formal update manifest distribution assets",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Distribution artifacts are uploaded to a public HTTPS v0.3.1 release URL.",
         "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata for v0.3.1.",
@@ -339,18 +408,73 @@
         "The app update downloader verifies downloaded asset size and SHA-256 before opening it."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T02:58:04.000Z",
+        "commit": "20cb2f9fff350910fa2bd89b237347fc218f6d56",
+        "environment": "Local manifest update from public GitHub Release v0.3.1 assets downloaded after macOS, Windows, and Linux release assets were published. Hashes and sizes were computed from downloaded release assets, not from unpublished build outputs.",
+        "commands": [
+          "gh release view v0.3.1 --json assets,tagName,url,isDraft,isPrerelease",
+          "gh release download v0.3.1 -D /tmp/crossgen-v031-release-assets --clobber",
+          "shasum -a 256 /tmp/crossgen-v031-release-assets/*",
+          "wc -c /tmp/crossgen-v031-release-assets/*",
+          "node scripts/update-manifest-asset.mjs --file /tmp/crossgen-v031-release-assets/CrossGen-0.3.1-mac-arm64.dmg --platform darwin --arch arm64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-mac-arm64.dmg",
+          "node scripts/update-manifest-asset.mjs --file /tmp/crossgen-v031-release-assets/CrossGen-Setup.exe --platform win32 --arch x64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe",
+          "node scripts/update-manifest-asset.mjs --file /tmp/crossgen-v031-release-assets/CrossGen-0.3.1-linux-x86_64.AppImage --platform linux --arch x64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-linux-x86_64.AppImage",
+          "pnpm verify:release-evidence -- --require-complete"
+        ],
         "references": [
           {
-            "label": "Formal update manifest distribution asset tracker",
+            "label": "Formal update manifest distribution assets tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/103"
+          },
+          {
+            "label": "CrossGen v0.3.1 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.1"
+          },
+          {
+            "label": "Release Windows run 29301942374",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942374"
+          },
+          {
+            "label": "Release Linux run 29301942367",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942367"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 public release asset upload and update manifest evidence."
+        "artifacts": [
+          {
+            "kind": "manifest-file",
+            "path": "docs/updates/latest.json",
+            "public": true,
+            "description": "Update manifest now points to v0.3.1 public release assets for darwin arm64 DMG, Windows x64 NSIS installer, and Linux x64 AppImage with exact SHA-256 and sizeBytes values."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-mac-arm64.dmg",
+            "fileName": "CrossGen-0.3.1-mac-arm64.dmg",
+            "sha256": "88965b0064534e9b596d5f82a4889e645021ff8b67bd370e31936434baa66f11",
+            "size": 103663616,
+            "public": true,
+            "description": "Manifest darwin arm64 asset."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe",
+            "fileName": "CrossGen-Setup.exe",
+            "sha256": "54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0",
+            "size": 98816143,
+            "public": true,
+            "description": "Manifest win32 x64 asset."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-linux-x86_64.AppImage",
+            "fileName": "CrossGen-0.3.1-linux-x86_64.AppImage",
+            "sha256": "ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb",
+            "size": 120565331,
+            "public": true,
+            "description": "Manifest linux x64 asset."
+          }
+        ],
+        "summary": "Passed. docs/updates/latest.json now advertises v0.3.1 and points to public GitHub Release assets whose downloaded bytes match the recorded SHA-256 and sizeBytes values: macOS DMG 88965b0064534e9b596d5f82a4889e645021ff8b67bd370e31936434baa66f11 / 103663616 bytes, Windows installer 54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0 / 98816143 bytes, Linux AppImage ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb / 120565331 bytes."
       }
     },
     {

--- a/docs/release/v0.3.1-evidence.json
+++ b/docs/release/v0.3.1-evidence.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "releaseVersion": "0.3.1",
-  "lastUpdated": "2026-07-14T02:11:19.000Z",
+  "lastUpdated": "2026-07-14T02:58:04.000Z",
   "gates": [
     {
       "id": "real-openai-api",
@@ -275,7 +275,7 @@
       "id": "windows-native-release",
       "title": "Native Windows release package validation",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Windows package verifier runs against the v0.3.1 artifact.",
         "NSIS silent install, installed app launch, main-window detection, and silent uninstall pass in full-install evidence.",
@@ -283,25 +283,65 @@
         "Download and open-folder behavior are checked on native Windows."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T02:58:04.000Z",
+        "commit": "20cb2f9fff350910fa2bd89b237347fc218f6d56",
+        "environment": "GitHub-hosted native Windows release runner on tag v0.3.1. The workflow built the x64 NSIS installer, ran Windows package verification in full-install mode, uploaded workflow artifacts, and published the installer plus blockmap to the v0.3.1 GitHub Release.",
+        "commands": [
+          "git push --force origin v0.3.1",
+          "Release Windows workflow run 29301942374",
+          "pnpm package:win",
+          "IMAGE2TOOLS_WINDOWS_VERIFY_MODE=full-install pnpm verify:release:windows",
+          "gh release download v0.3.1 -D /tmp/crossgen-v031-release-assets --clobber",
+          "shasum -a 256 /tmp/crossgen-v031-release-assets/CrossGen-Setup.exe /tmp/crossgen-v031-release-assets/CrossGen-Setup.exe.blockmap"
+        ],
         "references": [
           {
             "label": "Native Windows release validation tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/4"
+          },
+          {
+            "label": "Release Windows run 29301942374",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942374"
+          },
+          {
+            "label": "CrossGen v0.3.1 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.1"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 native Windows release package validation."
+        "artifacts": [
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942374",
+            "public": true,
+            "description": "Release Windows run passed Package Windows app, Verify Windows package in full-install mode, Upload Windows release artifact, and Publish GitHub Release asset."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe",
+            "fileName": "CrossGen-Setup.exe",
+            "sha256": "54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0",
+            "size": 98816143,
+            "public": true,
+            "description": "Windows x64 NSIS installer published by Release Windows run 29301942374."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe.blockmap",
+            "fileName": "CrossGen-Setup.exe.blockmap",
+            "sha256": "aa67ba2771dd666a3614fcaafb56940b6a4e6762f8e022e2e402964fdf0e24be",
+            "size": 103792,
+            "public": true,
+            "description": "Windows NSIS blockmap published with the v0.3.1 Windows installer."
+          }
+        ],
+        "summary": "Passed on native Windows release workflow run 29301942374 from tag v0.3.1 at commit 20cb2f9fff350910fa2bd89b237347fc218f6d56. The verifier confirmed the installer PE, unpacked x64 app PE, unpacked app launch and main-window detection, NSIS silent install with fallback-compatible args, installed app launch, and silent uninstall. The published Windows installer is 98816143 bytes with SHA-256 54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0."
       }
     },
     {
       "id": "linux-native-release",
       "title": "CI Linux package and AppImage validation",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Linux release verifier runs in the GitHub Actions Linux package job against the v0.3.1 AppImage and unpacked Linux artifact.",
         "Direct AppImage execution is best-effort when FUSE support is available; AppImage extraction and extracted app smoke verification cover CI environments without direct AppImage support.",
@@ -309,29 +349,58 @@
         "Linux-specific release coverage focuses on package creation, AppImage verification, Linux launch smoke, and packaged command-mode behavior."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T02:58:04.000Z",
+        "commit": "20cb2f9fff350910fa2bd89b237347fc218f6d56",
+        "environment": "GitHub-hosted Ubuntu release runner on tag v0.3.1. The workflow built the Linux AppImage, ran packaged CLI/MCP and agent integration smoke through xvfb, verified the Linux package, uploaded workflow artifacts, and published the AppImage to the v0.3.1 GitHub Release.",
+        "commands": [
+          "git push --force origin v0.3.1",
+          "Release Linux workflow run 29301942367",
+          "pnpm package",
+          "CROSSGEN_APP_EXECUTABLE=<packaged linux executable> CROSSGEN_APP_EXTRA_ARGS=--no-sandbox xvfb-run -a node scripts/verify-cli-mcp-smoke.mjs",
+          "CROSSGEN_APP_EXECUTABLE=<packaged linux executable> CROSSGEN_APP_EXTRA_ARGS=--no-sandbox xvfb-run -a node scripts/verify-agent-integration-smoke.mjs",
+          "pnpm verify:release:linux",
+          "gh release download v0.3.1 -D /tmp/crossgen-v031-release-assets --clobber",
+          "shasum -a 256 /tmp/crossgen-v031-release-assets/CrossGen-0.3.1-linux-x86_64.AppImage"
+        ],
         "references": [
           {
-            "label": "Linux package and AppImage validation tracker",
+            "label": "CI Linux package and AppImage validation tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/4"
           },
           {
-            "label": "CI workflow",
-            "url": "https://github.com/Bliveren/CrossGen/actions/workflows/ci.yml"
+            "label": "Release Linux run 29301942367",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942367"
+          },
+          {
+            "label": "CrossGen v0.3.1 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.1"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 CI Linux package, AppImage, launch, and packaged CLI/MCP evidence."
+        "artifacts": [
+          {
+            "kind": "ci-run",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942367",
+            "public": true,
+            "description": "Release Linux run passed Linux packaging, packaged CLI/MCP smoke, agent integration smoke, Linux package verification, artifact upload, and GitHub Release publishing."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-linux-x86_64.AppImage",
+            "fileName": "CrossGen-0.3.1-linux-x86_64.AppImage",
+            "sha256": "ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb",
+            "size": 120565331,
+            "public": true,
+            "description": "Linux x64 AppImage published by Release Linux run 29301942367."
+          }
+        ],
+        "summary": "Passed on Release Linux workflow run 29301942367 from tag v0.3.1 at commit 20cb2f9fff350910fa2bd89b237347fc218f6d56. The published Linux AppImage is 120565331 bytes with SHA-256 ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb."
       }
     },
     {
       "id": "update-manifest-assets",
       "title": "Formal update manifest distribution assets",
       "required": true,
-      "status": "pending",
+      "status": "passed",
       "acceptanceCriteria": [
         "Distribution artifacts are uploaded to a public HTTPS v0.3.1 release URL.",
         "docs/updates/latest.json contains matching asset URL, fileName, sha256, and sizeBytes metadata for v0.3.1.",
@@ -339,18 +408,73 @@
         "The app update downloader verifies downloaded asset size and SHA-256 before opening it."
       ],
       "evidence": {
-        "verifiedAt": null,
-        "commit": null,
-        "environment": null,
-        "commands": [],
+        "verifiedAt": "2026-07-14T02:58:04.000Z",
+        "commit": "20cb2f9fff350910fa2bd89b237347fc218f6d56",
+        "environment": "Local manifest update from public GitHub Release v0.3.1 assets downloaded after macOS, Windows, and Linux release assets were published. Hashes and sizes were computed from downloaded release assets, not from unpublished build outputs.",
+        "commands": [
+          "gh release view v0.3.1 --json assets,tagName,url,isDraft,isPrerelease",
+          "gh release download v0.3.1 -D /tmp/crossgen-v031-release-assets --clobber",
+          "shasum -a 256 /tmp/crossgen-v031-release-assets/*",
+          "wc -c /tmp/crossgen-v031-release-assets/*",
+          "node scripts/update-manifest-asset.mjs --file /tmp/crossgen-v031-release-assets/CrossGen-0.3.1-mac-arm64.dmg --platform darwin --arch arm64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-mac-arm64.dmg",
+          "node scripts/update-manifest-asset.mjs --file /tmp/crossgen-v031-release-assets/CrossGen-Setup.exe --platform win32 --arch x64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe",
+          "node scripts/update-manifest-asset.mjs --file /tmp/crossgen-v031-release-assets/CrossGen-0.3.1-linux-x86_64.AppImage --platform linux --arch x64 --url https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-linux-x86_64.AppImage",
+          "pnpm verify:release-evidence -- --require-complete"
+        ],
         "references": [
           {
-            "label": "Formal update manifest distribution asset tracker",
+            "label": "Formal update manifest distribution assets tracker",
             "url": "https://github.com/Bliveren/CrossGen/issues/103"
+          },
+          {
+            "label": "CrossGen v0.3.1 GitHub Release",
+            "url": "https://github.com/Bliveren/CrossGen/releases/tag/v0.3.1"
+          },
+          {
+            "label": "Release Windows run 29301942374",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942374"
+          },
+          {
+            "label": "Release Linux run 29301942367",
+            "url": "https://github.com/Bliveren/CrossGen/actions/runs/29301942367"
           }
         ],
-        "artifacts": [],
-        "summary": "Pending v0.3.1 public release asset upload and update manifest evidence."
+        "artifacts": [
+          {
+            "kind": "manifest-file",
+            "path": "docs/updates/latest.json",
+            "public": true,
+            "description": "Update manifest now points to v0.3.1 public release assets for darwin arm64 DMG, Windows x64 NSIS installer, and Linux x64 AppImage with exact SHA-256 and sizeBytes values."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-mac-arm64.dmg",
+            "fileName": "CrossGen-0.3.1-mac-arm64.dmg",
+            "sha256": "88965b0064534e9b596d5f82a4889e645021ff8b67bd370e31936434baa66f11",
+            "size": 103663616,
+            "public": true,
+            "description": "Manifest darwin arm64 asset."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe",
+            "fileName": "CrossGen-Setup.exe",
+            "sha256": "54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0",
+            "size": 98816143,
+            "public": true,
+            "description": "Manifest win32 x64 asset."
+          },
+          {
+            "kind": "release-asset",
+            "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-linux-x86_64.AppImage",
+            "fileName": "CrossGen-0.3.1-linux-x86_64.AppImage",
+            "sha256": "ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb",
+            "size": 120565331,
+            "public": true,
+            "description": "Manifest linux x64 asset."
+          }
+        ],
+        "summary": "Passed. docs/updates/latest.json now advertises v0.3.1 and points to public GitHub Release assets whose downloaded bytes match the recorded SHA-256 and sizeBytes values: macOS DMG 88965b0064534e9b596d5f82a4889e645021ff8b67bd370e31936434baa66f11 / 103663616 bytes, Windows installer 54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0 / 98816143 bytes, Linux AppImage ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb / 120565331 bytes."
       }
     },
     {

--- a/docs/release/v0.3.1-final-release-gate.md
+++ b/docs/release/v0.3.1-final-release-gate.md
@@ -1,0 +1,58 @@
+# v0.3.1 Final Release Gate
+
+Status: passed on 2026-07-14.
+
+Release tag:
+
+- `v0.3.1`
+- Commit: `20cb2f9fff350910fa2bd89b237347fc218f6d56`
+- Release: <https://github.com/Bliveren/CrossGen/releases/tag/v0.3.1>
+
+## Workflows
+
+| Gate | Run | Result |
+| --- | --- | --- |
+| Windows release | <https://github.com/Bliveren/CrossGen/actions/runs/29301942374> | Passed |
+| Linux release | <https://github.com/Bliveren/CrossGen/actions/runs/29301942367> | Passed |
+
+Windows release run `29301942374` built the NSIS installer and passed
+`IMAGE2TOOLS_WINDOWS_VERIFY_MODE=full-install pnpm verify:release:windows`.
+The verifier checked the installer PE, unpacked x64 app PE, unpacked app
+launch/main-window detection, NSIS silent install, installed app launch, and
+silent uninstall.
+
+Linux release run `29301942367` built the AppImage and passed packaged
+CLI/MCP smoke, agent integration smoke, and `pnpm verify:release:linux`.
+
+## Public Assets
+
+The public release assets were downloaded with:
+
+```bash
+gh release download v0.3.1 -D /tmp/crossgen-v031-release-assets --clobber
+shasum -a 256 /tmp/crossgen-v031-release-assets/*
+wc -c /tmp/crossgen-v031-release-assets/*
+```
+
+| Asset | Size | SHA-256 |
+| --- | ---: | --- |
+| `CrossGen-0.3.1-mac-arm64.dmg` | 103663616 | `88965b0064534e9b596d5f82a4889e645021ff8b67bd370e31936434baa66f11` |
+| `CrossGen-0.3.1-mac-arm64.dmg.blockmap` | 108711 | `62e644d8a71bb4342bf028f7cbd49516049c043318bd86c3206599e0587be8bd` |
+| `CrossGen-0.3.1-mac-arm64.zip` | 99355182 | `04497b03ed7fe34fa2c1d042250b19c36700f4774928d0f6ea91c0cd431555a0` |
+| `CrossGen-0.3.1-mac-arm64.zip.blockmap` | 104527 | `026769261db58e69f1dee21b50ae51d37062feedcd2076723dc33bd28dcb9c99` |
+| `CrossGen-Setup.exe` | 98816143 | `54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0` |
+| `CrossGen-Setup.exe.blockmap` | 103792 | `aa67ba2771dd666a3614fcaafb56940b6a4e6762f8e022e2e402964fdf0e24be` |
+| `CrossGen-0.3.1-linux-x86_64.AppImage` | 120565331 | `ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb` |
+
+## Update Manifest
+
+`docs/updates/latest.json` now advertises `0.3.1` and points to these public
+installer assets:
+
+- macOS arm64 DMG
+- Windows x64 NSIS installer
+- Linux x64 AppImage
+
+Each manifest asset was generated with `scripts/update-manifest-asset.mjs`
+from the downloaded public release asset, so `sha256` and `sizeBytes` match the
+published files.

--- a/docs/release/v0.3.1-preflight.md
+++ b/docs/release/v0.3.1-preflight.md
@@ -118,23 +118,23 @@ Required checks:
 - [ ] Create a clean `release/v0.3.1` branch/worktree from latest `origin/main`.
 - [ ] Confirm no preserved untracked release files need to be carried into this
   worktree.
-- [ ] Bump `package.json` to `0.3.1`.
-- [ ] Promote `docs/release/v0.3.1-evidence.json` to
+- [x] Bump `package.json` to `0.3.1`.
+- [x] Promote `docs/release/v0.3.1-evidence.json` to
   `docs/release/evidence.json` for the final release branch.
-- [ ] Run `pnpm build` from the v0.3.1 release branch.
-- [ ] Run `pnpm verify:mock-api`, `pnpm verify:mock-gemini-api`, and `pnpm verify:mock-model-discovery`.
-- [ ] Run packaged CLI and MCP smoke against the packaged app.
-- [ ] Run agent integration smoke for Codex, Claude Code, and Cursor configuration output.
-- [ ] Run queue concurrency smoke for default concurrency 1, explicit bounded concurrency 2, and two-host claim safety.
-- [ ] Run Gallery mutation smoke for folder, asset, export, path-confirmation, duplicate, and concurrent mutation behavior.
-- [ ] Run the image core regression checklist for generation, edit, inpaint, partial streaming, provider switching, Gallery, and editor workflows.
-- [ ] Complete real OpenAI-compatible GPT Image acceptance.
-- [ ] Complete real Gemini-compatible image acceptance.
+- [x] Run `pnpm build` from the v0.3.1 release branch.
+- [x] Run `pnpm verify:mock-api`, `pnpm verify:mock-gemini-api`, and `pnpm verify:mock-model-discovery`.
+- [x] Run packaged CLI and MCP smoke against the packaged app.
+- [x] Run agent integration smoke for Codex, Claude Code, and Cursor configuration output.
+- [x] Run queue concurrency smoke for default concurrency 1, explicit bounded concurrency 2, and two-host claim safety.
+- [x] Run Gallery mutation smoke for folder, asset, export, path-confirmation, duplicate, and concurrent mutation behavior.
+- [x] Run the image core regression checklist for generation, edit, inpaint, partial streaming, provider switching, Gallery, and editor workflows.
+- [x] Complete real OpenAI-compatible GPT Image acceptance.
+- [x] Complete real Gemini-compatible image acceptance.
 - [x] Build and verify Developer ID signed macOS release assets.
 - [x] Record Apple notarization status from actual notarization output.
-- [ ] Produce and validate native Windows release assets.
-- [ ] Produce and validate Linux release assets through CI.
-- [ ] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.
-- [ ] Run `pnpm verify:release-evidence -- --require-complete` on the final v0.3.1 release branch.
-- [ ] Create and push `v0.3.1` tag.
-- [ ] Create GitHub Release with assets matching the update manifest.
+- [x] Produce and validate native Windows release assets.
+- [x] Produce and validate Linux release assets through CI.
+- [x] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.
+- [x] Run `pnpm verify:release-evidence -- --require-complete` on the final v0.3.1 release branch.
+- [x] Create and push `v0.3.1` tag.
+- [x] Create GitHub Release with assets matching the update manifest.

--- a/docs/updates/latest.json
+++ b/docs/updates/latest.json
@@ -1,22 +1,30 @@
 {
-  "version": "0.3.0",
-  "pubDate": "2026-07-12T15:41:25.000Z",
-  "notes": "CrossGen 0.3.0 introduces the one-stop AI image generation manager: API access management, automatic model and route probing, Gallery and History reuse, prompt templates, lightweight image editing, and dark mode.",
+  "version": "0.3.1",
+  "pubDate": "2026-07-14T02:58:04.000Z",
+  "notes": "CrossGen 0.3.1 adds an agent-ready local runtime with CLI/MCP access, queue-backed generation, model and provider discovery, Gallery asset operations, and signed release packages.",
   "assets": [
     {
       "platform": "darwin",
-      "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-0.3.0-mac-arm64.dmg",
-      "fileName": "CrossGen-0.3.0-mac-arm64.dmg",
-      "sha256": "3e379ea62c849c949b2d756c4dc60c0c1ef1b4f78b82506a9b47213fb31c3d30",
-      "sizeBytes": 103573862,
+      "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-mac-arm64.dmg",
+      "fileName": "CrossGen-0.3.1-mac-arm64.dmg",
+      "sha256": "88965b0064534e9b596d5f82a4889e645021ff8b67bd370e31936434baa66f11",
+      "sizeBytes": 103663616,
       "arch": "arm64"
     },
     {
       "platform": "win32",
-      "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.0/CrossGen-Setup.exe",
+      "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-Setup.exe",
       "fileName": "CrossGen-Setup.exe",
-      "sha256": "5c7781c761888fbf9828c4947fa0be7fc330149c8fbf344912f583f7616ccd53",
-      "sizeBytes": 98758475,
+      "sha256": "54c586a9aee53b164c07f805ae3f6db37216e4f39c1b17734fc6bdbf7162feb0",
+      "sizeBytes": 98816143,
+      "arch": "x64"
+    },
+    {
+      "platform": "linux",
+      "url": "https://github.com/Bliveren/CrossGen/releases/download/v0.3.1/CrossGen-0.3.1-linux-x86_64.AppImage",
+      "fileName": "CrossGen-0.3.1-linux-x86_64.AppImage",
+      "sha256": "ce7513f1ebe102f61fe6ce30fd1aa492ab35056ee903c6f9454cb357d41a45eb",
+      "sizeBytes": 120565331,
       "arch": "x64"
     }
   ]

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -73,23 +73,19 @@ describe("release evidence verifier", () => {
     const result = await run([]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 9/12 required gate(s) passed.");
-    expect(result.stdout).toContain("Pending required gate(s):");
-    expect(result.stdout).toContain("windows-native-release");
-    expect(result.stdout).toContain("linux-native-release");
-    expect(result.stdout).toContain("update-manifest-assets");
-    expect(result.stdout).not.toContain("macos-signed");
+    expect(result.stdout).toContain("Release evidence validated: 12/12 required gate(s) passed.");
+    expect(result.stdout).not.toContain("Pending required gate(s):");
+    expect(result.stdout).not.toContain("windows-native-release");
+    expect(result.stdout).not.toContain("linux-native-release");
+    expect(result.stdout).not.toContain("update-manifest-assets");
   });
 
-  it("fails --require-complete for the default pending v0.3.1 release ledger", async () => {
+  it("passes --require-complete for the default complete v0.3.1 release ledger", async () => {
     const result = await run(["--require-complete"]);
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("Required release evidence gates are not passed");
-    expect(result.stderr).toContain("windows-native-release");
-    expect(result.stderr).toContain("linux-native-release");
-    expect(result.stderr).toContain("update-manifest-assets");
-    expect(result.stderr).not.toContain("macos-signed");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Release evidence validated: 12/12 required gate(s) passed.");
+    expect(result.stderr).not.toContain("Required release evidence gates are not passed");
   });
 
   it("fails --require-complete when a required gate is still pending", async () => {
@@ -139,18 +135,18 @@ describe("release evidence verifier", () => {
     const result = await run(["--file", "docs/release/v0.3.1-evidence.json", "--expected-version", "0.3.1"]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated: 9/12 required gate(s) passed.");
-    expect(result.stdout).toContain("Pending required gate(s):");
-    expect(result.stdout).toContain("windows-native-release");
-    expect(result.stdout).toContain("linux-native-release");
-    expect(result.stdout).toContain("update-manifest-assets");
+    expect(result.stdout).toContain("Release evidence validated: 12/12 required gate(s) passed.");
+    expect(result.stdout).not.toContain("Pending required gate(s):");
+    expect(result.stdout).not.toContain("windows-native-release");
+    expect(result.stdout).not.toContain("linux-native-release");
+    expect(result.stdout).not.toContain("update-manifest-assets");
     expect(result.stdout).not.toContain("macos-signed");
     expect(result.stdout).not.toContain("real-openai-api");
     expect(result.stdout).not.toContain("real-gemini-api");
     expect(result.stdout).not.toContain("image-core-regression");
   });
 
-  it("fails --require-complete for the pending v0.3.1 candidate evidence ledger", async () => {
+  it("passes --require-complete for the complete v0.3.1 candidate evidence ledger", async () => {
     const result = await run([
       "--file",
       "docs/release/v0.3.1-evidence.json",
@@ -159,11 +155,9 @@ describe("release evidence verifier", () => {
       "--require-complete"
     ]);
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("Required release evidence gates are not passed");
-    expect(result.stderr).toContain("windows-native-release");
-    expect(result.stderr).toContain("linux-native-release");
-    expect(result.stderr).toContain("update-manifest-assets");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Release evidence validated: 12/12 required gate(s) passed.");
+    expect(result.stderr).not.toContain("Required release evidence gates are not passed");
     expect(result.stderr).not.toContain("macos-signed");
     expect(result.stderr).not.toContain("real-openai-api");
     expect(result.stderr).not.toContain("real-gemini-api");
@@ -249,16 +243,24 @@ describe("release evidence verifier", () => {
         path.resolve("docs/release/v0.3.1-evidence.json"),
         path.join(docsReleaseDir, "v0.3.1-evidence.json")
       );
+      const candidateEvidencePath = path.join(docsReleaseDir, "v0.3.1-evidence.json");
+      const candidateEvidence = JSON.parse(await readFile(candidateEvidencePath, "utf8"));
+      const manifestGate = candidateEvidence.gates.find((gate) => gate.id === "update-manifest-assets");
+      manifestGate.status = "pending";
+      manifestGate.evidence = {
+        verifiedAt: null,
+        commit: null,
+        environment: null,
+        commands: [],
+        references: [{ label: "tracker", url: "https://github.com/Bliveren/CrossGen/issues/103" }],
+        artifacts: [],
+        summary: "Pending v0.3.1 public release asset upload and update manifest evidence."
+      };
+      await writeFile(candidateEvidencePath, JSON.stringify(candidateEvidence, null, 2));
 
       const checklistPath = path.join(tempRoot, "docs", "release", "v0.3.1-preflight.md");
       const checklist = await readFile(checklistPath, "utf8");
-      await writeFile(
-        checklistPath,
-        checklist.replace(
-          "- [ ] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.",
-          "- [x] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes."
-        )
-      );
+      expect(checklist).toContain("- [x] Update public release assets and `docs/updates/latest.json` from exact artifact hashes and sizes.");
 
       const result = await run(
         ["--file", "docs/release/v0.3.1-evidence.json", "--expected-version", "0.3.1"],


### PR DESCRIPTION
## Summary
- record the final v0.3.1 Windows, Linux, and update manifest release evidence
- update docs/updates/latest.json to published v0.3.1 release assets
- update release evidence tests for the completed 12/12 gate state

## Verification
- pnpm verify:release-evidence -- --require-complete
- node scripts/verify-release-evidence.mjs --file docs/release/v0.3.1-evidence.json --expected-version 0.3.1 --require-complete
- pnpm exec vitest run scripts/verify-release-evidence.test.mjs src/shared/package-config.test.ts scripts/update-manifest-asset.test.mjs
- git diff --check