### PR TITLE
Fix v0.3.1 CLI/MCP release candidate hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ CrossGen exposes the local runtime through JSON CLI commands and an MCP stdio se
 - `crossgen generate ... --yes --wait --json` and MCP `generate_image` submit work through the durable queue.
 - `crossgen asset export <asset-id> --to <path> --yes --json` copies a managed image into a project without moving the Gallery source.
 
-CLI and MCP default to read-only behavior. Write and generation modes are explicit, paid generation requires confirmation, and local path disclosure is opt-in.
+CLI and MCP are separate entry points. MCP can point directly at the installed CrossGen app executable with `--mcp` and does not require a CLI wrapper. The packaged CLI launcher forwards to the app executable and does not require Node.js, npm, pnpm, or a global package. CLI and MCP default to read-only behavior. Write and generation modes are explicit, paid generation requires confirmation, and local path disclosure is opt-in.
 
 See [`docs/cli-mcp.md`](./docs/cli-mcp.md) for command examples and [`docs/KNOWN_LIMITATIONS.md`](./docs/KNOWN_LIMITATIONS.md) for current agent/runtime limits.
 

--- a/build/cli/crossgen
+++ b/build/cli/crossgen
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+if [ -z "${CROSSGEN_APP_EXECUTABLE:-}" ]; then
+  if [ -x "$script_dir/../../MacOS/CrossGen" ]; then
+    CROSSGEN_APP_EXECUTABLE="$script_dir/../../MacOS/CrossGen"
+  elif [ -x "$script_dir/../../crossgen" ]; then
+    CROSSGEN_APP_EXECUTABLE="$script_dir/../../crossgen"
+  elif [ -x "/Applications/CrossGen.app/Contents/MacOS/CrossGen" ]; then
+    CROSSGEN_APP_EXECUTABLE="/Applications/CrossGen.app/Contents/MacOS/CrossGen"
+  fi
+  export CROSSGEN_APP_EXECUTABLE
+fi
+
+if [ -z "${CROSSGEN_APP_EXECUTABLE:-}" ] || [ ! -x "$CROSSGEN_APP_EXECUTABLE" ]; then
+  printf '%s\n' "CrossGen executable was not found." >&2
+  exit 127
+fi
+
+if [ "${1:-}" = "--data-dir" ]; then
+  if [ -z "${2:-}" ]; then
+    printf '%s\n' "Missing value for --data-dir." >&2
+    exit 2
+  fi
+  export CROSSGEN_DATA_DIR="$2"
+  export CROSSGEN_USER_DATA_DIR="$2"
+  shift 2
+fi
+
+case "${1:-}" in
+  --mcp)
+    exec "$CROSSGEN_APP_EXECUTABLE" "$@"
+    ;;
+  *)
+    exec "$CROSSGEN_APP_EXECUTABLE" --cli "$@"
+    ;;
+esac

--- a/build/cli/crossgen.cmd
+++ b/build/cli/crossgen.cmd
@@ -1,0 +1,35 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+if not defined CROSSGEN_APP_EXECUTABLE (
+  if exist "%SCRIPT_DIR%..\..\CrossGen.exe" set "CROSSGEN_APP_EXECUTABLE=%SCRIPT_DIR%..\..\CrossGen.exe"
+)
+
+if not defined CROSSGEN_APP_EXECUTABLE (
+  echo CrossGen executable was not found. 1>&2
+  exit /b 127
+)
+
+if not exist "%CROSSGEN_APP_EXECUTABLE%" (
+  echo CrossGen executable was not found. 1>&2
+  exit /b 127
+)
+
+if "%~1"=="--data-dir" (
+  if "%~2"=="" (
+    echo Missing value for --data-dir. 1>&2
+    exit /b 2
+  )
+  set "CROSSGEN_DATA_DIR=%~2"
+  set "CROSSGEN_USER_DATA_DIR=%~2"
+  shift
+  shift
+)
+
+if "%~1"=="--mcp" (
+  "%CROSSGEN_APP_EXECUTABLE%" %*
+) else (
+  "%CROSSGEN_APP_EXECUTABLE%" --cli %*
+)
+exit /b %ERRORLEVEL%

--- a/docs/cli-mcp.md
+++ b/docs/cli-mcp.md
@@ -4,7 +4,10 @@ CrossGen exposes the same local app state to terminal workflows and MCP hosts. T
 
 ## Runtime
 
-Install dependencies in the repository or use an installed CrossGen app:
+Desktop use does not require CLI or MCP setup. Open the CrossGen app, configure
+API access, and use the UI normally.
+
+For repository development, the Node wrapper remains available:
 
 ```bash
 pnpm install
@@ -12,16 +15,49 @@ pnpm build:main
 node dist/cli/crossgen.js --version --json
 ```
 
-The packaged npm binary is `crossgen`. It launches CrossGen through the first available runtime:
+For installed packages, CLI and MCP are intentionally separate:
+
+- MCP uses the current CrossGen app executable directly with `--mcp`.
+- CLI uses the package-provided native launcher, which directly forwards to the
+  CrossGen app executable with `--cli`.
+- Installed CLI/MCP use does not require Node.js, npm, pnpm, or a global Node
+  package.
+
+The development Node wrapper is useful for local source-tree work. It launches
+CrossGen through the first available runtime:
 
 1. `CROSSGEN_APP_EXECUTABLE`
 2. `CROSSGEN_ELECTRON_BIN`
 3. repository `node_modules/.bin/electron`
 4. common installed app locations
 
-Use `--data-dir <path>` when an agent needs an isolated CrossGen data directory. The wrapper maps it to both `CROSSGEN_DATA_DIR` and `CROSSGEN_USER_DATA_DIR`.
+Use `--data-dir <path>` when an agent needs an isolated CrossGen data directory.
+The development wrapper and package launcher both map it to `CROSSGEN_DATA_DIR`
+and `CROSSGEN_USER_DATA_DIR`.
 
 CI or other constrained Linux runners can set `CROSSGEN_APP_EXTRA_ARGS="--no-sandbox"` when launching a packaged app. The value is prepended to the Electron runtime arguments and is not enabled by default.
+
+## CLI Setup
+
+The installed app includes a small native launcher under its resources
+directory. It forwards to the app executable and does not require Node.js.
+
+On macOS, users who want a `crossgen` command can create a link to the launcher
+from a directory already on their `PATH`, or from `~/.local/bin` if they choose
+to add that directory themselves:
+
+```bash
+mkdir -p "$HOME/.local/bin"
+ln -s "/path/to/CrossGen.app/Contents/Resources/cli/crossgen" "$HOME/.local/bin/crossgen"
+```
+
+Use the app's actual location. Do not assume `/Applications/CrossGen.app`; users
+may run CrossGen from another directory or keep multiple builds. CrossGen should
+not edit shell startup files automatically. If `~/.local/bin` is not on `PATH`,
+show the status and let the user copy the needed shell configuration manually.
+
+MCP does not require this link. MCP client configuration should call the CrossGen
+app executable directly.
 
 ## Agent Checks
 
@@ -86,9 +122,33 @@ The smoke verifier runs against an isolated data directory and a local mock Open
 
 The agent integration smoke checks `doctor --agent`, `mcp config` output for Codex, Claude Code, and Cursor, MCP mode-specific tool registration, confirmation-required errors, and secret/path redaction for agent-facing outputs that should not disclose local asset paths.
 
+Package release gates should additionally run the smoke scripts against the
+packaged app or packaged launcher rather than only `node dist/cli/crossgen.js`.
+Set a package launcher command in the smoke environment when validating the
+installed no-Node path.
+
+Examples:
+
+```bash
+# Validate the packaged app executable directly. The smoke scripts add --cli
+# for CLI calls and --mcp for MCP calls.
+CROSSGEN_APP_EXECUTABLE="/path/to/CrossGen" pnpm verify:cli-mcp-smoke
+
+# Validate the packaged CLI launcher. The launcher adds --cli itself and
+# special-cases --mcp.
+CROSSGEN_SMOKE_CLI_COMMAND="/path/to/resources/cli/crossgen" pnpm verify:cli-mcp-smoke
+
+# If using an explicit command instead of CROSSGEN_APP_EXECUTABLE, pass the
+# required prefixes yourself.
+CROSSGEN_SMOKE_CLI_COMMAND="/path/to/CrossGen" CROSSGEN_SMOKE_CLI_ARGS='["--cli"]' \
+CROSSGEN_SMOKE_MCP_COMMAND="/path/to/CrossGen" CROSSGEN_SMOKE_MCP_ARGS='["--mcp"]' \
+pnpm verify:cli-mcp-smoke
+```
+
 ## MCP Setup
 
-Generate host configuration with the CLI:
+MCP does not need the CLI launcher. Host configuration should point directly at
+the current CrossGen executable and pass `--mcp`. Generate client configuration:
 
 ```bash
 crossgen mcp config --client codex --mode readonly --json
@@ -96,10 +156,10 @@ crossgen mcp config --client codex --mode write --json
 crossgen mcp config --client codex --mode generate --json
 ```
 
-The server process is started with:
+The server process is started directly from the app executable:
 
 ```bash
-crossgen --mcp
+/path/to/CrossGen --mcp
 ```
 
 Modes:

--- a/package.json
+++ b/package.json
@@ -69,6 +69,17 @@
       "dist-renderer/**/*",
       "package.json"
     ],
+    "extraResources": [
+      {
+        "from": "build/cli",
+        "to": "cli",
+        "filter": ["**/*"]
+      }
+    ],
+    "asarUnpack": [
+      "dist/cli/**/*",
+      "dist/mcp/**/*"
+    ],
     "asar": true,
     "publish": null,
     "mac": {

--- a/scripts/verify-agent-integration-smoke.mjs
+++ b/scripts/verify-agent-integration-smoke.mjs
@@ -25,6 +25,60 @@ function assertNoDataDir(text, dataDir, label) {
   assert(!text.includes(dataDir), `${label} leaked the isolated data directory.`);
 }
 
+function parseRuntimeArgs(value) {
+  const raw = value?.trim();
+  if (!raw) return [];
+  if (raw.startsWith("[")) {
+    const parsed = JSON.parse(raw);
+    assert(Array.isArray(parsed) && parsed.every((item) => typeof item === "string"), "Runtime args JSON must be a string array.");
+    return parsed;
+  }
+  return raw.split(/\s+/).filter(Boolean);
+}
+
+function cliInvocation(args) {
+  const smokeCommand = process.env.CROSSGEN_SMOKE_CLI_COMMAND?.trim();
+  if (smokeCommand) {
+    return {
+      command: smokeCommand,
+      args: [...parseRuntimeArgs(process.env.CROSSGEN_SMOKE_CLI_ARGS), ...args]
+    };
+  }
+  const appCommand = process.env.CROSSGEN_APP_EXECUTABLE?.trim();
+  if (appCommand) {
+    return {
+      command: appCommand,
+      args: [...parseRuntimeArgs(process.env.CROSSGEN_APP_EXTRA_ARGS), "--cli", ...args]
+    };
+  }
+  return {
+    command: process.execPath,
+    args: [cliPath, ...args]
+  };
+}
+
+function mcpInvocation() {
+  const smokeCommand = process.env.CROSSGEN_SMOKE_MCP_COMMAND?.trim() || process.env.CROSSGEN_SMOKE_CLI_COMMAND?.trim();
+  if (smokeCommand) {
+    const explicitArgs = process.env.CROSSGEN_SMOKE_MCP_ARGS;
+    return {
+      command: smokeCommand,
+      args: explicitArgs ? parseRuntimeArgs(explicitArgs) : ["--mcp"]
+    };
+  }
+  const appCommand = process.env.CROSSGEN_APP_EXECUTABLE?.trim();
+  if (appCommand) {
+    return {
+      command: appCommand,
+      args: [...parseRuntimeArgs(process.env.CROSSGEN_APP_EXTRA_ARGS), "--mcp"]
+    };
+  }
+  return {
+    command: process.execPath,
+    args: [cliPath, "--mcp"]
+  };
+}
+
 function runProcess(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -60,7 +114,15 @@ function parseJsonLine(stdout, label) {
 }
 
 async function runCli(dataDir, args, options = {}) {
-  const result = await runProcess(process.execPath, [cliPath, "--data-dir", dataDir, ...args], options);
+  const invocation = cliInvocation(args);
+  const result = await runProcess(invocation.command, invocation.args, {
+    ...options,
+    env: {
+      CROSSGEN_DATA_DIR: dataDir,
+      CROSSGEN_USER_DATA_DIR: dataDir,
+      ...(options.env ?? {})
+    }
+  });
   assertNoSecret(result.stdout, `CLI ${args.join(" ")} stdout`);
   assertNoSecret(result.stderr, `CLI ${args.join(" ")} stderr`);
   const expectedCode = options.expectedCode ?? 0;
@@ -80,9 +142,14 @@ function parseMcpResponses(stdout, label) {
 
 async function runMcp(dataDir, mode, requests) {
   const input = `${requests.map((request) => JSON.stringify(request)).join("\n")}\n`;
-  const result = await runProcess(process.execPath, [cliPath, "--data-dir", dataDir, "--mcp"], {
+  const invocation = mcpInvocation();
+  const result = await runProcess(invocation.command, invocation.args, {
     input,
-    env: { CROSSGEN_MCP_MODE: mode }
+    env: {
+      CROSSGEN_DATA_DIR: dataDir,
+      CROSSGEN_USER_DATA_DIR: dataDir,
+      CROSSGEN_MCP_MODE: mode
+    }
   });
   assertNoSecret(result.stdout, `MCP ${mode} stdout`);
   assertNoSecret(result.stderr, `MCP ${mode} stderr`);
@@ -237,7 +304,9 @@ async function verifyDoctor(dataDir) {
 }
 
 async function main() {
-  assert(existsSync(cliPath), "Missing dist/cli/crossgen.js. Run pnpm build:main before verify:agent-integration-smoke.");
+  if (!process.env.CROSSGEN_SMOKE_CLI_COMMAND && !process.env.CROSSGEN_APP_EXECUTABLE) {
+    assert(existsSync(cliPath), "Missing dist/cli/crossgen.js. Run pnpm build:main before verify:agent-integration-smoke.");
+  }
   const dataDir = path.join(smokeRoot, "agent");
   try {
     await writeMockState(dataDir);

--- a/scripts/verify-cli-mcp-smoke.mjs
+++ b/scripts/verify-cli-mcp-smoke.mjs
@@ -22,6 +22,66 @@ function assertNoSecret(text, label) {
   assert(!text.includes(mockApiKey), `${label} leaked the mock API key.`);
 }
 
+function parseRuntimeArgs(value) {
+  const raw = value?.trim();
+  if (!raw) return [];
+  if (raw.startsWith("[")) {
+    const parsed = JSON.parse(raw);
+    assert(Array.isArray(parsed) && parsed.every((item) => typeof item === "string"), "Runtime args JSON must be a string array.");
+    return parsed;
+  }
+  return raw.split(/\s+/).filter(Boolean);
+}
+
+function cliInvocation(args) {
+  const smokeCommand = process.env.CROSSGEN_SMOKE_CLI_COMMAND?.trim();
+  if (smokeCommand) {
+    return {
+      command: smokeCommand,
+      args: [...parseRuntimeArgs(process.env.CROSSGEN_SMOKE_CLI_ARGS), ...args],
+      packaged: true
+    };
+  }
+  const appCommand = process.env.CROSSGEN_APP_EXECUTABLE?.trim();
+  if (appCommand) {
+    return {
+      command: appCommand,
+      args: [...parseRuntimeArgs(process.env.CROSSGEN_APP_EXTRA_ARGS), "--cli", ...args],
+      packaged: true
+    };
+  }
+  return {
+    command: process.execPath,
+    args: [cliPath, ...args],
+    packaged: false
+  };
+}
+
+function mcpInvocation() {
+  const smokeCommand = process.env.CROSSGEN_SMOKE_MCP_COMMAND?.trim() || process.env.CROSSGEN_SMOKE_CLI_COMMAND?.trim();
+  if (smokeCommand) {
+    const explicitArgs = process.env.CROSSGEN_SMOKE_MCP_ARGS;
+    return {
+      command: smokeCommand,
+      args: explicitArgs ? parseRuntimeArgs(explicitArgs) : ["--mcp"],
+      packaged: true
+    };
+  }
+  const appCommand = process.env.CROSSGEN_APP_EXECUTABLE?.trim();
+  if (appCommand) {
+    return {
+      command: appCommand,
+      args: [...parseRuntimeArgs(process.env.CROSSGEN_APP_EXTRA_ARGS), "--mcp"],
+      packaged: true
+    };
+  }
+  return {
+    command: process.execPath,
+    args: [cliPath, "--mcp"],
+    packaged: false
+  };
+}
+
 async function findFreePort() {
   return new Promise((resolve, reject) => {
     const server = createServer();
@@ -101,7 +161,15 @@ function parseJsonLine(stdout, label) {
 }
 
 async function runCli(dataDir, args, options = {}) {
-  const result = await runProcess(process.execPath, [cliPath, "--data-dir", dataDir, ...args], options);
+  const invocation = cliInvocation(args);
+  const result = await runProcess(invocation.command, invocation.args, {
+    ...options,
+    env: {
+      CROSSGEN_DATA_DIR: dataDir,
+      CROSSGEN_USER_DATA_DIR: dataDir,
+      ...(options.env ?? {})
+    }
+  });
   assertNoSecret(result.stdout, `CLI ${args.join(" ")} stdout`);
   assertNoSecret(result.stderr, `CLI ${args.join(" ")} stderr`);
   const expectedCode = options.expectedCode ?? 0;
@@ -121,9 +189,14 @@ function parseMcpResponses(stdout, label) {
 
 async function runMcp(dataDir, mode, requests) {
   const input = `${requests.map((request) => JSON.stringify(request)).join("\n")}\n`;
-  const result = await runProcess(process.execPath, [cliPath, "--data-dir", dataDir, "--mcp"], {
+  const invocation = mcpInvocation();
+  const result = await runProcess(invocation.command, invocation.args, {
     input,
-    env: { CROSSGEN_MCP_MODE: mode }
+    env: {
+      CROSSGEN_DATA_DIR: dataDir,
+      CROSSGEN_USER_DATA_DIR: dataDir,
+      CROSSGEN_MCP_MODE: mode
+    }
   });
   assertNoSecret(result.stdout, `MCP ${mode} stdout`);
   assertNoSecret(result.stderr, `MCP ${mode} stderr`);
@@ -378,7 +451,9 @@ async function verifyMcpFlow(baseURL) {
 }
 
 async function main() {
-  assert(existsSync(cliPath), "Missing dist/cli/crossgen.js. Run pnpm build:main before verify:cli-mcp-smoke.");
+  if (!process.env.CROSSGEN_SMOKE_CLI_COMMAND && !process.env.CROSSGEN_APP_EXECUTABLE) {
+    assert(existsSync(cliPath), "Missing dist/cli/crossgen.js. Run pnpm build:main before verify:cli-mcp-smoke.");
+  }
   const port = await findFreePort();
   const baseURL = `http://127.0.0.1:${port}/v1`;
   const mock = startMockServer(port);

--- a/scripts/verify-cli-mcp-smoke.mjs
+++ b/scripts/verify-cli-mcp-smoke.mjs
@@ -336,6 +336,7 @@ async function verifyCliFlow(baseURL) {
   const jobStatus = await runCli(dataDir, ["job", "status", queueId, "--json"]);
   assertCliOk(jobStatus, "CLI job status");
   assert(jobStatus.data.job?.terminal === true, "CLI job status did not report terminal state.");
+  assert(jobStatus.data.job?.historyJob?.source === "cli", "CLI-generated History job did not record source=cli.");
 
   const gallery = await runCli(dataDir, ["gallery", "list", "--json"]);
   assertCliOk(gallery, "CLI gallery list");
@@ -423,10 +424,12 @@ async function verifyMcpFlow(baseURL) {
   const mcpGenerated = mcpStructuredData(mcpById(generateResponses, 3), "MCP generate_image");
   assert(mcpGenerated.execution?.terminal === true, "MCP generate_image did not reach terminal state.");
   assert(mcpGenerated.execution?.status === "succeeded", "MCP generate_image did not succeed.");
+  assert(mcpGenerated.execution?.job?.historyJob?.source === "mcp", "MCP-generated History job did not record source=mcp.");
 
   const mcpEdited = mcpStructuredData(mcpById(generateResponses, 4), "MCP edit_image");
   assert(mcpEdited.execution?.terminal === true, "MCP edit_image did not reach terminal state.");
   assert(mcpEdited.execution?.status === "succeeded", "MCP edit_image did not succeed.");
+  assert(mcpEdited.execution?.job?.historyJob?.source === "mcp", "MCP-edited History job did not record source=mcp.");
 
   const mcpGallery = mcpStructuredData(mcpById(generateResponses, 5), "MCP gallery_list");
   assert((mcpGallery.assets?.length ?? 0) >= 2, "MCP Gallery did not include generated and edited assets.");

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -162,6 +162,7 @@ function publicHistoryJob(job: GenerationJob) {
     id: job.id,
     name: job.name,
     tags: job.tags,
+    source: job.source ?? "desktop",
     providerKind: job.providerKind,
     providerId: job.providerId,
     launchId: job.launchId,

--- a/src/core/fileLock.test.ts
+++ b/src/core/fileLock.test.ts
@@ -46,17 +46,25 @@ describe("fileLock", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it("does not reclaim a stale-looking lock owned by a live process", async () => {
+  it("does not reclaim a fresh lock owned by a live process", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-lock-live-"));
+    const lockPath = path.join(tempDir, "state.lock");
+    await writeFile(lockPath, `${JSON.stringify({ pid: process.pid, acquiredAt: Date.now() })}\n`, "utf8");
+
+    await expect(withExclusiveFileLock(lockPath, async () => undefined, { timeoutMs: 30, staleLockMs: 1000, pollMs: 5 })).rejects.toThrow(`Timed out acquiring lock: ${lockPath}`);
+    expect(JSON.parse(await readFile(lockPath, "utf8"))).toMatchObject({ pid: process.pid });
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("reclaims an expired lock even if its pid has been reused by a live process", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-lock-reused-pid-"));
     const lockPath = path.join(tempDir, "state.lock");
     await writeFile(lockPath, `${JSON.stringify({ pid: process.pid, acquiredAt: Date.now() - 10000 })}\n`, "utf8");
     const oldDate = new Date(Date.now() - 10000);
     await utimes(lockPath, oldDate, oldDate);
 
-    await expect(
-      withExclusiveFileLock(lockPath, async () => undefined, { timeoutMs: 30, staleLockMs: 1, pollMs: 5 })
-    ).rejects.toThrow(`Timed out acquiring lock: ${lockPath}`);
-    expect(JSON.parse(await readFile(lockPath, "utf8"))).toMatchObject({ pid: process.pid });
+    await withExclusiveFileLock(lockPath, async () => undefined, { timeoutMs: 1000, staleLockMs: 1, pollMs: 5 });
+    await expect(readFile(lockPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await rm(tempDir, { recursive: true, force: true });
   });
 

--- a/src/core/fileLock.test.ts
+++ b/src/core/fileLock.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -42,6 +42,30 @@ describe("fileLock", () => {
     await Promise.all([firstTask!, second]);
 
     expect(events.indexOf("first-end")).toBeLessThan(events.indexOf("second-start"));
+    await expect(readFile(lockPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not reclaim a stale-looking lock owned by a live process", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-lock-live-"));
+    const lockPath = path.join(tempDir, "state.lock");
+    await writeFile(lockPath, `${JSON.stringify({ pid: process.pid, acquiredAt: Date.now() - 10000 })}\n`, "utf8");
+    const oldDate = new Date(Date.now() - 10000);
+    await utimes(lockPath, oldDate, oldDate);
+
+    await expect(
+      withExclusiveFileLock(lockPath, async () => undefined, { timeoutMs: 30, staleLockMs: 1, pollMs: 5 })
+    ).rejects.toThrow(`Timed out acquiring lock: ${lockPath}`);
+    expect(JSON.parse(await readFile(lockPath, "utf8"))).toMatchObject({ pid: process.pid });
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("reclaims a lock owned by a dead process without waiting for stale timeout", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-lock-dead-"));
+    const lockPath = path.join(tempDir, "state.lock");
+    await writeFile(lockPath, `${JSON.stringify({ pid: 99999999, acquiredAt: Date.now() })}\n`, "utf8");
+
+    await withExclusiveFileLock(lockPath, async () => undefined, { timeoutMs: 1000, staleLockMs: 30000, pollMs: 5 });
     await expect(readFile(lockPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/src/core/fileLock.ts
+++ b/src/core/fileLock.ts
@@ -59,12 +59,14 @@ async function removeLockFile(lockPath: string): Promise<boolean> {
 async function tryRemoveStaleLock(lockPath: string, staleLockMs: number, now: () => number): Promise<boolean> {
   try {
     const stat = await fs.stat(lockPath);
+    if (now() - stat.mtimeMs >= staleLockMs) {
+      return removeLockFile(lockPath);
+    }
     const ownerPid = await readLockOwnerPid(lockPath);
     if (ownerPid !== null) {
       return isProcessAlive(ownerPid) ? false : removeLockFile(lockPath);
     }
-    if (now() - stat.mtimeMs < staleLockMs) return false;
-    return removeLockFile(lockPath);
+    return false;
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") return true;
     return false;

--- a/src/core/fileLock.ts
+++ b/src/core/fileLock.ts
@@ -26,12 +26,45 @@ async function ensureParentDir(filePath: string): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
 }
 
+async function readLockOwnerPid(lockPath: string): Promise<number | null> {
+  try {
+    const raw = await fs.readFile(lockPath, "utf8");
+    const parsed = JSON.parse(raw) as { pid?: unknown };
+    return Number.isSafeInteger(parsed.pid) && Number(parsed.pid) > 0 ? Number(parsed.pid) : null;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ESRCH") return false;
+    return true;
+  }
+}
+
+async function removeLockFile(lockPath: string): Promise<boolean> {
+  try {
+    await fs.unlink(lockPath);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return true;
+    return false;
+  }
+}
+
 async function tryRemoveStaleLock(lockPath: string, staleLockMs: number, now: () => number): Promise<boolean> {
   try {
     const stat = await fs.stat(lockPath);
+    const ownerPid = await readLockOwnerPid(lockPath);
+    if (ownerPid !== null) {
+      return isProcessAlive(ownerPid) ? false : removeLockFile(lockPath);
+    }
     if (now() - stat.mtimeMs < staleLockMs) return false;
-    await fs.unlink(lockPath);
-    return true;
+    return removeLockFile(lockPath);
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") return true;
     return false;

--- a/src/core/modelCapabilities.test.ts
+++ b/src/core/modelCapabilities.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { GENERAL_LAUNCH_ID, GPT_IMAGE_2_LAUNCH_ID, NANO_BANANA_3_LAUNCH_ID } from "../shared/modelCatalog";
+import {
+  GENERAL_LAUNCH_ID,
+  GEMINI_3_PRO_IMAGE_MODEL_ID,
+  GPT_IMAGE_2_LAUNCH_ID,
+  NANO_BANANA_3_LAUNCH_ID,
+  NANO_BANANA_3_MODEL_ID
+} from "../shared/modelCatalog";
 import type { ProviderConfig } from "../shared/types";
 import { capabilityContractForFocusedModel, capabilitySummaryForDiscoveredModel, listProviderModelCapabilitySummaries } from "./modelCapabilities";
 import { getFocusedModelDefinition } from "../shared/modelCatalog";
@@ -133,5 +139,29 @@ describe("model capability contracts", () => {
       edit: false,
       confidence: "discovered"
     });
+  });
+
+  it("keeps shared-launch Gemini models selectable with unique keys", () => {
+    const summaries = listProviderModelCapabilitySummaries(
+      provider({
+        id: "provider-gemini",
+        kind: "gemini",
+        name: "Gemini",
+        defaultModel: NANO_BANANA_3_MODEL_ID,
+        activeLaunchId: NANO_BANANA_3_LAUNCH_ID,
+        activeModelId: NANO_BANANA_3_MODEL_ID,
+        discoveredModels: [
+          { id: GEMINI_3_PRO_IMAGE_MODEL_ID, providerKind: "gemini" }
+        ]
+      })
+    );
+
+    const nanoModels = summaries.filter((summary) => summary.launchId === NANO_BANANA_3_LAUNCH_ID);
+    expect(nanoModels.map((summary) => summary.modelId)).toEqual([NANO_BANANA_3_MODEL_ID, GEMINI_3_PRO_IMAGE_MODEL_ID]);
+    expect(nanoModels.map((summary) => summary.selectionKey)).toEqual([
+      `${NANO_BANANA_3_LAUNCH_ID}:${NANO_BANANA_3_MODEL_ID}`,
+      `${NANO_BANANA_3_LAUNCH_ID}:${GEMINI_3_PRO_IMAGE_MODEL_ID}`
+    ]);
+    expect(new Set(nanoModels.map((summary) => summary.selectionKey)).size).toBe(nanoModels.length);
   });
 });

--- a/src/core/modelCapabilities.ts
+++ b/src/core/modelCapabilities.ts
@@ -31,6 +31,7 @@ export interface ModelCapabilitySummary {
   modelId: string;
   displayName: string;
   launchId?: FocusedLaunchId;
+  selectionKey: string;
   source: ModelCapabilitySource;
   capabilities: ImageModelCapabilityContract;
 }
@@ -69,6 +70,10 @@ function baseContract(
     contract,
     confidence
   };
+}
+
+function selectionKeyForModel(launchId: FocusedLaunchId | undefined, providerKind: ProviderKind, modelId: string): string {
+  return `${launchId ?? providerKind}:${normalizeModelId(modelId)}`;
 }
 
 function promptOnlyCapabilities(providerKind: ProviderKind, confidence: ImageCapabilityConfidence): ImageModelCapabilityContract {
@@ -127,6 +132,7 @@ function summaryForFocusedModel(providerId: string | undefined, definition: Focu
     modelId,
     displayName: getModelDisplayName(definition.launchId, modelId),
     launchId: definition.launchId,
+    selectionKey: selectionKeyForModel(definition.launchId, definition.providerKind, modelId),
     source: definition.launchId === GENERAL_LAUNCH_ID ? "general-fallback" : "focused-catalog",
     capabilities: capabilityContractForFocusedModel(definition)
   };
@@ -155,6 +161,7 @@ export function capabilitySummaryForDiscoveredModel(providerId: string | undefin
       providerKind: model.providerKind,
       modelId: model.id,
       displayName,
+      selectionKey: selectionKeyForModel(undefined, model.providerKind, model.id),
       source: "discovered",
       capabilities: promptOnlyCapabilities(model.providerKind, "discovered")
     };
@@ -165,6 +172,7 @@ export function capabilitySummaryForDiscoveredModel(providerId: string | undefin
     providerKind: model.providerKind,
     modelId: model.id,
     displayName,
+    selectionKey: selectionKeyForModel(undefined, model.providerKind, model.id),
     source: "unknown",
     capabilities: unknownCapabilities()
   };
@@ -195,6 +203,7 @@ export function listProviderModelCapabilitySummaries(provider: ProviderConfig): 
         modelId: provider.activeModelId,
         displayName: provider.activeModelId,
         launchId: GENERAL_LAUNCH_ID,
+        selectionKey: selectionKeyForModel(GENERAL_LAUNCH_ID, provider.kind, provider.activeModelId),
         source: "general-fallback",
         capabilities: promptOnlyCapabilities(provider.kind, "assumed")
       });

--- a/src/core/queueStore.test.ts
+++ b/src/core/queueStore.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createQueueStore } from "./queueStore";
-import type { GenerationQueueItem } from "../shared/types";
+import type { GenerationQueueItem, GenerationQueueWorkerHost } from "../shared/types";
 
 function queueItem(patch: Partial<GenerationQueueItem> = {}): GenerationQueueItem {
   const now = new Date().toISOString();
@@ -47,6 +47,19 @@ function queueItem(patch: Partial<GenerationQueueItem> = {}): GenerationQueueIte
     stage: "queued",
     sourceAssetIds: [],
     outputMediaKinds: ["image"],
+    ...patch
+  };
+}
+
+function workerHost(patch: Partial<GenerationQueueWorkerHost> = {}): GenerationQueueWorkerHost {
+  const now = "2026-07-19T00:00:00.000Z";
+  return {
+    hostId: "host_1",
+    kind: "desktop",
+    processId: process.pid,
+    mode: "generate",
+    heartbeatAt: now,
+    leaseExpiresAt: now,
     ...patch
   };
 }
@@ -239,6 +252,69 @@ describe("queueStore", () => {
       limit: 2
     });
     expect(claimed.map((item) => item.queueId)).toEqual(["queue-now"]);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("prunes worker hosts older than 24 hours and caps retained hosts", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crossgen-queue-"));
+    const queuePath = path.join(tempDir, "queue.json");
+    const nowMs = Date.parse("2026-07-19T12:00:00.000Z");
+    const store = createQueueStore({
+      queuePath,
+      lockPath: `${queuePath}.lock`,
+      now: () => nowMs
+    });
+
+    const workerHosts: GenerationQueueWorkerHost[] = [
+      ...Array.from({ length: 3 }, (_, index) =>
+        workerHost({
+          hostId: `expired-${index + 1}`,
+          heartbeatAt: "2026-07-17T11:59:59.000Z",
+          leaseExpiresAt: `2026-07-18T11:59:5${index}.000Z`
+        })
+      ),
+      ...Array.from({ length: 22 }, (_, index) =>
+        workerHost({
+          hostId: `recent-${index + 1}`,
+          heartbeatAt: `2026-07-19T11:${String(index).padStart(2, "0")}:00.000Z`,
+          leaseExpiresAt: `2026-07-19T11:${String(index).padStart(2, "0")}:30.000Z`
+        })
+      )
+    ];
+
+    await store.write({
+      schemaVersion: 1,
+      updatedAt: "2026-07-19T12:00:00.000Z",
+      items: [],
+      workerHosts
+    });
+
+    const queue = await store.read();
+    expect(queue.workerHosts).toHaveLength(20);
+    expect(queue.workerHosts.some((host) => host.hostId.startsWith("expired-"))).toBe(false);
+    expect(queue.workerHosts.map((host) => host.hostId)).toEqual([
+      "recent-22",
+      "recent-21",
+      "recent-20",
+      "recent-19",
+      "recent-18",
+      "recent-17",
+      "recent-16",
+      "recent-15",
+      "recent-14",
+      "recent-13",
+      "recent-12",
+      "recent-11",
+      "recent-10",
+      "recent-9",
+      "recent-8",
+      "recent-7",
+      "recent-6",
+      "recent-5",
+      "recent-4",
+      "recent-3"
+    ]);
 
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/src/core/queueStore.ts
+++ b/src/core/queueStore.ts
@@ -52,6 +52,9 @@ const DEFAULT_QUEUE_FILE: GenerationQueueFile = {
   workerHosts: []
 };
 
+const WORKER_HOST_EXPIRED_RETENTION_MS = 24 * 60 * 60 * 1000;
+const MAX_RETAINED_WORKER_HOSTS = 20;
+
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
@@ -177,6 +180,33 @@ function cloneQueue(queue: GenerationQueueFile): GenerationQueueFile {
   return structuredClone(queue);
 }
 
+function hostTimestampMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function workerHostRecencyMs(host: GenerationQueueWorkerHost): number {
+  return Math.max(hostTimestampMs(host.leaseExpiresAt), hostTimestampMs(host.heartbeatAt));
+}
+
+function pruneWorkerHosts(queue: GenerationQueueFile, nowMs: number): GenerationQueueFile {
+  const staleLeaseCutoffMs = nowMs - WORKER_HOST_EXPIRED_RETENTION_MS;
+  const next = cloneQueue(queue);
+  next.workerHosts = next.workerHosts
+    .filter((host) => {
+      const leaseExpiresAt = hostTimestampMs(host.leaseExpiresAt);
+      if (!Number.isFinite(leaseExpiresAt)) return workerHostRecencyMs(host) > staleLeaseCutoffMs;
+      return leaseExpiresAt > staleLeaseCutoffMs;
+    })
+    .sort((a, b) => workerHostRecencyMs(b) - workerHostRecencyMs(a) || a.hostId.localeCompare(b.hostId))
+    .slice(0, MAX_RETAINED_WORKER_HOSTS);
+  return next;
+}
+
+function normalizeQueueForWrite(queue: GenerationQueueFile, nowMs: number): GenerationQueueFile {
+  return pruneWorkerHosts(normalizeQueueFile(queue), nowMs);
+}
+
 function markStaleRunning(queue: GenerationQueueFile, nowMs: number, staleRunningAfterMs: number): GenerationQueueFile {
   const next = cloneQueue(queue);
   for (const item of next.items) {
@@ -263,7 +293,7 @@ export function createQueueStore(options: QueueStoreOptions): QueueStore {
       return readQueueFile(options.queuePath);
     },
     async write(queue: GenerationQueueFile): Promise<void> {
-      await withExclusiveFileLock(options.lockPath, async () => writeQueueFile(options.queuePath, normalizeQueueFile(queue)), {
+      await withExclusiveFileLock(options.lockPath, async () => writeQueueFile(options.queuePath, normalizeQueueForWrite(queue, now())), {
         timeoutMs,
         staleLockMs
       });
@@ -273,7 +303,7 @@ export function createQueueStore(options: QueueStoreOptions): QueueStore {
         options.lockPath,
         async () => {
           const current = await readQueueFile(options.queuePath);
-          const next = normalizeQueueFile(await mutator(current));
+          const next = normalizeQueueForWrite(await mutator(current), now());
           await writeQueueFile(options.queuePath, next);
           return next;
         },
@@ -285,7 +315,7 @@ export function createQueueStore(options: QueueStoreOptions): QueueStore {
         options.lockPath,
         async () => {
           const current = await readQueueFile(options.queuePath);
-          const next = markStaleRunning(current, nowOverride, staleRunningAfterMs);
+          const next = pruneWorkerHosts(markStaleRunning(current, nowOverride, staleRunningAfterMs), nowOverride);
           await writeQueueFile(options.queuePath, next);
           return next;
         },
@@ -311,8 +341,9 @@ export function createQueueStore(options: QueueStoreOptions): QueueStore {
           if (index >= 0) next.workerHosts[index] = normalized;
           else next.workerHosts.push(normalized);
           next.updatedAt = nowIso;
-          await writeQueueFile(options.queuePath, next);
-          return next;
+          const pruned = pruneWorkerHosts(next, Date.parse(nowIso));
+          await writeQueueFile(options.queuePath, pruned);
+          return pruned;
         },
         { timeoutMs, staleLockMs }
       );
@@ -322,9 +353,11 @@ export function createQueueStore(options: QueueStoreOptions): QueueStore {
         options.lockPath,
         async () => {
           const current = await readQueueFile(options.queuePath);
-          const recovered = markStaleRunning(current, now(), staleRunningAfterMs);
-          const claimed = claimItems(recovered, claimOptions, now(), leaseMs);
-          await writeQueueFile(options.queuePath, recovered);
+          const nowMs = now();
+          const recovered = markStaleRunning(current, nowMs, staleRunningAfterMs);
+          const claimed = claimItems(recovered, claimOptions, nowMs, leaseMs);
+          const next = pruneWorkerHosts(recovered, nowMs);
+          await writeQueueFile(options.queuePath, next);
           return claimed;
         },
         { timeoutMs, staleLockMs }
@@ -337,9 +370,11 @@ export function createQueueStore(options: QueueStoreOptions): QueueStore {
           const current = await readQueueFile(options.queuePath);
           const next = cloneQueue(current);
           next.items.push(normalizeQueueItem(item));
-          next.updatedAt = new Date(now()).toISOString();
-          await writeQueueFile(options.queuePath, next);
-          return next;
+          const nowMs = now();
+          next.updatedAt = new Date(nowMs).toISOString();
+          const pruned = pruneWorkerHosts(next, nowMs);
+          await writeQueueFile(options.queuePath, pruned);
+          return pruned;
         },
         { timeoutMs, staleLockMs }
       );

--- a/src/main/main.test.ts
+++ b/src/main/main.test.ts
@@ -68,7 +68,7 @@ describe("main config save builder", () => {
     expect(next.streamingPartialsEnabled).toBe(false);
   });
 
-  it("clears saved key and discovery metadata when switching provider without a new key", () => {
+  it("preserves saved key and invalidates discovery metadata when switching provider without a new key", () => {
     const next = buildProviderConfigForSave(
       savedConfig(),
       input({
@@ -82,8 +82,8 @@ describe("main config save builder", () => {
     );
 
     expect(next.kind).toBe("gemini");
-    expect(next.encryptedApiKey).toBeUndefined();
-    expect(next.encryption).toBe("none");
+    expect(next.encryptedApiKey).toBe("plain:c2stdZXN0LW9wZW5haS1rZXk=");
+    expect(next.encryption).toBe("localFallback");
     expect(next.activeLaunchId).toBe("nano-banana-3");
     expect(next.activeModelId).toBe("gemini-3.1-flash-image");
     expect(next.discoveredModels).toEqual([]);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,7 +11,7 @@ import {
   type IpcMainInvokeEvent
 } from "electron";
 import { createHash, randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFileSync, watch, type FSWatcher } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,9 +42,6 @@ import type {
   ImageQuality,
   JobStatus,
   JobProgressEvent,
-  OpenAIImageRoute,
-  OpenAIImageRouteProbe,
-  OpenAIImageRouting,
   PromptTemplate,
   PromptTemplateInput,
   ProviderConfig,
@@ -139,7 +136,8 @@ import {
   type McpMode
 } from "../cli/readonly.js";
 import { runReadonlyMcpStdioServer } from "../mcp/stdioServer.js";
-import { buildEndpoint, fetchWithTimeout } from "./services/openaiImageAdapter.js";
+import { fetchWithTimeout } from "./services/openaiImageAdapter.js";
+import { probeOpenAIImageRouting } from "./services/openaiImageRouting.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
 import { buildProviderConfigForSave, providerDisplayName } from "./services/providerConfigSave.js";
@@ -244,8 +242,15 @@ let galleryOperationQueue: Promise<void> = Promise.resolve();
 let galleryWatchNeedsFullSync = false;
 let galleryWatchChangedRelPaths = new Set<string>();
 let stateWriteCount = 0;
+let lastSelfWriteAt = 0;   // Date.now() of the most recent self-write; used to suppress self-triggered reloads
+let stateFileWatcher: FSWatcher | null = null;
+let stateFileWatchDebounce: NodeJS.Timeout | null = null;
+const STATE_FILE_WATCH_DEBOUNCE_MS = 300;
+const STATE_FILE_SELF_WRITE_GRACE_MS = 500;
 let appStateStore: JsonStateStore<AppStateFile> | null = null;
 let generationQueueStore: QueueStore | null = null;
+const APP_STATE_LOCK_TIMEOUT_MS = 60000;
+const APP_STATE_LOCK_STALE_MS = 5 * 60 * 1000;
 const desktopWorkerHostId = `desktop_${process.pid}_${randomUUID()}`;
 let desktopQueueWorkerTimer: NodeJS.Timeout | null = null;
 let desktopQueueWorkerRunning = false;
@@ -295,6 +300,11 @@ interface GalleryAssetSourceMetadata {
   sourcePathHash?: string;
   sourceJobId?: string;
   sourceAssetId?: string;
+}
+
+interface GalleryDiskScanSnapshot {
+  galleryDir: string;
+  disk: Awaited<ReturnType<typeof scanGalleryDisk>>;
 }
 
 async function runGalleryOperation<T>(operation: () => Promise<T>): Promise<T> {
@@ -480,7 +490,9 @@ function getAppStateStore(): JsonStateStore<AppStateFile> {
     backupPath: getBackupStatePath(),
     lockPath: getStateLockPath(),
     defaultState: getDefaultState(),
-    normalize: normalizeState
+    normalize: normalizeState,
+    timeoutMs: APP_STATE_LOCK_TIMEOUT_MS,
+    staleLockMs: APP_STATE_LOCK_STALE_MS
   });
   return appStateStore;
 }
@@ -577,6 +589,7 @@ async function writeState(state: AppStateFile, options: WriteStateOptions = {}):
   const payload = persistentStatePayload(state);
   await getAppStateStore().write(payload, options);
   stateWriteCount += 1;
+  lastSelfWriteAt = Date.now();
   stateCache = payload;
 }
 
@@ -617,6 +630,7 @@ async function mutateStateAndQueue<TResult>(
     return next.result;
   });
   stateWriteCount += 1;
+  lastSelfWriteAt = Date.now();
   stateCache = transaction.state;
   return transaction;
 }
@@ -1216,19 +1230,32 @@ function sendGalleryEvent(state: AppStateFile, reason: "disk" | "mutation"): voi
   }
 }
 
+// Pushes a full snapshot to every renderer. Used when the state file was mutated by an
+// external process (CLI / MCP) so the desktop UI hot-reloads instead of showing stale data.
+function broadcastSnapshot(state: AppStateFile): void {
+  const windows = BrowserWindow.getAllWindows();
+  if (windows.length === 0) return;
+  const snapshot = snapshotFromState(state);
+  for (const window of windows) {
+    window.webContents.send("app:snapshot", snapshot);
+  }
+}
+
 async function mutateDesktopGalleryState<TResult>(
   operation: (state: AppStateFile) => Promise<{ state: AppStateFile; result: TResult; changed?: boolean }>
 ): Promise<TResult> {
   let result: TResult | undefined;
   let shouldNotify = false;
+  const snapshot = await scanGalleryDiskForState(await readState());
   const nextState = await getAppStateStore().mutate(async (state) => {
-    const synced = await buildGalleryDiskSyncedState(state, undefined, { useStateCache: false });
+    const synced = await buildSyncedStateFromDiskSnapshot(state, snapshot, undefined, { useStateCache: false });
     const outcome = await operation(synced.state);
     result = outcome.result;
     shouldNotify = outcome.changed !== false;
     return persistentStatePayload(outcome.state);
   });
   stateWriteCount += 1;
+  lastSelfWriteAt = Date.now();
   stateCache = nextState;
   if (result === undefined) throw new Error("Gallery 操作没有返回结果。");
   if (shouldNotify) sendGalleryEvent(nextState, "mutation");
@@ -1726,16 +1753,13 @@ function applyGalleryAssetCreateResult(state: AppStateFile, result: GalleryAsset
 
 async function buildGalleryDiskSyncedState(
   inputState: AppStateFile,
+  disk: Awaited<ReturnType<typeof scanGalleryDisk>>,
   changedRelPaths?: string[],
   options: { useStateCache?: boolean } = {}
 ): Promise<{ state: AppStateFile; changed: boolean }> {
-  const galleryDir = getGalleryDir(inputState);
-  await ensureDir(galleryDir);
-
   const now = new Date().toISOString();
   const baseState = options.useStateCache === false ? inputState : stateCache ?? inputState;
   const hasIncrementalChanges = Boolean(changedRelPaths?.length);
-  const disk = await scanGalleryDisk(galleryDir, hasIncrementalChanges ? { rootRelPaths: changedRelPaths } : undefined);
   const reconcileOptions = {
     now,
     createFolderId: () => `gallery_folder_${randomUUID()}`,
@@ -1747,14 +1771,38 @@ async function buildGalleryDiskSyncedState(
   return result;
 }
 
+async function scanGalleryDiskForState(inputState: AppStateFile, changedRelPaths?: string[]): Promise<GalleryDiskScanSnapshot> {
+  const galleryDir = getGalleryDir(inputState);
+  await ensureDir(galleryDir);
+  const hasIncrementalChanges = Boolean(changedRelPaths?.length);
+  return {
+    galleryDir,
+    disk: await scanGalleryDisk(galleryDir, hasIncrementalChanges ? { rootRelPaths: changedRelPaths } : undefined)
+  };
+}
+
+async function buildSyncedStateFromDiskSnapshot(
+  inputState: AppStateFile,
+  snapshot: GalleryDiskScanSnapshot,
+  changedRelPaths?: string[],
+  options: { useStateCache?: boolean } = {}
+): Promise<{ state: AppStateFile; changed: boolean }> {
+  if (!sameResolvedPath(getGalleryDir(inputState), snapshot.galleryDir)) {
+    return { state: inputState, changed: false };
+  }
+  return buildGalleryDiskSyncedState(inputState, snapshot.disk, changedRelPaths, options);
+}
+
 async function syncGalleryWithDisk(inputState: AppStateFile, changedRelPaths?: string[]): Promise<AppStateFile> {
   let syncedState = inputState;
+  const snapshot = await scanGalleryDiskForState(inputState, changedRelPaths);
   const nextState = await getAppStateStore().mutate(async (state) => {
-    const result = await buildGalleryDiskSyncedState(state, changedRelPaths, { useStateCache: false });
+    const result = await buildSyncedStateFromDiskSnapshot(state, snapshot, changedRelPaths, { useStateCache: false });
     syncedState = result.state;
     return result.changed ? persistentStatePayload(result.state) : persistentStatePayload(state);
   });
   stateWriteCount += 1;
+  lastSelfWriteAt = Date.now();
   stateCache = nextState;
   return syncedState;
 }
@@ -2209,120 +2257,6 @@ async function refreshModelDiscovery(config: StoredProviderConfig): Promise<Stor
       updatedAt: new Date().toISOString()
     };
   }
-}
-
-async function probeOpenAIImageRouting(config: StoredProviderConfig, apiKey: string): Promise<OpenAIImageRouting | undefined> {
-  if (config.kind !== "openai" || config.activeLaunchId !== GPT_IMAGE_2_LAUNCH_ID) return config.openAIImageRouting;
-
-  const model = config.activeModelId || config.defaultModel || GPT_IMAGE_2_MODEL_ID;
-  const probeTimeoutMs = Math.min(Math.max(Math.floor(config.timeoutMs / 8), 2500), 8000);
-  const probes = await Promise.all([
-    probeOpenAIImageRoute(config.baseURL, apiKey, probeTimeoutMs, "image-api", "generate", {
-      endpoint: "/images/generations",
-      body: {
-        model
-      }
-    }),
-    probeOpenAIImageRoute(config.baseURL, apiKey, probeTimeoutMs, "image-api", "edit", {
-      endpoint: "/images/edits",
-      body: new FormData()
-    }),
-    probeOpenAIImageRoute(config.baseURL, apiKey, probeTimeoutMs, "responses", "edit", {
-      endpoint: "/responses",
-      body: {
-        model
-      }
-    }),
-    probeOpenAIImageRoute(config.baseURL, apiKey, probeTimeoutMs, "responses", "generate", {
-      endpoint: "/responses",
-      body: {
-        model
-      }
-    }),
-    probeOpenAIImageRoute(config.baseURL, apiKey, probeTimeoutMs, "chat-completions", "edit", {
-      endpoint: "/chat/completions",
-      body: {
-        model
-      }
-    }),
-    probeOpenAIImageRoute(config.baseURL, apiKey, probeTimeoutMs, "chat-completions", "generate", {
-      endpoint: "/chat/completions",
-      body: {
-        model
-      }
-    })
-  ]);
-
-  return {
-    preferredGenerateRoute: preferredOpenAIImageRoute(probes, "generate"),
-    preferredEditRoute: preferredOpenAIImageRoute(probes, "edit"),
-    probes,
-    updatedAt: new Date().toISOString()
-  };
-}
-
-async function probeOpenAIImageRoute(
-  baseURL: string,
-  apiKey: string,
-  timeoutMs: number,
-  route: OpenAIImageRoute,
-  mode: "generate" | "edit",
-  request: {
-    endpoint: "/images/generations" | "/images/edits" | "/responses" | "/chat/completions";
-    body: Record<string, unknown> | FormData;
-  }
-): Promise<OpenAIImageRouteProbe> {
-  const startedAt = Date.now();
-  try {
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${apiKey}`,
-      Accept: request.endpoint === "/chat/completions" ? "text/event-stream" : "application/json"
-    };
-    if (!(request.body instanceof FormData)) {
-      headers["Content-Type"] = "application/json";
-    }
-    const response = await fetchWithTimeout(fetch, buildEndpoint(baseURL, request.endpoint), {
-      method: "POST",
-      headers,
-      body: request.body instanceof FormData ? request.body : JSON.stringify(request.body)
-    }, timeoutMs);
-    const latencyMs = Date.now() - startedAt;
-    return {
-      route,
-      mode,
-      endpoint: request.endpoint,
-      ok: isRouteProbeReachableStatus(response.status),
-      latencyMs,
-      status: response.status,
-      error: isRouteProbeReachableStatus(response.status) ? undefined : `HTTP ${response.status}`
-    };
-  } catch (error) {
-    return {
-      route,
-      mode,
-      endpoint: request.endpoint,
-      ok: false,
-      latencyMs: Date.now() - startedAt,
-      error: normalizeError(error)
-    };
-  }
-}
-
-function isRouteProbeReachableStatus(status: number): boolean {
-  return status >= 200 && status < 300;
-}
-
-function preferredOpenAIImageRoute(probes: OpenAIImageRouteProbe[], mode: "generate" | "edit"): OpenAIImageRoute | undefined {
-  const successfulCandidates = probes
-    .filter((probe) => probe.mode === mode && probe.ok && probe.status !== undefined && probe.status >= 200 && probe.status < 300)
-    .sort((a, b) => routePreferenceScore(a) - routePreferenceScore(b));
-  if (successfulCandidates[0]) return successfulCandidates[0].route;
-
-  return "chat-completions";
-}
-
-function routePreferenceScore(probe: OpenAIImageRouteProbe): number {
-  return probe.latencyMs;
 }
 
 function selectActiveLaunchForDiscovery(
@@ -3162,8 +3096,9 @@ async function migrateHistoryStorage(state: AppStateFile, nextDir: string): Prom
   };
 }
 
-async function migrateGalleryStorage(state: AppStateFile, nextDir: string): Promise<AppStateFile> {
-  const syncedState = (await buildGalleryDiskSyncedState(state, undefined, { useStateCache: false })).state;
+async function migrateGalleryStorage(state: AppStateFile, nextDir: string, snapshot?: GalleryDiskScanSnapshot): Promise<AppStateFile> {
+  const diskSnapshot = snapshot ?? await scanGalleryDiskForState(state);
+  const syncedState = (await buildSyncedStateFromDiskSnapshot(state, diskSnapshot, undefined, { useStateCache: false })).state;
   const storage = getStorageSettings(syncedState);
   const oldDir = storage.galleryDir;
   const resolvedNextDir = path.resolve(nextDir);
@@ -3222,21 +3157,22 @@ async function handleChooseStorageFolder(_event: IpcMainInvokeEvent, kindInput: 
   if (result.canceled || !result.filePaths[0]) return snapshotFromState(currentState);
 
   const nextDir = result.filePaths[0];
+  const baseGallerySnapshot = kind === "gallery" || options.syncBoth
+    ? await scanGalleryDiskForState(currentState)
+    : null;
   const nextState = await getAppStateStore().mutate(async (state) => {
     const baseState = kind === "gallery" || options.syncBoth
-      ? (await buildGalleryDiskSyncedState(state, undefined, { useStateCache: false })).state
+      ? (await buildSyncedStateFromDiskSnapshot(state, baseGallerySnapshot!, undefined, { useStateCache: false })).state
       : state;
     const migratedState = options.syncBoth
-      ? await migrateGalleryStorage(await migrateHistoryStorage(baseState, nextDir), nextDir)
+      ? await migrateGalleryStorage(await migrateHistoryStorage(baseState, nextDir), nextDir, baseGallerySnapshot ?? undefined)
       : kind === "history"
         ? await migrateHistoryStorage(baseState, nextDir)
-        : await migrateGalleryStorage(baseState, nextDir);
-    const finalState = kind === "gallery" || options.syncBoth
-      ? (await buildGalleryDiskSyncedState(migratedState, undefined, { useStateCache: false })).state
-      : migratedState;
-    return persistentStatePayload(finalState);
+        : await migrateGalleryStorage(baseState, nextDir, baseGallerySnapshot ?? undefined);
+    return persistentStatePayload(migratedState);
   });
   stateWriteCount += 1;
+  lastSelfWriteAt = Date.now();
   stateCache = nextState;
   if (kind === "gallery" || options.syncBoth) {
     await startGalleryWatcherForState(nextState);
@@ -3432,6 +3368,66 @@ async function startGalleryWatcherForState(state: AppStateFile): Promise<void> {
 async function startGalleryWatcher(): Promise<void> {
   const state = await syncGalleryWithDisk(await readState());
   await startGalleryWatcherForState(state);
+}
+
+function stopStateFileWatcher(): void {
+  if (stateFileWatcher) {
+    stateFileWatcher.close();
+    stateFileWatcher = null;
+  }
+  if (stateFileWatchDebounce) {
+    clearTimeout(stateFileWatchDebounce);
+    stateFileWatchDebounce = null;
+  }
+}
+
+// Watches the shared app-state file so external mutations (CLI / MCP writing under the
+// cross-process lock) hot-reload the desktop UI instead of leaving it stale.
+// Watches the containing directory (not the file directly): the state store writes
+// atomically via tmp+rename, which on Linux/inotify would orphan a file-level watch after
+// the first replace. Directory watching survives the rename and we filter by basename.
+function startStateFileWatcher(): void {
+  stopStateFileWatcher();
+  const statePath = getStatePath();
+  const stateDir = path.dirname(statePath);
+  const stateFileName = path.basename(statePath);
+  try {
+    stateFileWatcher = watch(stateDir, (_eventType, filename) => {
+      if (filename && path.basename(String(filename)) !== stateFileName) return;
+      scheduleExternalStateReload();
+    });
+  } catch (error) {
+    // watch() throws if the directory does not exist yet; it is created on first write and
+    // the watcher is (re)started after startup completes, so a missing dir here is non-fatal.
+    console.warn("[CrossGen] Failed to watch state file for external changes.", sanitizeError(error));
+  }
+}
+
+function scheduleExternalStateReload(): void {
+  if (stateFileWatchDebounce) clearTimeout(stateFileWatchDebounce);
+  stateFileWatchDebounce = setTimeout(() => {
+    stateFileWatchDebounce = null;
+    void reloadStateFromDiskIfExternal();
+  }, STATE_FILE_WATCH_DEBOUNCE_MS);
+}
+
+async function reloadStateFromDiskIfExternal(): Promise<void> {
+  // Ignore filesystem events caused by our own writes: the debounce window plus this grace
+  // check keep a self-write from clobbering in-flight desktop edits with a re-read.
+  if (Date.now() - lastSelfWriteAt < STATE_FILE_SELF_WRITE_GRACE_MS) return;
+  if (BrowserWindow.getAllWindows().length === 0) return;
+  try {
+    const external = applyStartupRecovery(normalizeState(await readStateFile(getStatePath())));
+    // Serialize behind the Gallery operation queue so a concurrent desktop mutation and an
+    // external reload never interleave into a half-applied snapshot.
+    await runGalleryOperation(async () => {
+      const synced = await syncGalleryForRead(external);
+      stateCache = persistentStatePayload(synced);
+      broadcastSnapshot(synced);
+    });
+  } catch (error) {
+    console.warn("[CrossGen] Failed to reload state after external change.", sanitizeError(error));
+  }
 }
 
 function scheduleGalleryDiskSync(changedRelPath: string | null = null): void {
@@ -5382,6 +5378,7 @@ app.whenReady().then(async () => {
     return;
   }
   void startGalleryWatcher();
+  startStateFileWatcher();
   startDesktopQueueWorker();
 
   app.on("activate", () => {
@@ -5400,4 +5397,5 @@ app.on("window-all-closed", () => {
 app.on("before-quit", () => {
   stopDesktopQueueWorker();
   stopGalleryWatcher();
+  stopStateFileWatcher();
 });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -554,18 +554,30 @@ async function ensureDir(dirPath: string): Promise<void> {
   await fs.mkdir(dirPath, { recursive: true });
 }
 
+function shouldRecoverInterruptedJobsOnRead(): boolean {
+  return process.argv.indexOf("--cli") < 0 && process.argv.indexOf("--mcp") < 0;
+}
+
+async function applyStartupRecovery(state: AppStateFile): Promise<AppStateFile> {
+  if (!shouldRecoverInterruptedJobsOnRead()) return state;
+  const queue = await getGenerationQueueStore().read().catch(() => undefined);
+  const result = recoverInterruptedJobs(state.history, new Date().toISOString(), queue);
+  recoveredInterruptedJobs = recoveredInterruptedJobs || result.changed;
+  return result.changed ? { ...state, history: result.history } : state;
+}
+
 async function readState(): Promise<AppStateFile> {
   if (stateCache) return stateCache;
 
   try {
-    stateCache = applyStartupRecovery(normalizeState(await readStateFile(getStatePath())));
+    stateCache = await applyStartupRecovery(normalizeState(await readStateFile(getStatePath())));
   } catch (error) {
     if (!isNodeError(error) || error.code !== "ENOENT") {
       console.warn("[CrossGen] Failed to read state file; trying backup.", sanitizeError(error));
     }
 
     try {
-      stateCache = applyStartupRecovery(normalizeState(await readStateFile(getBackupStatePath())));
+      stateCache = await applyStartupRecovery(normalizeState(await readStateFile(getBackupStatePath())));
       await writeState(stateCache, { updateBackup: false });
       return stateCache;
     } catch (backupError) {
@@ -621,7 +633,7 @@ async function mutateStateAndQueue<TResult>(
       statePath: getStatePath(),
       backupPath: getBackupStatePath(),
       defaultState: getDefaultState(),
-      normalize: (value) => applyStartupRecovery(normalizeState(value))
+      normalize: normalizeState
     }
   }, async (context) => {
     const next = await operation(context.state, context.queue);
@@ -638,12 +650,6 @@ async function mutateStateAndQueue<TResult>(
 async function readStateFile(filePath: string): Promise<unknown> {
   const raw = await fs.readFile(filePath, "utf8");
   return JSON.parse(raw) as unknown;
-}
-
-function applyStartupRecovery(state: AppStateFile): AppStateFile {
-  const result = recoverInterruptedJobs(state.history);
-  recoveredInterruptedJobs = recoveredInterruptedJobs || result.changed;
-  return result.changed ? { ...state, history: result.history } : state;
 }
 
 function encryptApiKey(apiKey: string): Pick<StoredProviderConfig, "encryptedApiKey" | "encryption"> {
@@ -1152,7 +1158,7 @@ async function persistMaskDataUrl(dataUrl: string, imagesDir: string): Promise<I
   };
 }
 
-function createJob(request: RunJobRequest, config: StoredProviderConfig, inputAssets: InputAsset[], maskAsset?: InputAsset): GenerationJob {
+function createJob(request: RunJobRequest, config: StoredProviderConfig, inputAssets: InputAsset[], maskAsset?: InputAsset, source: QueueSource = "desktop"): GenerationJob {
   const now = new Date().toISOString();
   const launchId = request.params.launchId;
   const modelId = request.params.model;
@@ -1160,6 +1166,7 @@ function createJob(request: RunJobRequest, config: StoredProviderConfig, inputAs
     id: `job_${randomUUID()}`,
     name: "",
     tags: [],
+    source,
     providerKind: request.params.providerKind,
     providerId: config.id,
     launchId,
@@ -1306,13 +1313,15 @@ async function handleSaveConfig(_event: IpcMainInvokeEvent, input: ProviderConfi
 
   const hasUsableApiKey = Boolean(nextConfig.encryptedApiKey);
   const baseURLChanged = nextConfig.baseURL !== activeProvider.baseURL;
+  const providerKindChanged = nextConfig.kind !== activeProvider.kind;
   const submittedNewApiKey = input.apiKey !== undefined && input.apiKey.trim().length > 0;
-  if (hasUsableApiKey && (submittedNewApiKey || baseURLChanged)) {
-    nextConfig = await refreshModelDiscovery(nextConfig);
-  }
 
   const nextProviders = state.providers.map(p => p.id === activeProvider.id ? nextConfig : p);
-  await writeState({ ...state, providers: nextProviders });
+  const nextState = { ...state, providers: nextProviders };
+  await writeState(nextState);
+  if (hasUsableApiKey && (submittedNewApiKey || baseURLChanged || providerKindChanged)) {
+    scheduleProviderDiscoveryRefresh(nextConfig.id, nextConfig.updatedAt);
+  }
   return toPublicConfig(nextConfig);
 }
 
@@ -1352,12 +1361,14 @@ async function handleAddProvider(_event: IpcMainInvokeEvent, input: ProviderConf
       throw new Error(validation.message ?? "API Key 无效。");
     }
     Object.assign(newConfig, encryptApiKey(input.apiKey));
-    newConfig = await refreshModelDiscovery(newConfig);
   }
 
   const nextProviders = [...state.providers, newConfig];
   const nextState = { ...state, providers: nextProviders, activeProviderId: newId };
   await writeState(nextState);
+  if (newConfig.encryptedApiKey) {
+    scheduleProviderDiscoveryRefresh(newConfig.id, newConfig.updatedAt);
+  }
 
   return snapshotFromState(nextState);
 }
@@ -2259,6 +2270,30 @@ async function refreshModelDiscovery(config: StoredProviderConfig): Promise<Stor
   }
 }
 
+function scheduleProviderDiscoveryRefresh(providerId: string, expectedUpdatedAt: string): void {
+  void refreshProviderDiscoveryIfCurrent(providerId, expectedUpdatedAt).catch((error: unknown) => {
+    console.warn("[CrossGen] Background model discovery failed.", sanitizeError(error));
+  });
+}
+
+async function refreshProviderDiscoveryIfCurrent(providerId: string, expectedUpdatedAt: string): Promise<void> {
+  const state = await readState();
+  const currentConfig = state.providers.find((provider) => provider.id === providerId);
+  if (!currentConfig || currentConfig.updatedAt !== expectedUpdatedAt) return;
+
+  const refreshedConfig = await refreshModelDiscovery(currentConfig);
+  const latestState = await readState();
+  const latestConfig = latestState.providers.find((provider) => provider.id === providerId);
+  if (!latestConfig || latestConfig.updatedAt !== expectedUpdatedAt) return;
+
+  const nextState = {
+    ...latestState,
+    providers: latestState.providers.map((provider) => provider.id === providerId ? refreshedConfig : provider)
+  };
+  await writeState(nextState);
+  broadcastSnapshot(nextState);
+}
+
 function selectActiveLaunchForDiscovery(
   config: StoredProviderConfig,
   models: StoredProviderConfig["discoveredModels"],
@@ -2399,7 +2434,7 @@ async function getOrCreateHistoryJobForQueueItem(
   }
 
   const { inputs, mask } = await resolveRequestInputs(request, getImagesDir(state));
-  const job = createJob(request, provider, inputs, mask);
+  const job = createJob(request, provider, inputs, mask, item.source);
   await upsertJob(job);
   return job;
 }
@@ -2445,7 +2480,7 @@ function terminalJobForQueueExecution(job: GenerationJob, execution: GenerationQ
     return {
       ...job,
       status: "cancelled",
-      error: execution.error ?? job.error ?? "任务已终止。",
+      error: execution.error ?? "任务已终止。",
       updatedAt: nowIso
     };
   }
@@ -2551,7 +2586,7 @@ function cancelledHistoryJob(job: GenerationJob, item: GenerationQueueItem): Gen
   return {
     ...job,
     status: "cancelled",
-    error: job.error ?? "任务已取消。",
+    error: "任务已取消。",
     updatedAt: item.updatedAt
   };
 }
@@ -2922,7 +2957,7 @@ async function handleRunJob(_event: IpcMainInvokeEvent, request: RunJobRequest):
     if (!canRunRequestWithConfig(normalizedRequest, currentProvider)) {
       throw new Error("任务 provider 与当前服务配置不一致。请先切换并保存对应服务商。");
     }
-    job = createJob(normalizedRequest, currentProvider, inputs, mask);
+    job = createJob(normalizedRequest, currentProvider, inputs, mask, "desktop");
     queueItem = createGenerationQueueItem({
       source: "desktop",
       providerId: currentProvider.id,
@@ -3417,7 +3452,7 @@ async function reloadStateFromDiskIfExternal(): Promise<void> {
   if (Date.now() - lastSelfWriteAt < STATE_FILE_SELF_WRITE_GRACE_MS) return;
   if (BrowserWindow.getAllWindows().length === 0) return;
   try {
-    const external = applyStartupRecovery(normalizeState(await readStateFile(getStatePath())));
+    const external = normalizeState(await readStateFile(getStatePath()));
     // Serialize behind the Gallery operation queue so a concurrent desktop mutation and an
     // external reload never interleave into a half-applied snapshot.
     await runGalleryOperation(async () => {
@@ -4306,7 +4341,7 @@ async function enqueueGenerationForAgent(input: AgentGenerationEnqueueInput) {
   const targetGalleryFolderId = normalizeTargetGalleryFolderId(state, input.targetGalleryFolderId);
   const request = validateAgentRunJobRequest(buildAgentRunJobRequest(provider, input), provider);
   const { inputs, mask } = await resolveRequestInputs(request, getImagesDir(state));
-  const job = createJob(request, provider, inputs, mask);
+  const job = createJob(request, provider, inputs, mask, input.source);
   const queueItem = createGenerationQueueItem({
     source: input.source,
     providerId: provider.id,

--- a/src/main/services/openaiImageRouting.test.ts
+++ b/src/main/services/openaiImageRouting.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOpenAIImageRouteProbeRequest,
+  isRouteProbeReachableStatus,
+  preferredOpenAIImageRoute,
+  probeOpenAIImageRoute,
+  probeOpenAIImageRouting
+} from "./openaiImageRouting";
+import { defaultStoredConfig } from "./stateMigration";
+import type { OpenAIImageRouteProbe } from "../../shared/types";
+
+describe("OpenAI image route probing", () => {
+  it("builds lightweight probe requests that do not trigger full image generation", () => {
+    expect(buildOpenAIImageRouteProbeRequest("image-api", "generate", "gpt-image-2")).toEqual({
+      endpoint: "/images/generations",
+      body: { model: "gpt-image-2" }
+    });
+
+    const editProbe = buildOpenAIImageRouteProbeRequest("image-api", "edit", "gpt-image-2");
+    expect(editProbe.endpoint).toBe("/images/edits");
+    expect(editProbe.body).toBeInstanceOf(FormData);
+    expect((editProbe.body as FormData).get("model")).toBe("gpt-image-2");
+    expect((editProbe.body as FormData).has("image")).toBe(false);
+
+    expect(buildOpenAIImageRouteProbeRequest("responses", "edit", "gpt-image-2")).toMatchObject({
+      endpoint: "/responses",
+      body: {
+        model: "gpt-image-2",
+        input: [],
+        tools: [{ type: "image_generation", action: "edit" }]
+      }
+    });
+
+    expect(buildOpenAIImageRouteProbeRequest("chat-completions", "generate", "gpt-image-2")).toMatchObject({
+      endpoint: "/chat/completions",
+      body: {
+        model: "gpt-image-2",
+        stream: true,
+        params: {},
+        features: { image_generation: false },
+        messages: []
+      }
+    });
+  });
+
+  it("marks validation rejections reachable without selecting them over successful probes", async () => {
+    expect(isRouteProbeReachableStatus(400)).toBe(true);
+    expect(isRouteProbeReachableStatus(422)).toBe(true);
+    expect(isRouteProbeReachableStatus(500)).toBe(false);
+
+    const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        model: "gpt-image-2",
+        messages: []
+      });
+      return new Response("validation error", { status: 400 });
+    }) as typeof fetch;
+    const probe = await probeOpenAIImageRoute(
+      fetchImpl,
+      "https://api.test/v1",
+      "sk-test",
+      2500,
+      "chat-completions",
+      "generate",
+      buildOpenAIImageRouteProbeRequest("chat-completions", "generate", "gpt-image-2")
+    );
+
+    expect(probe).toMatchObject({
+      route: "chat-completions",
+      endpoint: "/chat/completions",
+      ok: true,
+      status: 400,
+      error: undefined
+    });
+
+    const probes: OpenAIImageRouteProbe[] = [
+      { route: "image-api", mode: "generate", endpoint: "/images/generations", ok: true, latencyMs: 10, status: 400 },
+      { route: "responses", mode: "generate", endpoint: "/responses", ok: true, latencyMs: 20, status: 200 }
+    ];
+    expect(preferredOpenAIImageRoute(probes, "generate")).toBe("responses");
+  });
+
+  it("defaults GPT Image 2 probe preferences to chat when routes are only validation-reachable", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return new Response(JSON.stringify({ error: { message: "validation error" } }), {
+        status: 400,
+        headers: { "content-type": "application/json" }
+      });
+    }) as typeof fetch;
+
+    const routing = await probeOpenAIImageRouting(
+      {
+        ...defaultStoredConfig,
+        baseURL: "https://api.test/v1",
+        timeoutMs: 60000
+      },
+      "sk-test",
+      fetchImpl,
+      () => "2026-07-19T12:00:00.000Z"
+    );
+
+    expect(routing?.probes).toHaveLength(6);
+    expect(routing?.probes.every((probe) => probe.ok)).toBe(true);
+    expect(routing?.preferredGenerateRoute).toBe("chat-completions");
+    expect(routing?.preferredEditRoute).toBe("chat-completions");
+    expect(routing?.updatedAt).toBe("2026-07-19T12:00:00.000Z");
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://api.test/v1/images/generations",
+      "https://api.test/v1/images/edits",
+      "https://api.test/v1/responses",
+      "https://api.test/v1/responses",
+      "https://api.test/v1/chat/completions",
+      "https://api.test/v1/chat/completions"
+    ]);
+  });
+});

--- a/src/main/services/openaiImageRouting.ts
+++ b/src/main/services/openaiImageRouting.ts
@@ -1,0 +1,159 @@
+import {
+  GPT_IMAGE_2_LAUNCH_ID,
+  GPT_IMAGE_2_MODEL_ID
+} from "../../shared/modelCatalog.js";
+import type { OpenAIImageRoute, OpenAIImageRouteProbe, OpenAIImageRouting } from "../../shared/types.js";
+import { buildEndpoint, fetchWithTimeout } from "./openaiImageAdapter.js";
+import { redactLikelySecrets } from "./providerHttp.js";
+import type { StoredProviderConfig } from "./stateMigration.js";
+
+type ProbeMode = "generate" | "edit";
+type ProbeEndpoint = "/images/generations" | "/images/edits" | "/responses" | "/chat/completions";
+
+interface OpenAIImageRouteProbeRequest {
+  endpoint: ProbeEndpoint;
+  body: Record<string, unknown> | FormData;
+}
+
+function normalizeProbeError(error: unknown): string {
+  if (error instanceof Error) return redactLikelySecrets(error.message);
+  return redactLikelySecrets(String(error));
+}
+
+export function buildOpenAIImageRouteProbeRequest(route: OpenAIImageRoute, mode: ProbeMode, model: string): OpenAIImageRouteProbeRequest {
+  if (route === "image-api") {
+    if (mode === "generate") {
+      return {
+        endpoint: "/images/generations",
+        body: { model }
+      };
+    }
+    const form = new FormData();
+    form.set("model", model);
+    return {
+      endpoint: "/images/edits",
+      body: form
+    };
+  }
+
+  if (route === "responses") {
+    return {
+      endpoint: "/responses",
+      body: {
+        model,
+        input: [],
+        tools: [{ type: "image_generation", action: mode }]
+      }
+    };
+  }
+
+  return {
+    endpoint: "/chat/completions",
+    body: {
+      model,
+      stream: true,
+      params: {},
+      features: {
+        image_generation: false
+      },
+      messages: []
+    }
+  };
+}
+
+export function isRouteProbeSuccessStatus(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+export function isRouteProbeReachableStatus(status: number): boolean {
+  return isRouteProbeSuccessStatus(status) || status === 400 || status === 422;
+}
+
+export async function probeOpenAIImageRouting(
+  config: StoredProviderConfig,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+  nowIso: () => string = () => new Date().toISOString()
+): Promise<OpenAIImageRouting | undefined> {
+  if (config.kind !== "openai" || config.activeLaunchId !== GPT_IMAGE_2_LAUNCH_ID) return config.openAIImageRouting;
+
+  const model = config.activeModelId || config.defaultModel || GPT_IMAGE_2_MODEL_ID;
+  const probeTimeoutMs = Math.min(Math.max(Math.floor(config.timeoutMs / 8), 2500), 8000);
+  const routes: Array<[OpenAIImageRoute, ProbeMode]> = [
+    ["image-api", "generate"],
+    ["image-api", "edit"],
+    ["responses", "edit"],
+    ["responses", "generate"],
+    ["chat-completions", "edit"],
+    ["chat-completions", "generate"]
+  ];
+  const probes = await Promise.all(
+    routes.map(([route, mode]) => probeOpenAIImageRoute(fetchImpl, config.baseURL, apiKey, probeTimeoutMs, route, mode, buildOpenAIImageRouteProbeRequest(route, mode, model)))
+  );
+
+  return {
+    preferredGenerateRoute: preferredOpenAIImageRoute(probes, "generate"),
+    preferredEditRoute: preferredOpenAIImageRoute(probes, "edit"),
+    probes,
+    updatedAt: nowIso()
+  };
+}
+
+export async function probeOpenAIImageRoute(
+  fetchImpl: typeof fetch,
+  baseURL: string,
+  apiKey: string,
+  timeoutMs: number,
+  route: OpenAIImageRoute,
+  mode: ProbeMode,
+  request: OpenAIImageRouteProbeRequest
+): Promise<OpenAIImageRouteProbe> {
+  const startedAt = Date.now();
+  try {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: request.endpoint === "/chat/completions" ? "text/event-stream" : "application/json"
+    };
+    if (!(request.body instanceof FormData)) {
+      headers["Content-Type"] = "application/json";
+    }
+    const response = await fetchWithTimeout(fetchImpl, buildEndpoint(baseURL, request.endpoint), {
+      method: "POST",
+      headers,
+      body: request.body instanceof FormData ? request.body : JSON.stringify(request.body)
+    }, timeoutMs);
+    const latencyMs = Date.now() - startedAt;
+    const reachable = isRouteProbeReachableStatus(response.status);
+    return {
+      route,
+      mode,
+      endpoint: request.endpoint,
+      ok: reachable,
+      latencyMs,
+      status: response.status,
+      error: reachable ? undefined : `HTTP ${response.status}`
+    };
+  } catch (error) {
+    return {
+      route,
+      mode,
+      endpoint: request.endpoint,
+      ok: false,
+      latencyMs: Date.now() - startedAt,
+      error: normalizeProbeError(error)
+    };
+  }
+}
+
+export function preferredOpenAIImageRoute(probes: OpenAIImageRouteProbe[], mode: ProbeMode): OpenAIImageRoute | undefined {
+  const successfulCandidates = probes
+    .filter((probe) => probe.mode === mode && isRouteProbeSuccessStatus(probe.status ?? 0))
+    .sort((a, b) => routePreferenceScore(a) - routePreferenceScore(b));
+  if (successfulCandidates[0]) return successfulCandidates[0].route;
+
+  return "chat-completions";
+}
+
+function routePreferenceScore(probe: OpenAIImageRouteProbe): number {
+  return probe.latencyMs;
+}

--- a/src/main/services/providerConfigSave.ts
+++ b/src/main/services/providerConfigSave.ts
@@ -24,7 +24,6 @@ export function providerDisplayName(kind: StoredProviderConfig["kind"]): string 
 export function buildProviderConfigForSave(current: StoredProviderConfig, input: ProviderConfigInput, now: string): StoredProviderConfig {
   const kind = input.kind ?? current.kind;
   const providerChanged = kind !== current.kind;
-  const hasNewApiKey = input.apiKey !== undefined && input.apiKey.trim().length > 0;
   const defaultModel = defaultModelForProvider(kind, input.defaultModel);
   const baseURL = normalizeBaseURL(input.baseURL || defaultBaseURLForProvider(kind, current.baseURL));
   const name = input.name?.trim() || (providerChanged ? providerDisplayName(kind) : current.name);
@@ -55,18 +54,6 @@ export function buildProviderConfigForSave(current: StoredProviderConfig, input:
     openAIImageRouting: discoveryInvalidated ? undefined : current.openAIImageRouting,
     updatedAt: now
   };
-
-  if (providerChanged && !hasNewApiKey) {
-    return {
-      ...nextConfig,
-      encryptedApiKey: undefined,
-      encryption: "none",
-      discoveredModels: [],
-      lastModelDiscoveryAt: undefined,
-      lastModelDiscoveryError: undefined,
-      openAIImageRouting: undefined
-    };
-  }
 
   return nextConfig;
 }

--- a/src/main/services/stateMigration.ts
+++ b/src/main/services/stateMigration.ts
@@ -10,6 +10,7 @@ import type {
   OpenAIImageParams,
   PromptTemplate,
   ProviderKind,
+  QueueSource,
   QueueRuntimeConfig,
   StorageSettings,
   WorkspaceDraft
@@ -393,6 +394,10 @@ function normalizeStringList(value: unknown): string[] {
   });
 }
 
+function normalizeQueueSource(value: unknown): QueueSource | undefined {
+  return value === "desktop" || value === "cli" || value === "mcp" ? value : undefined;
+}
+
 function normalizeGenerationJob(value: unknown, fallbackProviderId: string): GenerationJob {
   const input = isRecord(value) ? value : {};
   const params = normalizeImageParams(input.params);
@@ -408,6 +413,7 @@ function normalizeGenerationJob(value: unknown, fallbackProviderId: string): Gen
     ...(input as unknown as GenerationJob),
     name: nonEmptyString(input.name, fallbackName),
     tags: normalizeStringList(input.tags),
+    source: normalizeQueueSource(input.source),
     providerKind,
     providerId: nonEmptyString(input.providerId, fallbackProviderId),
     launchId,

--- a/src/main/services/stateRecovery.test.ts
+++ b/src/main/services/stateRecovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GenerationJob } from "../../shared/types";
+import type { GenerationJob, GenerationQueueFile, GenerationQueueItem } from "../../shared/types";
 import { DEFAULT_IMAGE_PARAMS } from "../../shared/validation";
 import { INTERRUPTED_JOB_MESSAGE, recoverInterruptedJobs } from "./stateRecovery";
 
@@ -24,6 +24,46 @@ function job(status: GenerationJob["status"]): GenerationJob {
   };
 }
 
+function queueItem(status: GenerationQueueItem["status"], historyJobId = `job_${status}`): GenerationQueueItem {
+  const now = new Date(0).toISOString();
+  return {
+    queueId: `queue_${status}`,
+    source: "cli",
+    providerId: "default",
+    request: {
+      mode: "generate",
+      prompt: "Recover this job",
+      inputPaths: [],
+      params: DEFAULT_IMAGE_PARAMS
+    },
+    status,
+    priority: 0,
+    attempt: 0,
+    maxAttempts: 1,
+    createdAt: now,
+    updatedAt: now,
+    outputAssetIds: [],
+    partialAssetIds: [],
+    galleryAssetIds: [],
+    cancelRequested: false,
+    costConfirmed: true,
+    executionKind: "sync-provider",
+    stage: "queued",
+    sourceAssetIds: [],
+    outputMediaKinds: ["image"],
+    historyJobId
+  };
+}
+
+function queue(items: GenerationQueueItem[]): GenerationQueueFile {
+  return {
+    schemaVersion: 1,
+    updatedAt: new Date(0).toISOString(),
+    items,
+    workerHosts: []
+  };
+}
+
 describe("state recovery", () => {
   it("marks queued and running jobs as failed on startup", () => {
     const result = recoverInterruptedJobs([job("queued"), job("running"), job("succeeded")], new Date(1).toISOString());
@@ -42,5 +82,39 @@ describe("state recovery", () => {
 
     expect(result.changed).toBe(false);
     expect(result.history).toEqual([failed, succeeded]);
+  });
+
+  it("does not mark jobs failed when their queue item is still active", () => {
+    const queued = job("queued");
+    const running = job("running");
+    const result = recoverInterruptedJobs(
+      [queued, running],
+      new Date(1).toISOString(),
+      queue([
+        queueItem("queued", queued.id),
+        queueItem("running", running.id)
+      ])
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.history).toEqual([queued, running]);
+  });
+
+  it("recovers hanging jobs from terminal queue state when available", () => {
+    const cancelled = job("queued");
+    const interrupted = job("running");
+    const result = recoverInterruptedJobs(
+      [cancelled, interrupted],
+      new Date(1).toISOString(),
+      queue([
+        queueItem("cancelled", cancelled.id),
+        queueItem("interrupted", interrupted.id)
+      ])
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.history.map((item) => item.status)).toEqual(["cancelled", "failed"]);
+    expect(result.history[0].error).toBe("任务已取消。");
+    expect(result.history[1].error).toBe(INTERRUPTED_JOB_MESSAGE);
   });
 });

--- a/src/main/services/stateRecovery.ts
+++ b/src/main/services/stateRecovery.ts
@@ -1,16 +1,51 @@
-import type { GenerationJob } from "../../shared/types.js";
+import type { GenerationJob, GenerationQueueFile, GenerationQueueItem } from "../../shared/types.js";
 
 export const INTERRUPTED_JOB_MESSAGE = "应用上次退出时任务仍在运行，已自动恢复为失败状态。";
+const CANCELLED_JOB_MESSAGE = "任务已取消。";
 
 export interface RecoveryResult {
   history: GenerationJob[];
   changed: boolean;
 }
 
-export function recoverInterruptedJobs(history: GenerationJob[], recoveredAt = new Date().toISOString()): RecoveryResult {
+function queueItemByHistoryId(queue?: GenerationQueueFile): Map<string, GenerationQueueItem> {
+  const byHistoryId = new Map<string, GenerationQueueItem>();
+  for (const item of queue?.items ?? []) {
+    if (item.historyJobId) byHistoryId.set(item.historyJobId, item);
+  }
+  return byHistoryId;
+}
+
+function recoverJobFromQueue(job: GenerationJob, item: GenerationQueueItem, recoveredAt: string): GenerationJob {
+  if (item.status === "queued" || item.status === "running") return job;
+  if (item.status === "cancelled") {
+    return {
+      ...job,
+      status: "cancelled",
+      error: item.lastError ?? CANCELLED_JOB_MESSAGE,
+      updatedAt: item.updatedAt || recoveredAt
+    };
+  }
+  if (item.status === "succeeded") return job;
+  return {
+    ...job,
+    status: "failed",
+    error: item.lastError ?? INTERRUPTED_JOB_MESSAGE,
+    updatedAt: item.updatedAt || recoveredAt
+  };
+}
+
+export function recoverInterruptedJobs(history: GenerationJob[], recoveredAt = new Date().toISOString(), queue?: GenerationQueueFile): RecoveryResult {
   let changed = false;
+  const queueByHistoryId = queueItemByHistoryId(queue);
   const recovered = history.map((job) => {
     if (job.status !== "queued" && job.status !== "running") return job;
+    const queueItem = queueByHistoryId.get(job.id);
+    if (queueItem) {
+      const next = recoverJobFromQueue(job, queueItem, recoveredAt);
+      if (next !== job) changed = true;
+      return next;
+    }
     changed = true;
     return {
       ...job,

--- a/src/mcp/stdioServer.test.ts
+++ b/src/mcp/stdioServer.test.ts
@@ -54,6 +54,15 @@ function writers(): GalleryMcpWriters {
   };
 }
 
+function duplicateFolderWriters(): GalleryMcpWriters {
+  return {
+    ...writers(),
+    folderCreate: async () => {
+      throw new Error("Gallery 文件夹名称已存在。");
+    }
+  };
+}
+
 function controllers(): GenerationMcpControllers {
   return {
     generationSubmit: async ({ mode, prompt, inputPaths, folderId, idempotencyKey, waitMs }) => ({
@@ -90,14 +99,17 @@ function queueControllers(): QueueMcpControllers {
   };
 }
 
-async function runServer(inputText: string, options: { mode?: ReadonlyMcpMode; withWriters?: boolean; withControllers?: boolean } = {}) {
+async function runServer(
+  inputText: string,
+  options: { mode?: ReadonlyMcpMode; withWriters?: boolean; withControllers?: boolean; writers?: GalleryMcpWriters } = {}
+) {
   const input = new PassThrough();
   const captured = captureOutput();
   const run = runReadonlyMcpStdioServer({
     mode: options.mode ?? "readonly",
     serverVersion: "0.3.0-test",
     readers: readers(),
-    writers: options.withWriters ? writers() : undefined,
+    writers: options.writers ?? (options.withWriters ? writers() : undefined),
     queueControllers: options.withWriters ? queueControllers() : undefined,
     jobControllers: options.withControllers ? controllers() : undefined,
     input,
@@ -269,6 +281,22 @@ describe("readonly MCP stdio server", () => {
         isError: true,
         structuredContent: {
           error: { code: "CONFIRMATION_REQUIRED" }
+        }
+      }
+    });
+  });
+
+  it("maps duplicate folder names to a specific MCP error code", async () => {
+    const { output } = await runServer(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "crossgen_folder_create", arguments: { name: "Campaign" } } }),
+      { mode: "write", withWriters: true, writers: duplicateFolderWriters() }
+    );
+
+    expect(lineResponses(output)[0]).toMatchObject({
+      result: {
+        isError: true,
+        structuredContent: {
+          error: { code: "FOLDER_ALREADY_EXISTS" }
         }
       }
     });

--- a/src/mcp/stdioServer.ts
+++ b/src/mcp/stdioServer.ts
@@ -124,6 +124,40 @@ function toolError(code: string, message: string, nextActions: string[] = []): T
   };
 }
 
+function galleryToolErrorFromMessage(message: string): ToolCallResult | undefined {
+  if (!message) return undefined;
+  if (message.includes("文件夹名称已存在")) {
+    return toolError("FOLDER_ALREADY_EXISTS", message);
+  }
+  if (message.includes("文件夹不存在")) {
+    return toolError("FOLDER_NOT_FOUND", message, ["Use crossgen_folder_list or crossgen_folder_tree to find current folder ids."]);
+  }
+  if (message.includes("资源不存在")) {
+    return toolError("ASSET_NOT_FOUND", message, ["Use crossgen_gallery_list or crossgen_asset_inspect to find current asset ids."]);
+  }
+  if (
+    message.includes("不能为空") ||
+    message.includes("不能包含路径分隔符") ||
+    message.includes("非法字符") ||
+    message.includes("不能以空格或句点结尾") ||
+    message.includes("不可用于托管目录") ||
+    message.includes("过长") ||
+    message.includes("只能导入图片文件") ||
+    message.includes("不是文件") ||
+    message.includes("无法创建唯一的 Gallery 文件名") ||
+    message.includes("不能将文件夹移动到自身或其子文件夹") ||
+    message.includes("导出路径不能为空") ||
+    message.includes("导出路径不能与原文件相同") ||
+    message.includes("导出目标已存在")
+  ) {
+    return toolError("INVALID_ARGUMENT", message);
+  }
+  if (message.includes("无法操作：资源不属于 CrossGen 管理目录") || message.includes("Gallery 资源路径无效")) {
+    return toolError("PATH_NOT_ALLOWED", message);
+  }
+  return undefined;
+}
+
 function isToolCallResult(value: unknown): value is ToolCallResult {
   return Boolean(value && typeof value === "object" && Array.isArray((value as ToolCallResult).content));
 }
@@ -924,9 +958,8 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
     if (!tool) {
       return toolError("INVALID_ARGUMENT", "Unknown CrossGen MCP tool.", [`Use tools/list to inspect available tools before calling ${name || "a tool"}.`]);
     }
-    try {
-      const requestId = typeof call.requestId === "string" && call.requestId.trim() ? call.requestId.trim() : `mcp_${randomUUID()}`;
-      const result = normalizeToolResult(await tool.handler(asRecord(call.arguments)));
+    const requestId = typeof call.requestId === "string" && call.requestId.trim() ? call.requestId.trim() : `mcp_${randomUUID()}`;
+    const withSchemaEnvelope = (result: ToolCallResult): ToolCallResult => {
       if (result.structuredContent && typeof result.structuredContent === "object" && !Array.isArray(result.structuredContent)) {
         result.structuredContent = {
           schemaVersion: 1,
@@ -935,8 +968,17 @@ export async function runReadonlyMcpStdioServer(options: ReadonlyMcpStdioServerO
         };
       }
       return result;
+    };
+    try {
+      const result = normalizeToolResult(await tool.handler(asRecord(call.arguments)));
+      return withSchemaEnvelope(result);
     } catch (error) {
-      return toolError("UNKNOWN_ERROR", sanitizeError(error));
+      const message = sanitizeError(error);
+      const galleryError = galleryToolErrorFromMessage(message);
+      if (galleryError) {
+        return withSchemaEnvelope(galleryError);
+      }
+      return withSchemaEnvelope(toolError("UNKNOWN_ERROR", message));
     }
   }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type {
   AppBridge,
+  AppSnapshot,
   DownloadRequest,
   EditedImageDownloadRequest,
   EditedGalleryImageInput,
@@ -70,6 +71,11 @@ const bridge: AppBridge = {
     const handler = (_event: Electron.IpcRendererEvent, payload: GallerySyncEvent) => callback(payload);
     ipcRenderer.on("gallery:event", handler);
     return () => ipcRenderer.off("gallery:event", handler);
+  },
+  onSnapshotChange: (callback: (snapshot: AppSnapshot) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, payload: AppSnapshot) => callback(payload);
+    ipcRenderer.on("app:snapshot", handler);
+    return () => ipcRenderer.off("app:snapshot", handler);
   }
 };
 

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -127,7 +127,7 @@ describe("renderer multi-model smoke", () => {
   it("submits GPT Image 2 multi-count requests without stream partial previews", async () => {
     const bridge = await renderApp(snapshot());
 
-    await click(buttonByText("Parameters", ".section-toggle"));
+    await openParameterDialog();
     expect(inputByLabel("Stream partial preview").checked).toBe(false);
     expect(inputByLabel("Partial images").value).toBe("0");
 
@@ -155,7 +155,7 @@ describe("renderer multi-model smoke", () => {
   it("lets users enable stream partial previews when they are off by default", async () => {
     const bridge = await renderApp(snapshot());
 
-    await click(buttonByText("Parameters", ".section-toggle"));
+    await openParameterDialog();
     const streamPreview = inputByLabel("Stream partial preview");
     expect(streamPreview.disabled).toBe(false);
     expect(streamPreview.checked).toBe(false);
@@ -187,7 +187,7 @@ describe("renderer multi-model smoke", () => {
     await openGalleryRail();
     await contextMenu(document.querySelector<HTMLElement>(".gallery-item")!);
     await click(elementByText("Choose from Gallery", ".context-menu-item"));
-    await click(buttonByText("Parameters", ".section-toggle"));
+    await openParameterDialog();
     const streamPreview = inputByLabel("Stream partial preview");
     expect(streamPreview.disabled).toBe(false);
 
@@ -213,7 +213,7 @@ describe("renderer multi-model smoke", () => {
   it("keeps the PNG compression note in a tooltip instead of inline text", async () => {
     await renderApp(snapshot());
 
-    await click(buttonByText("Parameters", ".section-toggle"));
+    await openParameterDialog();
     await changeSelect(selectByLabel("Format"), "png");
 
     const compressionField = inputByLabel("Compression").closest<HTMLElement>(".range-field")!;
@@ -233,7 +233,7 @@ describe("renderer multi-model smoke", () => {
     });
     const bridge = await renderApp(snapshot({ providers: [config], activeProviderId: config.id }));
 
-    await click(buttonByText("Parameters", ".section-toggle"));
+    await openParameterDialog();
 
     expect(selectByLabel("API route").selectedOptions[0]?.textContent).toBe("Auto · Chat");
     expect(document.body.textContent).toContain("API route: Chat");
@@ -260,8 +260,8 @@ describe("renderer multi-model smoke", () => {
 
     await click(document.querySelector<HTMLButtonElement>('.sidebar-mini-stack button[aria-label="Parameters"]')!);
 
-    expect(document.querySelector<HTMLElement>(".app-shell")?.classList.contains("sidebar-collapsed")).toBe(false);
-    expect(document.querySelector(".advanced-controls")).toBeTruthy();
+    expect(document.querySelector<HTMLElement>(".app-shell")?.classList.contains("sidebar-collapsed")).toBe(true);
+    expect(document.querySelector(".parameter-dialog .advanced-controls")).toBeTruthy();
   });
 
   it("keeps the job progress listener stable when partial images arrive", async () => {
@@ -422,6 +422,7 @@ describe("renderer multi-model smoke", () => {
     expect(launchButton("Nano Banana 3").disabled).toBe(false);
 
     await click(launchButton("Nano Banana 3"));
+    await openParameterDialog();
     await changeSelect(selectByLabel("Aspect ratio"), "4:3");
     await click(buttonByText("Generate", ".primary-run"));
 
@@ -446,8 +447,10 @@ describe("renderer multi-model smoke", () => {
     const bridge = await renderApp(snapshot());
 
     expect(document.body.textContent).toContain("API config");
-    expect(document.body.textContent).toContain("OpenAI · api.openai.com/v1");
-    expect(document.body.textContent).toContain("Key saved · 1 model discovered");
+    expect(apiAccessCurrentButton().textContent).toContain("OpenAI");
+    expect(apiAccessCurrentButton().textContent).toContain("1 model discovered");
+    expect(apiAccessCurrentButton().textContent).not.toContain("api.openai.com/v1");
+    expect(apiAccessCurrentButton().textContent).not.toContain("Key saved");
 
     await click(apiAccessCurrentButton());
     await changeInput(inputByLabel("API config name"), "Primary gateway");
@@ -463,15 +466,58 @@ describe("renderer multi-model smoke", () => {
     expect(document.body.textContent).toContain("Current API config");
   });
 
+  it("does not block saved API key feedback on slow connection checks", async () => {
+    const bridge = await renderApp(snapshot());
+    await flushAsync();
+    vi.mocked(bridge.testConnection).mockImplementation(() => new Promise(() => undefined));
+
+    await click(apiAccessCurrentButton());
+    await changeInput(inputByLabel("API Key"), "sk-new-key-that-is-long-enough");
+    await click(buttonByText("Save"));
+    await flushAsync();
+
+    const savedButton = buttonByText("Saved", ".api-config-detail button");
+    expect(bridge.saveConfig).toHaveBeenCalledWith(expect.objectContaining({ apiKey: "sk-new-key-that-is-long-enough" }));
+    expect(bridge.testConnection).toHaveBeenCalled();
+    expect(savedButton.disabled).toBe(false);
+    expect(document.body.textContent).toContain("Config saved locally.");
+  });
+
+  it("edits API type from the details pane without showing the type on the card", async () => {
+    const defaultConfig = providerConfig({ name: "Main gateway" });
+    const bridge = await renderApp(snapshot({ providers: [defaultConfig], activeProviderId: defaultConfig.id }));
+
+    await openSavedApiAccess();
+    const card = apiConfigCardByText("Main gateway");
+    expect(card.textContent).not.toContain("OpenAI");
+    expect(card.getAttribute("title")).toBe("Click to edit config");
+
+    const detail = document.querySelector<HTMLElement>(".api-config-detail")!;
+    expect(selectByLabel("API type", detail).value).toBe("openai");
+    await changeSelect(selectByLabel("API type", detail), "gemini");
+    await click(buttonByText("Save", ".api-config-detail button"));
+
+    expect(bridge.saveConfig).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "gemini",
+      defaultModel: NANO_BANANA_3_MODEL_ID,
+      activeLaunchId: NANO_BANANA_3_LAUNCH_ID,
+      activeModelId: NANO_BANANA_3_MODEL_ID
+    }));
+  });
+
   it("adds a second API config and switches to it automatically", async () => {
     const bridge = await renderApp(snapshot());
 
     await openSavedApiAccess();
     await click(buttonByText("Add API config"));
     const addForm = apiAccessAddForm();
+    expect(document.body.textContent).toContain("New config");
+    expect(apiConfigCardByText("Configuring").textContent).toContain("OpenAI");
     await changeSelect(selectByLabel("API type", addForm), "gemini");
     await changeInput(inputByLabel("API config name", addForm), "Gemini gateway");
     await changeInput(inputByLabel("API Key", addForm), "gemini-test-key");
+    expect(apiConfigCardByText("Gemini gateway").textContent).toContain("Configuring");
+    expect(apiConfigCardByText("Gemini gateway").textContent).not.toContain("Key entered");
     await click(buttonByText("Add API config", ".api-access-add-form button"));
 
     expect(bridge.addProvider).toHaveBeenCalledWith(
@@ -495,6 +541,8 @@ describe("renderer multi-model smoke", () => {
     await openSavedApiAccess();
     await click(buttonByText("Add API config"));
     const addForm = apiAccessAddForm();
+    expect(document.body.textContent).toContain("New config");
+    expect(apiConfigCardByText("Configuring").textContent).toContain("OpenAI");
     await changeSelect(selectByLabel("API type", addForm), "custom");
     await changeInput(inputByLabel("API config name", addForm), "Custom gateway");
     await changeInput(inputByLabel("Base URL", addForm), "https://gateway.example.com/v1");
@@ -509,8 +557,9 @@ describe("renderer multi-model smoke", () => {
       })
     );
     expect(bridge.testConnection).not.toHaveBeenCalled();
-    expect(document.body.textContent).toContain("Custom gateway");
-    expect(document.body.textContent).toContain("No key saved");
+    expect(apiAccessCurrentButton().textContent).toContain("Custom gateway");
+    expect(apiAccessCurrentButton().textContent).toContain("0 models discovered");
+    expect(apiAccessCurrentButton().textContent).not.toContain("No key saved");
     expect(buttonByText("GPT Image 2", ".launch-button").disabled).toBe(true);
   });
 
@@ -565,13 +614,15 @@ describe("renderer multi-model smoke", () => {
     });
 
     await openSavedApiAccess();
-    await click(apiConfigDiscoverButtonByText("Gemini access"));
-    await flushAsync();
     await click(apiConfigCardMainByText("Gemini access"));
+    expect([...apiConfigCardByText("Gemini access").querySelectorAll<HTMLButtonElement>(".api-config-card-actions button")].some((button) => button.getAttribute("aria-label") === "Discover models")).toBe(false);
+    await click(buttonByText("Discover models", ".api-config-detail button"));
+    await flushAsync();
 
     expect(bridge.discoverModels).toHaveBeenCalledWith("gemini-access");
+    expect(apiConfigCardByText("Gemini access").textContent).toContain("Discovered");
     expect(apiConfigCardByText("Gemini access").textContent).toContain("2 models discovered");
-    expect(apiConfigCardByText("Gemini access").getAttribute("title")).toContain(NANO_BANANA_3_MODEL_ID);
+    expect(apiConfigCardByText("Gemini access").querySelector(".api-config-card-models")?.getAttribute("title")).toContain(NANO_BANANA_3_MODEL_ID);
     expect(document.body.textContent).toContain("Gemini 3 Pro Image");
   });
 
@@ -1089,6 +1140,40 @@ describe("renderer multi-model smoke", () => {
     expect(document.body.textContent).toContain("product");
   });
 
+  it("marks CLI and MCP history cards with their generation channel", async () => {
+    await renderApp(snapshot({
+      history: [
+        geminiJob(0, { source: "cli", outputs: [imageAsset("history-cli.png")] }),
+        geminiJob(1, { source: "mcp", outputs: [imageAsset("history-mcp.png", "job_gemini_1")] })
+      ]
+    }));
+
+    const sourceChips = [...document.querySelectorAll<HTMLElement>(".history-chip.source-tag")].map((chip) => chip.textContent);
+    expect(sourceChips).toEqual(["MCP", "CLI"]);
+  });
+
+  it("keeps a History card expanded until another card is hovered or the user clicks elsewhere", async () => {
+    const first = geminiJob(0, { outputs: [imageAsset("history-hover-a.png")] });
+    const second = geminiJob(1, { outputs: [imageAsset("history-hover-b.png", "job_gemini_1")] });
+    await renderApp(snapshot({ history: [first, second] }));
+
+    const cards = [...document.querySelectorAll<HTMLElement>(".history-item")];
+    expect(cards).toHaveLength(2);
+
+    await pointer(cards[0]!, "mouseover");
+    expect(cards[0]!.classList.contains("hover-open")).toBe(true);
+
+    await pointer(cards[0]!, "mouseout");
+    expect(cards[0]!.classList.contains("hover-open")).toBe(true);
+
+    await pointer(cards[1]!, "mouseover");
+    expect(cards[0]!.classList.contains("hover-open")).toBe(false);
+    expect(cards[1]!.classList.contains("hover-open")).toBe(true);
+
+    await pointer(document.body, "pointerdown");
+    expect(cards[1]!.classList.contains("hover-open")).toBe(false);
+  });
+
   it("adds Gallery tags from the card popover and updates the visible filter state", async () => {
     const asset = galleryAsset("gallery-tags.png", { tags: ["old"] });
     const other = galleryAsset("gallery-other.png", { tags: ["draft"] });
@@ -1566,6 +1651,7 @@ describe("renderer multi-model smoke", () => {
     const bridge = await renderApp(snapshot({ providers: [geminiConfig], activeProviderId: geminiConfig.id }));
 
     await click(launchButton("Nano Banana 3"));
+    await openParameterDialog();
     await changeSelect(selectByLabel("Aspect ratio"), "1:1");
     await click(buttonByText("Generate", ".primary-run"));
 
@@ -1610,6 +1696,28 @@ describe("renderer multi-model smoke", () => {
     expect(document.querySelector<HTMLButtonElement>('.input-panel button[aria-label="Add as mask"]')).toBeNull();
     expect(document.body.textContent).toContain("Drag local images, History results, or Gallery images here.");
     expect(document.querySelector<HTMLButtonElement>('.input-panel button[aria-label="Clear"]')).toBeNull();
+  });
+
+  it("shows the Images API route notice for GPT Image 2 exact mask mode", async () => {
+    await renderApp(snapshot({
+      draft: {
+        activeLaunchId: GPT_IMAGE_2_LAUNCH_ID,
+        activeModelId: GPT_IMAGE_2_MODEL_ID,
+        mode: "inpaint",
+        prompt: "Replace the masked area",
+        params: DEFAULT_IMAGE_PARAMS,
+        inputAssets: [inputAsset("mask-source.png")],
+        maskDataUrl: "data:image/png;base64,iVBORw0KGgo=",
+        brushSize: 48,
+        updatedAt: now
+      }
+    }));
+
+    expect(document.body.textContent).toContain("Mask mode uses the official Images API edit route");
+    expect(document.querySelector<HTMLSelectElement>(".parameter-route-field select")?.value).toBe("image-api");
+    await openParameterDialog();
+    expect(selectByLabel("API route").value).toBe("image-api");
+    expect(selectByLabel("API route").disabled).toBe(true);
   });
 
   it("caps local reference images to the active model capability", async () => {
@@ -1731,23 +1839,24 @@ describe("renderer multi-model smoke", () => {
     );
   });
 
-  it("keeps API config, launch buttons, parameters, and updates in a clear left-rail order", async () => {
+  it("keeps API config and launch buttons in the left rail and moves parameters into the workspace", async () => {
     await renderApp(snapshot());
     const sidebar = document.querySelector<HTMLElement>(".sidebar")!;
     const configSection = sidebar.querySelector<HTMLElement>(".api-access-section")!;
     const launchSection = sidebar.querySelector<HTMLElement>(".launch-section")!;
-    const parameterSection = buttonByText("Parameters", ".section-toggle").closest<HTMLElement>(".tool-section")!;
+    const parameterBar = document.querySelector<HTMLElement>(".parameter-config-bar")!;
     const updatePanel = sidebar.querySelector<HTMLElement>(".sidebar-utility-bar")!;
+    const promptBlock = document.querySelector<HTMLElement>(".prompt-block")!;
 
     expect(configSection.textContent).toContain("API config");
     expect(launchSection.textContent).toContain("Launch");
-    expect(parameterSection.textContent).toContain("Parameters");
+    expect(parameterBar.textContent).toContain("Parameters");
     expect(updatePanel.textContent).toContain("0.1.0");
     expect(sidebar.querySelector(".template-sidebar-section")).toBeNull();
     expect(sidebar.querySelector(".draft-section")).toBeNull();
+    expect(sidebar.querySelector(".parameter-config-bar")).toBeNull();
     expect(configSection.compareDocumentPosition(launchSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(launchSection.compareDocumentPosition(parameterSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(parameterSection.compareDocumentPosition(updatePanel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(promptBlock.compareDocumentPosition(parameterBar) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("offers a persistent theme mode toggle in the left rail", async () => {
@@ -1846,6 +1955,44 @@ describe("renderer multi-model smoke", () => {
     expect(shell.style.getPropertyValue("--history-width")).toBe("280px");
     expect(historyResizer.getAttribute("aria-disabled")).toBe("false");
     expect(historyResizer.getAttribute("aria-valuenow")).toBe("280");
+  });
+
+  it("compresses the right rail with the window before auto-collapsing it", async () => {
+    window.localStorage.setItem("image2tools.historyWidth", "460");
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1360 });
+
+    await renderApp(snapshot({ history: [geminiJob(0)], galleryAssets: [galleryAsset("compressed.png")] }));
+
+    const shell = document.querySelector<HTMLElement>(".app-shell")!;
+    expect(shell.classList.contains("sidebar-collapsed")).toBe(false);
+    expect(shell.classList.contains("right-rail-collapsed")).toBe(false);
+    expect(shell.style.getPropertyValue("--history-width")).toBe("406px");
+  });
+
+  it("auto-collapses the right rail at the same narrow-window breakpoint as the left rail", async () => {
+    await renderApp(snapshot({ history: [geminiJob(0)], galleryAssets: [galleryAsset("breakpoint.png")] }));
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1320 });
+    window.dispatchEvent(new Event("resize"));
+    await flushAsync();
+
+    const shell = document.querySelector<HTMLElement>(".app-shell")!;
+    expect(shell.classList.contains("sidebar-collapsed")).toBe(true);
+    expect(shell.classList.contains("right-rail-collapsed")).toBe(true);
+    expect(shell.style.getPropertyValue("--history-width")).toBe("256px");
+  });
+
+  it("auto-collapses the right rail before a narrow window can squeeze the editor under it", async () => {
+    await renderApp(snapshot({ history: [geminiJob(0)], galleryAssets: [galleryAsset("narrow.png")] }));
+    await openGalleryRail();
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1000 });
+    window.dispatchEvent(new Event("resize"));
+    await flushAsync();
+
+    const shell = document.querySelector<HTMLElement>(".app-shell")!;
+    expect(shell.classList.contains("sidebar-collapsed")).toBe(true);
+    expect(shell.classList.contains("right-rail-collapsed")).toBe(true);
+    expect(shell.style.getPropertyValue("--history-width")).toBe("256px");
+    expect(document.querySelector(".right-rail.collapsed .gallery-thumb img")).toBeTruthy();
   });
 
   it("keeps the workspace in the main grid when the sidebar is collapsed", async () => {
@@ -2720,6 +2867,12 @@ function apiAccessCurrentButton(): HTMLButtonElement {
   return button;
 }
 
+function parameterConfigButton(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(".parameter-config-trigger");
+  if (!button) throw new Error("Parameter config button was not found.");
+  return button;
+}
+
 function apiConfigCardByText(text: string): HTMLElement {
   const card = [...document.querySelectorAll<HTMLElement>(".api-config-card")].find((item) => item.textContent?.includes(text));
   if (!card) throw new Error(`API config card containing "${text}" was not found.`);
@@ -2733,7 +2886,7 @@ function apiConfigCardMainByText(text: string): HTMLButtonElement {
 }
 
 function apiConfigUseButtonByText(text: string): HTMLButtonElement {
-  const button = apiConfigCardByText(text).querySelector<HTMLButtonElement>(".api-config-use-button");
+  const button = [...apiConfigCardByText(text).querySelectorAll<HTMLButtonElement>(".api-config-card-actions button")].find((item) => item.getAttribute("aria-label") === "Use this config now");
   if (!button) throw new Error(`API config use button containing "${text}" was not found.`);
   return button;
 }
@@ -2744,18 +2897,16 @@ function apiConfigDeleteButtonByText(text: string): HTMLButtonElement {
   return button;
 }
 
-function apiConfigDiscoverButtonByText(text: string): HTMLButtonElement {
-  const button = [...apiConfigCardByText(text).querySelectorAll<HTMLButtonElement>(".api-config-card-actions button")].find((item) => item.getAttribute("aria-label") === "Discover models");
-  if (!button) throw new Error(`API config discover button containing "${text}" was not found.`);
-  return button;
-}
-
 async function openSavedApiAccess() {
   await click(apiAccessCurrentButton());
 }
 
 async function openTemplateDialog() {
   await click(buttonByText("Prompt templates", ".prompt-actions button"));
+}
+
+async function openParameterDialog() {
+  await click(parameterConfigButton());
 }
 
 async function openGalleryRail() {

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -752,24 +752,33 @@ describe("renderer multi-model smoke", () => {
     expect(document.querySelector(".notice-area")?.getAttribute("aria-live")).toBe("polite");
     expect(document.querySelector(".notice-area")?.getAttribute("aria-atomic")).toBe("true");
 
+    const shell = document.querySelector<HTMLElement>(".app-shell")!;
     const previewOpener = document.querySelector<HTMLElement>(".preview-image-frame img")!;
     previewOpener.focus();
     expect(document.activeElement).toBe(previewOpener);
+    expect(document.querySelector(".preview-layout.editor-focus-mode")).toBeNull();
+    expect(shell.classList.contains("sidebar-collapsed")).toBe(false);
+    expect(shell.classList.contains("right-rail-collapsed")).toBe(false);
+
     await keyDown(previewOpener, "Enter");
     await flushAsync();
 
-    const previewDialog = document.querySelector<HTMLElement>(".preview-modal-dialog")!;
-    const previewClose = document.querySelector<HTMLButtonElement>(".preview-modal-close")!;
-    expect(previewDialog.getAttribute("aria-modal")).toBe("true");
-    expect(previewDialog.getAttribute("aria-labelledby")).toBe("preview-modal-title");
-    expect(document.querySelector("#preview-modal-title")?.textContent).toBe("Image preview");
-    expect(document.activeElement).toBe(previewClose);
+    // Double-click / Enter now expands the in-place editor instead of opening a read-only modal.
+    expect(document.querySelector(".preview-layout.editor-focus-mode")).not.toBeNull();
+    expect(document.querySelector(".preview-modal-dialog")).toBeNull();
+    // The editing toolbar remains available in expanded mode.
+    expect(document.querySelector('.preview-control-strip button[aria-label="Edit"]')).not.toBeNull();
+    // Expanding the editor collapses both side regions.
+    expect(shell.classList.contains("sidebar-collapsed")).toBe(true);
+    expect(shell.classList.contains("right-rail-collapsed")).toBe(true);
 
-    await keyDown(previewDialog, "Escape");
+    await keyDown(document.body, "Escape");
     await flushAsync();
 
-    expect(document.querySelector(".preview-modal-dialog")).toBeNull();
-    expect(document.activeElement).toBe(previewOpener);
+    // Exiting restores both side regions together.
+    expect(document.querySelector(".preview-layout.editor-focus-mode")).toBeNull();
+    expect(shell.classList.contains("sidebar-collapsed")).toBe(false);
+    expect(shell.classList.contains("right-rail-collapsed")).toBe(false);
   });
 
   it("picks a Gallery image as a reference asset from the context menu", async () => {
@@ -990,6 +999,28 @@ describe("renderer multi-model smoke", () => {
 
     expect(bridge.pickGalleryAsset).toHaveBeenCalledWith(matching.id);
     expect(document.body.textContent).toContain("@ folder-match.png");
+  });
+
+  it("hot-reloads history from an external state change via onSnapshotChange", async () => {
+    const bridge = await renderApp(snapshot({ history: [geminiJob(0, { outputs: [imageAsset("existing.png")] })] }));
+
+    expect(document.querySelectorAll(".history-item")).toHaveLength(1);
+
+    // Simulate the main process pushing a fresh snapshot after a CLI/MCP external write.
+    const pushSnapshot = vi.mocked(bridge.onSnapshotChange).mock.calls[0]?.[0];
+    expect(pushSnapshot).toBeTruthy();
+
+    const externalSnapshot = snapshot({
+      history: [
+        geminiJob(1, { outputs: [imageAsset("external.png", "job_gemini_1")] }),
+        geminiJob(0, { outputs: [imageAsset("existing.png")] })
+      ]
+    });
+    await act(async () => {
+      pushSnapshot!(externalSnapshot);
+    });
+
+    expect(document.querySelectorAll(".history-item")).toHaveLength(2);
   });
 
   it("adds a history result to a selected Gallery folder", async () => {
@@ -1576,7 +1607,7 @@ describe("renderer multi-model smoke", () => {
     const reminder = document.querySelector<HTMLElement>(".reference-rights-reminder");
     expect(reminder?.textContent).toContain("Only upload images you have permission to use");
     expect(referenceGrid && reminder ? Boolean(referenceGrid.compareDocumentPosition(reminder) & Node.DOCUMENT_POSITION_FOLLOWING) : false).toBe(true);
-    expect(document.querySelector<HTMLButtonElement>('button[aria-label="Add as mask"]')?.disabled).toBe(true);
+    expect(document.querySelector<HTMLButtonElement>('.input-panel button[aria-label="Add as mask"]')).toBeNull();
     expect(document.body.textContent).toContain("Drag local images, History results, or Gallery images here.");
     expect(document.querySelector<HTMLButtonElement>('.input-panel button[aria-label="Clear"]')).toBeNull();
   });
@@ -2475,6 +2506,7 @@ function createBridge(initialSnapshot: AppSnapshot): AppBridge {
     clearHistory: vi.fn(async () => []),
     onJobEvent: vi.fn(() => () => undefined),
     onGalleryEvent: vi.fn(() => () => undefined),
+    onSnapshotChange: vi.fn(() => () => undefined),
     addProvider: vi.fn(async (input) => {
       const kind = input.kind ?? "openai";
       const newProvider = providerConfig({

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -115,7 +115,7 @@ import { ImageEditor } from "./ImageEditor";
 import { DialogShell } from "./DialogShell";
 import { HistoryFilterToolbar, HistoryFloatingPager, HistoryItemCard, HistoryListShell } from "./HistoryPanel";
 import { ApiConfigDialog, LaunchSection, ProviderSummarySection } from "./ProviderConfigPanel";
-import { ParameterSection } from "./ParameterConfigPanel";
+import { ParameterConfigDialog, ParameterConfigLauncher } from "./ParameterConfigPanel";
 import {
   GalleryCompactControls,
   GalleryContentGrid,
@@ -260,6 +260,7 @@ const RIGHT_RAIL_THUMB_MIN_SIZE = 128;
 const RIGHT_RAIL_THUMB_HORIZONTAL_CHROME = 48;
 const LEFT_RAIL_AUTO_COLLAPSE_WIDTH = MIN_SIDEBAR_WIDTH;
 const RIGHT_RAIL_AUTO_COLLAPSE_WIDTH = MIN_HISTORY_WIDTH;
+const RAIL_AUTO_COLLAPSE_BREAKPOINT = 1320;
 const DEFAULT_PREVIEW_PANEL_RATIO = 0.618;
 const MIN_PREVIEW_PANEL_RATIO = 0.48;
 const MAX_PREVIEW_PANEL_RATIO = 0.74;
@@ -928,6 +929,7 @@ export function App() {
   const [params, setParams] = useState<ImageParams>(DEFAULT_IMAGE_PARAMS);
   const modeLabels = useMemo(() => modeLabelsForParams(copy, params), [copy, params]);
   const [apiKey, setApiKey] = useState("");
+  const [apiAccessKind, setApiAccessKind] = useState<ProviderKind>("openai");
   const [apiAccessName, setApiAccessName] = useState("OpenAI");
   const [baseURL, setBaseURL] = useState(DEFAULT_BASE_URL);
   const [isActiveApiConfigOpen, setIsActiveApiConfigOpen] = useState(false);
@@ -966,7 +968,7 @@ export function App() {
   const [generationAttemptIndex, setGenerationAttemptIndex] = useState<number | null>(null);
   const [arePromptSecondaryActionsIconOnly, setArePromptSecondaryActionsIconOnly] = useState(false);
   const [isPrimaryRunIconOnly, setIsPrimaryRunIconOnly] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [isParameterDialogOpen, setIsParameterDialogOpen] = useState(false);
   const [openLaunchMenuId, setOpenLaunchMenuId] = useState<FocusedLaunchId | null>(null);
   const [historySearch, setHistorySearch] = useState("");
   const [historyStatusFilter, setHistoryStatusFilter] = useState<"all" | "succeeded" | "failed">("all");
@@ -984,6 +986,7 @@ export function App() {
   const [editingHistoryTagsId, setEditingHistoryTagsId] = useState<string | null>(null);
   const [historyTagsInput, setHistoryTagsInput] = useState("");
   const [historyGalleryMenuJobId, setHistoryGalleryMenuJobId] = useState<string | null>(null);
+  const [expandedHistoryCardId, setExpandedHistoryCardId] = useState<string | null>(null);
   const [isTemplatesOpen, setIsTemplatesOpen] = useState(false);
   const [templateSearch, setTemplateSearch] = useState("");
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
@@ -1110,6 +1113,7 @@ export function App() {
   const [referenceLimitToast, setReferenceLimitToast] = useState<{ id: number; text: string } | null>(null);
   const [buttonFeedback, setButtonFeedback] = useState<Record<string, number>>({});
   const [globalTooltip, setGlobalTooltip] = useState<GlobalTooltip | null>(null);
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   const [sidebarWidth, setSidebarWidth] = useState(() => readStoredWidth("image2tools.sidebarWidth", DEFAULT_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH));
   const [historyWidth, setHistoryWidth] = useState(() => readStoredWidth("image2tools.historyWidth", DEFAULT_HISTORY_WIDTH, MIN_RIGHT_RAIL_WIDTH, MAX_HISTORY_WIDTH));
   const [previewPanelRatio, setPreviewPanelRatio] = useState(() => readStoredWidth("image2tools.previewPanelRatio", DEFAULT_PREVIEW_PANEL_RATIO, MIN_PREVIEW_PANEL_RATIO, MAX_PREVIEW_PANEL_RATIO));
@@ -1117,6 +1121,10 @@ export function App() {
   const [contextMenu, setContextMenu] = useState<ImageContextMenuState | null>(null);
   const [sidebarCollapseButtonY, setSidebarCollapseButtonY] = useState(() => (typeof window === "undefined" ? 0 : window.innerHeight - 86));
   const [rightRailCollapseButtonY, setRightRailCollapseButtonY] = useState(() => (typeof window === "undefined" ? 0 : window.innerHeight - 86));
+  const [isAutoRightRailCollapsed, setIsAutoRightRailCollapsed] = useState(() => {
+    const leftWidth = window.innerWidth <= RAIL_AUTO_COLLAPSE_BREAKPOINT ? COMPACT_SIDEBAR_WIDTH : DEFAULT_SIDEBAR_WIDTH;
+    return window.innerWidth <= RAIL_AUTO_COLLAPSE_BREAKPOINT || window.innerWidth - leftWidth - RESIZER_WIDTH * 2 < MIN_WORKSPACE_WIDTH + RIGHT_RAIL_AUTO_COLLAPSE_WIDTH;
+  });
 
   const maskCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const galleryContentRef = useRef<HTMLDivElement | null>(null);
@@ -1202,12 +1210,12 @@ export function App() {
   const generalModeNotice = generalParams ? generalRuntimeNotice(generalParams.providerKind, copy) : copy.generalRuntimeUnsupported;
   const activeInpaintCapability = inpaintCapabilityForParams(params);
   const usesExactMask = activeInpaintCapability === "exact-mask";
+  const showExactMaskRouteNotice = requestMode === "inpaint" && usesExactMask;
   const sizeSelectValue = openAIParams && sizePresets.includes(openAIParams.size) ? openAIParams.size : "custom";
   const streamDisabledReason = openAIParams ? streamPartialPreviewDisabledReason(openAIParams, activeConfig, requestMode, copy) : undefined;
   const streamPartialsAllowed = openAIParams ? !streamDisabledReason : false;
   const apiKeyPlaceholder = selectedApiConfig.apiKeyPreview ?? (selectedApiConfig.apiKeySaved ? copy.savedLocally : copy.pasteApiKey);
   const launchButtons = useMemo(() => getLaunchButtonStates(activeConfig, copy), [copy, activeConfig]);
-  const activeLaunchDisplay = launchButtons.find((button) => button.launchId === activeConfig.activeLaunchId)?.displayName ?? modelLabelFromId(activeConfig.activeModelId);
   const connectionLabel = connectionStatusLabel(connectionCheck, copy);
   const connectionTitle = connectionCheck.status === "error" && connectionCheck.message ? copy.connectionErrorDetail(connectionCheck.message) : connectionLabel;
   const connectionErrorText = connectionCheck.status === "error" && connectionCheck.message ? copy.connectionErrorDetail(connectionCheck.message) : null;
@@ -1217,14 +1225,21 @@ export function App() {
     ?? (selectedApiConfig.lastModelDiscoveryAt || selectedApiConfig.discoveredModels.length > 0 ? selectedDiscoveryText : copy.apiAccessNoModels);
   const isSelectedConfigSaved = savedApiConfigId === selectedApiConfig.id && selectedApiConfig.apiKeySaved && !apiKey.trim();
   const inactiveApiConfigs = snapshot.providers.filter((config) => config.id !== activeConfig.id);
-  const maxSidebarWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, window.innerWidth - historyWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
-  const maxHistoryWidth = Math.min(MAX_HISTORY_WIDTH, Math.max(MIN_RIGHT_RAIL_WIDTH, window.innerWidth - sidebarWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
-  const isRightRailStacked = historyWidth <= RIGHT_RAIL_STACKED_WIDTH;
-  const isRightRailDense = historyWidth <= RIGHT_RAIL_DENSE_WIDTH;
-  const isRightRailCompact = isRightRailCollapsed || historyWidth <= RIGHT_RAIL_COLLAPSED_WIDTH;
+  const renderedSidebarWidth = isSidebarCompact ? COMPACT_SIDEBAR_WIDTH : sidebarWidth;
+  const maxHistoryWidth = Math.min(MAX_HISTORY_WIDTH, Math.max(MIN_RIGHT_RAIL_WIDTH, viewportWidth - renderedSidebarWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
+  const clampedHistoryWidth = clamp(historyWidth, MIN_RIGHT_RAIL_WIDTH, maxHistoryWidth);
+  const isRightRailCompact = isRightRailCollapsed || isAutoRightRailCollapsed || historyWidth <= RIGHT_RAIL_COLLAPSED_WIDTH;
+  const autoCollapsedHistoryWidth = Math.min(RIGHT_RAIL_COLLAPSED_WIDTH, Math.max(MIN_RIGHT_RAIL_WIDTH, maxHistoryWidth));
+  const renderedHistoryWidth =
+    isAutoRightRailCollapsed && !isRightRailCollapsed && historyWidth > RIGHT_RAIL_COLLAPSED_WIDTH
+      ? autoCollapsedHistoryWidth
+      : clampedHistoryWidth;
+  const maxSidebarWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, viewportWidth - renderedHistoryWidth - RESIZER_WIDTH * 2 - MIN_WORKSPACE_WIDTH));
+  const isRightRailStacked = renderedHistoryWidth <= RIGHT_RAIL_STACKED_WIDTH;
+  const isRightRailDense = renderedHistoryWidth <= RIGHT_RAIL_DENSE_WIDTH;
   const rightRailLayoutMode = isRightRailCompact ? "compact" : isRightRailDense ? "dense" : isRightRailStacked ? "stacked" : "full";
   const rightRailThumbSize = clamp(
-    historyWidth - RIGHT_RAIL_THUMB_HORIZONTAL_CHROME,
+    renderedHistoryWidth - RIGHT_RAIL_THUMB_HORIZONTAL_CHROME,
     RIGHT_RAIL_THUMB_MIN_SIZE,
     RIGHT_RAIL_THUMB_MAX_SIZE
   );
@@ -1719,11 +1734,44 @@ export function App() {
   }, [isTagManagerOpen]);
 
   useEffect(() => {
-    const updateCompactState = () => setIsAutoSidebarCollapsed(window.innerWidth <= 1320);
+    if (!expandedHistoryCardId) return undefined;
+
+    const closeExpandedHistoryCard = (event: Event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (target?.closest(".history-item")) return;
+      setExpandedHistoryCardId(null);
+    };
+
+    window.addEventListener("pointerdown", closeExpandedHistoryCard, true);
+    return () => window.removeEventListener("pointerdown", closeExpandedHistoryCard, true);
+  }, [expandedHistoryCardId]);
+
+  useEffect(() => {
+    const updateViewportWidth = () => setViewportWidth(window.innerWidth);
+    updateViewportWidth();
+    window.addEventListener("resize", updateViewportWidth);
+    return () => window.removeEventListener("resize", updateViewportWidth);
+  }, []);
+
+  useEffect(() => {
+    const updateCompactState = () => setIsAutoSidebarCollapsed(window.innerWidth <= RAIL_AUTO_COLLAPSE_BREAKPOINT);
     updateCompactState();
     window.addEventListener("resize", updateCompactState);
     return () => window.removeEventListener("resize", updateCompactState);
   }, []);
+
+  useEffect(() => {
+    const updateCompactState = () => {
+      const leftWidth = isSidebarCompact ? COMPACT_SIDEBAR_WIDTH : sidebarWidthRef.current;
+      setIsAutoRightRailCollapsed(
+        window.innerWidth <= RAIL_AUTO_COLLAPSE_BREAKPOINT ||
+        window.innerWidth - leftWidth - RESIZER_WIDTH * 2 < MIN_WORKSPACE_WIDTH + RIGHT_RAIL_AUTO_COLLAPSE_WIDTH
+      );
+    };
+    updateCompactState();
+    window.addEventListener("resize", updateCompactState);
+    return () => window.removeEventListener("resize", updateCompactState);
+  }, [isSidebarCompact]);
 
   useEffect(() => {
     const container = promptActionsRef.current;
@@ -1888,7 +1936,7 @@ export function App() {
       resizeObserver?.disconnect();
       window.removeEventListener("resize", scheduleMeasure);
     };
-  }, [isRightRailCompact, isSidebarCompact, notice.text, rightRailView, rightRailLayoutMode, showAdvanced, updateCheck?.status]);
+  }, [isParameterDialogOpen, isRightRailCompact, isSidebarCompact, notice.text, rightRailView, rightRailLayoutMode, updateCheck?.status]);
 
   useEffect(() => {
     const node = historyListRef.current;
@@ -1907,6 +1955,13 @@ export function App() {
   useEffect(() => {
     setHistoryPageIndex((current) => Math.min(current, historyPageCount - 1));
   }, [historyPageCount]);
+
+  useEffect(() => {
+    setExpandedHistoryCardId((current) => {
+      if (!current) return current;
+      return visibleHistory.some((job) => job.id === current) ? current : null;
+    });
+  }, [visibleHistory]);
 
   useEffect(() => {
     if (!isActiveApiConfigOpen) return;
@@ -2892,6 +2947,7 @@ export function App() {
 
   function hydrateApiConfigForm(config: ProviderConfig) {
     setSelectedApiConfigId(config.id);
+    setApiAccessKind(config.kind);
     setApiAccessName(apiAccessDisplayName(config, copy.apiAccessUntitled));
     setBaseURL(config.baseURL);
     setApiKey("");
@@ -2900,10 +2956,12 @@ export function App() {
 
   function openApiConfigDialog(config: ProviderConfig = activeConfig) {
     hydrateApiConfigForm(config);
+    setIsAddingApiAccess(false);
     setIsActiveApiConfigOpen(true);
   }
 
   function selectApiConfigForEditing(config: ProviderConfig) {
+    setIsAddingApiAccess(false);
     hydrateApiConfigForm(config);
     resetConnectionCheckForConfigEdit();
   }
@@ -2912,6 +2970,7 @@ export function App() {
     setSnapshot(next);
     const nextActiveConfig = next.providers.find(p => p.id === next.activeProviderId) ?? next.providers[0];
     const nextSelectedConfig = next.providers.find(p => p.id === selectedApiConfigId) ?? nextActiveConfig;
+    setApiAccessKind(nextSelectedConfig.kind);
     setApiAccessName(apiAccessDisplayName(nextSelectedConfig, copy.apiAccessUntitled));
     setBaseURL(nextSelectedConfig.baseURL);
     setSelectedApiConfigId(nextSelectedConfig.id);
@@ -2926,6 +2985,7 @@ export function App() {
       return { ...current, providers: nextProviders };
     });
     if (config.id === (selectedApiConfigId ?? activeConfig.id)) {
+      setApiAccessKind(config.kind);
       setApiAccessName(apiAccessDisplayName(config, copy.apiAccessUntitled));
       setBaseURL(config.baseURL);
     }
@@ -2950,16 +3010,23 @@ export function App() {
 
   function renderApiConfigConnectionBadge(config: ProviderConfig) {
     const check = apiConfigConnectionCheck(config);
-    const label = connectionStatusLabel(check, copy);
-    const title = check.status === "error" && check.message ? copy.connectionErrorDetail(check.message) : label;
-    const checking = config.id === activeConfig.id && (isTestingConnection || check.status === "checking");
+    const testing = config.id === activeConfig.id && (isTestingConnection || check.status === "checking");
+    const discovering = discoveringProviderId === config.id;
+    const hasDiscovery = !config.lastModelDiscoveryError && (Boolean(config.lastModelDiscoveryAt) || config.discoveredModels.length > 0);
+    const isTested = check.status === "ok";
+    const hasError = check.status === "error" || Boolean(config.lastModelDiscoveryError);
+    const status = testing || discovering ? "checking" : hasError ? "error" : isTested || hasDiscovery ? "ok" : "idle";
+    const label = testing ? copy.connectionChecking : discovering ? copy.discoveringModels : isTested ? copy.apiAccessTestedStatus : hasDiscovery ? copy.apiAccessDiscoveredStatus : connectionStatusLabel(check, copy);
+    const title = check.status === "error" && check.message
+      ? copy.connectionErrorDetail(check.message)
+      : config.lastModelDiscoveryError ?? (isTested ? copy.apiAccessTestedStatus : hasDiscovery ? discoveredModelTooltip(config, copy) : label);
     return (
-      <span className="connection-badge api-config-card-connection" data-status={check.status} title={title}>
-        {checking ? (
+      <span className="connection-badge api-config-card-connection" data-status={status} title={title}>
+        {testing || discovering ? (
           <Loader2 className="spin" size={12} />
-        ) : check.status === "ok" ? (
+        ) : isTested || hasDiscovery ? (
           <CheckCircle2 size={12} />
-        ) : check.status === "error" ? (
+        ) : hasError ? (
           <AlertTriangle size={12} />
         ) : (
           <span className="connection-dot" />
@@ -2990,22 +3057,28 @@ export function App() {
       return;
     }
     setIsSavingConfig(true);
+    let shouldRunConnectionTest = false;
     try {
       const targetConfig = selectedApiConfig;
-      const configKind = targetConfig.kind;
+      const configKind = apiAccessKind;
       const isEditingActiveConfig = targetConfig.id === activeConfig.id;
+      const providerKindChanged = configKind !== targetConfig.kind;
+      const nextActiveLaunchId = providerKindChanged ? defaultLaunchForProvider(configKind) : targetConfig.activeLaunchId;
+      const nextDefaultModel = providerKindChanged
+        ? defaultModelForProvider(configKind)
+        : isEditingActiveConfig ? defaultModelForConfigSave(configKind, params, activeConfig) : targetConfig.defaultModel;
       const config = await bridge.saveConfig({
         providerId: targetConfig.id,
         kind: configKind,
         name: apiAccessName.trim() || providerLabelFromKind(configKind),
         apiKey: apiKey.trim() ? apiKey : undefined,
         baseURL,
-        defaultModel: isEditingActiveConfig ? defaultModelForConfigSave(configKind, params, activeConfig) : targetConfig.defaultModel,
+        defaultModel: nextDefaultModel,
         defaultSize: isEditingActiveConfig ? defaultSizeForConfigSave(params, activeConfig) : targetConfig.defaultSize,
         defaultQuality: isEditingActiveConfig ? defaultQualityForConfigSave(params, activeConfig) : targetConfig.defaultQuality,
         timeoutMs: isEditingActiveConfig ? params.timeoutMs : targetConfig.timeoutMs,
-        activeLaunchId: targetConfig.activeLaunchId,
-        activeModelId: targetConfig.activeModelId
+        activeLaunchId: nextActiveLaunchId,
+        activeModelId: providerKindChanged ? nextDefaultModel : targetConfig.activeModelId
       });
       applyConfig(config);
       if (config.id === activeConfig.id) {
@@ -3018,8 +3091,7 @@ export function App() {
         text: config.lastModelDiscoveryError ? config.lastModelDiscoveryError : copy.notices.configSaved
       });
       if (config.id === activeConfig.id && config.apiKeySaved) {
-        hasAutoTestedConnectionRef.current = true;
-        await runConnectionTest({ silent: false, apiKeySaved: config.apiKeySaved });
+        shouldRunConnectionTest = true;
       } else if (config.id === activeConfig.id) {
         setConnectionCheck({ status: "idle" });
       }
@@ -3028,12 +3100,22 @@ export function App() {
     } finally {
       setIsSavingConfig(false);
     }
+    if (shouldRunConnectionTest) {
+      hasAutoTestedConnectionRef.current = true;
+      void runConnectionTest({ silent: false, apiKeySaved: true });
+    }
   }
 
   function changeNewApiAccessKind(kind: ProviderKind) {
     setNewApiAccessKind(kind);
     setNewApiAccessBaseURL(defaultBaseURLForProvider(kind, kind === "custom" ? newApiAccessBaseURL : baseURL));
     setNewApiAccessName((current) => current || providerLabelFromKind(kind));
+  }
+
+  function changeApiAccessKind(kind: ProviderKind) {
+    setSavedApiConfigId(null);
+    resetConnectionCheckForConfigEdit();
+    setApiAccessKind(kind);
   }
 
   async function switchApiAccess(providerId: string) {
@@ -3064,6 +3146,7 @@ export function App() {
   async function addApiAccess() {
     if (!bridge) return;
     setIsSavingConfig(true);
+    let shouldRunConnectionTest = false;
     try {
       await persistCurrentDraft();
       const defaultModel = defaultModelForProvider(newApiAccessKind);
@@ -3091,13 +3174,16 @@ export function App() {
       setConnectionCheck({ status: "idle" });
       setNotice({ kind: "success", text: copy.apiAccessAdded });
       if (nextActiveConfig.apiKeySaved) {
-        hasAutoTestedConnectionRef.current = true;
-        await runConnectionTest({ silent: true, apiKeySaved: nextActiveConfig.apiKeySaved });
+        shouldRunConnectionTest = true;
       }
     } catch (error) {
       setNotice({ kind: "error", text: normalizeNotice(error) });
     } finally {
       setIsSavingConfig(false);
+    }
+    if (shouldRunConnectionTest) {
+      hasAutoTestedConnectionRef.current = true;
+      void runConnectionTest({ silent: true, apiKeySaved: true });
     }
   }
 
@@ -5095,7 +5181,106 @@ export function App() {
       </select>
     </label>
   ) : null;
-  const parameterSummary = openAIParams ? (
+  const parameterQuickControls = openAIParams ? (
+    <>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.size}</small>
+        <select
+          aria-label={copy.size}
+          value={sizeSelectValue}
+          onChange={(event) => {
+            const value = event.target.value;
+            updateOpenAIParams({ size: value === "custom" ? customSize : value });
+          }}
+        >
+          {sizePresets.map((size) => (
+            <option key={size} value={size}>
+              {size}
+            </option>
+          ))}
+          <option value="custom">{copy.custom}</option>
+        </select>
+      </label>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.quality}</small>
+        <select aria-label={copy.quality} value={openAIParams.quality} onChange={(event) => updateOpenAIParams({ quality: event.target.value as ImageQuality })}>
+          {qualityOptions.map((quality) => (
+            <option key={quality} value={quality}>
+              {quality}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.format}</small>
+        <select aria-label={copy.format} value={openAIParams.outputFormat} onChange={(event) => updateOpenAIParams({ outputFormat: event.target.value as ImageFormat })}>
+          {formatOptions.map((format) => (
+            <option key={format} value={format}>
+              {format.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="parameter-summary-chip parameter-quick-field parameter-route-field" title={imageRouteTitle}>
+        <span className="route-label">
+          <small>{copy.imageRoute}</small>
+          <span className="route-info-icon" aria-label={copy.imageRouteInfo} data-tooltip={copy.imageRouteInfo} title={copy.imageRouteInfo}>
+            <Info size={12} />
+          </span>
+        </span>
+        <select
+          aria-label={copy.imageRoute}
+          value={requestMode === "inpaint" ? "image-api" : openAIParams.imageRoute}
+          disabled={requestMode === "inpaint"}
+          onChange={(event) => updateOpenAIParams({ imageRoute: event.target.value as OpenAIImageRouteSelection })}
+        >
+          <option value="auto">{copy.imageRouteAutoUsing(openAIImageRouteLabel(copy, autoOpenAIImageRoute(activeConfig, requestMode)))}</option>
+          <option value="chat-completions">{copy.imageRouteChatCompletions}</option>
+          <option value="responses">{copy.imageRouteResponses}</option>
+          <option value="image-api">{copy.imageRouteImageApi}</option>
+        </select>
+      </label>
+    </>
+  ) : geminiParams ? (
+    <>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.aspectRatio}</small>
+        <select aria-label={copy.aspectRatio} value={geminiParams.aspectRatio} onChange={(event) => updateGeminiParams({ aspectRatio: event.target.value as GeminiAspectRatio })}>
+          {GEMINI_ASPECT_RATIO_OPTIONS.map((aspectRatio) => (
+            <option key={aspectRatio} value={aspectRatio}>
+              {aspectRatio}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.resolution}</small>
+        <select aria-label={copy.resolution} value={geminiParams.resolution} onChange={(event) => updateGeminiParams({ resolution: event.target.value as GeminiResolution })}>
+          {GEMINI_RESOLUTION_OPTIONS.map((resolution) => (
+            <option key={resolution} value={resolution}>
+              {resolution}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.count}</small>
+        <input aria-label={copy.count} type="number" min="1" max="1" value={geminiParams.outputCount} onChange={() => updateGeminiParams({ outputCount: 1 })} />
+      </label>
+    </>
+  ) : (
+    <>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.model}</small>
+        <input aria-label={copy.model} value={generalParams?.model || copy.generalFallback} readOnly />
+      </label>
+      <label className="parameter-summary-chip parameter-quick-field">
+        <small>{copy.provider}</small>
+        <input aria-label={copy.provider} value={providerLabelFromKind(generalParams?.providerKind ?? activeConfig.kind)} readOnly />
+      </label>
+    </>
+  );
+  const parameterPrimaryControls = openAIParams ? (
     <>
       <label>
         <span>{copy.size}</span>
@@ -5134,7 +5319,7 @@ export function App() {
           ))}
         </select>
       </label>
-      {showAdvanced && openAIImageRouteControl}
+      {openAIImageRouteControl}
     </>
   ) : geminiParams ? (
     <>
@@ -5623,7 +5808,7 @@ export function App() {
       style={
         {
           "--sidebar-width": `${isSidebarCompact ? COMPACT_SIDEBAR_WIDTH : sidebarWidth}px`,
-          "--history-width": `${historyWidth}px`,
+          "--history-width": `${renderedHistoryWidth}px`,
           "--right-rail-thumb-size": `${rightRailThumbSize}px`,
           "--preview-ratio": previewPanelRatio,
           "--sidebar-collapse-button-y": `${sidebarCollapseButtonY}px`,
@@ -5663,10 +5848,7 @@ export function App() {
           <button
             type="button"
             className="icon-button"
-            onClick={() => {
-              setIsSidebarCollapsed(false);
-              setShowAdvanced(true);
-            }}
+            onClick={() => setIsParameterDialogOpen(true)}
             aria-label={copy.parameters}
             data-tooltip={copy.parameters}
           >
@@ -5694,10 +5876,7 @@ export function App() {
 
         <ProviderSummarySection
           copy={copy}
-          activeConfig={activeConfig}
           displayName={apiAccessDisplayName(activeConfig, copy.apiAccessUntitled)}
-          providerLabel={providerLabelFromKind(activeConfig.kind)}
-          baseUrlSummary={summarizeBaseURL(activeConfig.baseURL)}
           discoveryText={discoveryText}
           connectionStatus={connectionCheck.status}
           connectionLabel={connectionLabel}
@@ -5710,23 +5889,13 @@ export function App() {
           copy={copy}
           activeConfig={activeConfig}
           activeProviderKind={params.providerKind}
-          activeLaunchDisplay={activeLaunchDisplay}
           launchButtons={launchButtons}
           openLaunchMenuId={openLaunchMenuId}
           saving={isSavingConfig}
-          providerLabelForKind={providerLabelFromKind}
           modelOptionsForLaunch={getLaunchModelOptions}
           onToggleLaunchMenu={(launchId, open) => setOpenLaunchMenuId(open ? launchId : null)}
           onLaunch={(button) => void launchModel(button)}
           onSelectModel={(launchId, model) => void selectLaunchModel(launchId, model)}
-        />
-
-        <ParameterSection
-          copy={copy}
-          expanded={showAdvanced}
-          summary={parameterSummary}
-          controls={advancedControls}
-          onToggle={() => setShowAdvanced((current) => !current)}
         />
 
         <section className="notice-area" data-kind={notice.kind} aria-live={notice.kind === "error" ? "assertive" : "polite"} aria-atomic="true">
@@ -6007,6 +6176,14 @@ export function App() {
               {validationError && <p className="inline-check error">{validationError}</p>}
             </div>
 
+            {!showReferenceTools && (
+              <ParameterConfigLauncher
+                copy={copy}
+                quickControls={parameterQuickControls}
+                onOpen={() => setIsParameterDialogOpen(true)}
+              />
+            )}
+
             {showReferenceTools && (
               <>
                 <div
@@ -6094,6 +6271,17 @@ export function App() {
                     <span>{copy.uploadRightsReminder}</span>
                   </p>
                 )}
+                {showExactMaskRouteNotice && (
+                  <p className="inline-check warning mask-route-notice">
+                    <AlertTriangle size={14} />
+                    <span>{copy.exactMaskRouteNotice}</span>
+                  </p>
+                )}
+                <ParameterConfigLauncher
+                  copy={copy}
+                  quickControls={parameterQuickControls}
+                  onOpen={() => setIsParameterDialogOpen(true)}
+                />
               </>
             )}
 
@@ -6109,7 +6297,7 @@ export function App() {
         aria-orientation="vertical"
         aria-valuemin={MIN_RIGHT_RAIL_WIDTH}
         aria-valuemax={maxHistoryWidth}
-        aria-valuenow={historyWidth}
+        aria-valuenow={renderedHistoryWidth}
         aria-disabled={false}
         tabIndex={0}
         onPointerDown={(event) => {
@@ -6237,6 +6425,7 @@ export function App() {
                         resultSrc={result ? assetSource(result) : undefined}
                         jobError={jobError}
                         active={activeJob?.id === job.id}
+                        hoverOpen={expandedHistoryCardId === job.id}
                         selected={isSelected}
                         batchMode={isHistoryBatchMode}
                         displayName={displayName}
@@ -6259,6 +6448,7 @@ export function App() {
                         copyButtonLabel={buttonFeedback[`copy:${job.id}`] ? copy.clicked : copy.copy}
                         downloadButtonLabel={result && buttonFeedback[`download:${result.id}`] ? copy.clicked : copy.download}
                         onToggleSelection={(checked) => toggleHistoryJobSelection(job.id, checked)}
+                        onHoverOpen={() => setExpandedHistoryCardId(job.id)}
                         onOpen={() => {
                           setActiveGalleryAssetId(null);
                           setActiveJob(job);
@@ -6290,7 +6480,14 @@ export function App() {
             {galleryRailPanel}
           </StableGalleryRailPanel>
         )}
-        <div ref={rightRailActionsRef} className={`right-rail-actions ${isRightRailActionDrawerOpen ? "drawer-open" : ""}`}>
+        <div
+          ref={rightRailActionsRef}
+          className={[
+            "right-rail-actions",
+            isRightRailActionDrawerOpen ? "drawer-open" : "",
+            isTagManagerOpen ? "tag-manager-open" : ""
+          ].filter(Boolean).join(" ")}
+        >
           <span className="right-rail-summary">
             {rightRailView === "history"
               ? isHistoryBatchMode ? copy.historySelectionCount(selectedHistoryItemCount) : copy.historyStats(snapshot.history.length)
@@ -6382,6 +6579,7 @@ export function App() {
           discoveringProviderId={discoveringProviderId}
           discoveringAny={isDiscoveringModels}
           connectionErrorText={connectionErrorText}
+          kind={apiAccessKind}
           name={apiAccessName}
           apiKey={apiKey}
           baseURL={baseURL}
@@ -6398,11 +6596,15 @@ export function App() {
           displayNameForConfig={(config) => apiAccessDisplayName(config, copy.apiAccessUntitled)}
           providerLabelForKind={providerLabelFromKind}
           baseUrlSummaryForConfig={(config) => summarizeBaseURL(config.baseURL)}
+          baseUrlSummaryForValue={summarizeBaseURL}
           discoverySummaryForConfig={(config) => discoverySummary(config, copy)}
           discoveryTooltipForConfig={(config) => discoveredModelTooltip(config, copy)}
           modelLabel={discoveredModelLabel}
           connectionBadgeForConfig={renderApiConfigConnectionBadge}
-          onClose={() => setIsActiveApiConfigOpen(false)}
+          onClose={() => {
+            setIsAddingApiAccess(false);
+            setIsActiveApiConfigOpen(false);
+          }}
           onUseConfig={(config) => void switchApiAccess(config.id)}
           onSelectConfig={selectApiConfigForEditing}
           onDeleteConfig={(config) => void deleteApiAccess(config)}
@@ -6414,6 +6616,7 @@ export function App() {
           onNewApiAccessKeyChange={setNewApiAccessKey}
           onAddApiAccess={() => void addApiAccess()}
           onCancelAddApiAccess={() => setIsAddingApiAccess(false)}
+          onKindChange={changeApiAccessKind}
           onNameChange={(value) => {
             setSavedApiConfigId(null);
             setApiAccessName(value);
@@ -6429,6 +6632,14 @@ export function App() {
             setBaseURL(value);
           }}
           onSubmit={() => void saveConfig()}
+        />
+      )}
+      {isParameterDialogOpen && (
+        <ParameterConfigDialog
+          copy={copy}
+          primaryControls={parameterPrimaryControls}
+          controls={advancedControls}
+          onClose={() => setIsParameterDialogOpen(false)}
         />
       )}
       {isTemplatesOpen && (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,7 +2,6 @@ import { memo, Profiler, useEffect, useMemo, useRef, useState, type ReactNode } 
 import {
   AlertTriangle,
   BookOpen,
-  Brush,
   ChevronLeft,
   ChevronRight,
   ChevronUp,
@@ -29,6 +28,7 @@ import {
   LibraryBig,
   Monitor,
   Moon,
+  MoreHorizontal,
   Paintbrush,
   Pencil,
   Radar,
@@ -1102,7 +1102,10 @@ export function App() {
     hasExportableEditorOverlay,
     hasEditedPreviewChanges
   } = useImageEditor();
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [isEditorFocusMode, setIsEditorFocusMode] = useState(false);
+  const [referencePreviewAssetId, setReferencePreviewAssetId] = useState<string | null>(null);
+  const [isReferenceMaskToolsOpen, setIsReferenceMaskToolsOpen] = useState(false);
+  const [referenceMaskConfirmAssetId, setReferenceMaskConfirmAssetId] = useState<string | null>(null);
   const [isReferenceDragOver, setIsReferenceDragOver] = useState(false);
   const [referenceLimitToast, setReferenceLimitToast] = useState<{ id: number; text: string } | null>(null);
   const [buttonFeedback, setButtonFeedback] = useState<Record<string, number>>({});
@@ -1118,11 +1121,14 @@ export function App() {
   const maskCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const galleryContentRef = useRef<HTMLDivElement | null>(null);
   const historyListRef = useRef<HTMLDivElement | null>(null);
+  const referenceClickTimerRef = useRef<number | null>(null);
   const referenceLimitToastTimerRef = useRef<number | null>(null);
   const sourceImageRef = useRef<HTMLImageElement | null>(null);
   const paintedDuringStrokeRef = useRef(false);
+  const lastMaskPointRef = useRef<{ x: number; y: number } | null>(null);
   const hasAutoTestedConnectionRef = useRef(false);
   const partialImageCountRef = useRef(0);
+  const editorFocusRestoreRef = useRef<{ sidebarCollapsed: boolean; rightRailWidth: number; rightRailCollapsed: boolean } | null>(null);
   const previewLayoutRef = useRef<HTMLDivElement | null>(null);
   const promptActionsRef = useRef<HTMLDivElement | null>(null);
   const primaryRunButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -1150,6 +1156,11 @@ export function App() {
   );
   const sourceAsset = effectiveInputAssets[0];
   const sourcePreview = assetSource(sourceAsset);
+  const referencePreviewAsset = referencePreviewAssetId ? inputAssets.find((asset) => asset.id === referencePreviewAssetId) ?? null : null;
+  const referencePreviewSource = referencePreviewAsset ? assetSource(referencePreviewAsset) : undefined;
+  const referenceMaskConfirmAsset = referenceMaskConfirmAssetId
+    ? inputAssets.find((asset) => asset.id === referenceMaskConfirmAssetId) ?? null
+    : null;
   const maskPreview = maskDataUrl ?? assetSource(maskAsset);
   const activeResults = getResultAssets(activeJob);
   const selectedResult = activeResults.find((asset) => asset.id === selectedResultId);
@@ -1266,6 +1277,32 @@ export function App() {
 
     expandedHistoryWidthRef.current = Math.max(historyWidthRef.current, MIN_HISTORY_WIDTH);
     applyRightRailWidth(RIGHT_RAIL_COLLAPSED_WIDTH, { forceCollapsed: true });
+  }
+
+  function toggleEditorFocusMode() {
+    setIsEditorFocusMode((current) => {
+      const next = !current;
+      if (next) {
+        // Entering focus mode: remember both side regions, then collapse them so the
+        // middle editor expands. Both restore together when focus mode exits.
+        editorFocusRestoreRef.current = {
+          sidebarCollapsed: isSidebarCollapsed,
+          rightRailWidth: historyWidthRef.current,
+          rightRailCollapsed: isRightRailCollapsed
+        };
+        setIsSidebarCollapsed(true);
+        expandedHistoryWidthRef.current = Math.max(historyWidthRef.current, MIN_HISTORY_WIDTH);
+        applyRightRailWidth(RIGHT_RAIL_COLLAPSED_WIDTH, { forceCollapsed: true });
+      } else {
+        const restore = editorFocusRestoreRef.current;
+        editorFocusRestoreRef.current = null;
+        if (restore) {
+          setIsSidebarCollapsed(restore.sidebarCollapsed);
+          applyRightRailWidth(restore.rightRailWidth, { forceCollapsed: restore.rightRailCollapsed });
+        }
+      }
+      return next;
+    });
   }
 
   const {
@@ -2039,9 +2076,18 @@ export function App() {
 
   useEffect(() => {
     return () => {
+      if (referenceClickTimerRef.current) window.clearTimeout(referenceClickTimerRef.current);
       if (referenceLimitToastTimerRef.current) window.clearTimeout(referenceLimitToastTimerRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (!referencePreviewAssetId) return;
+    if (inputAssets.some((asset) => asset.id === referencePreviewAssetId)) return;
+    setReferencePreviewAssetId(null);
+    setIsReferenceMaskToolsOpen(false);
+    setReferenceMaskConfirmAssetId(null);
+  }, [inputAssets, referencePreviewAssetId]);
 
   useEffect(() => {
     if (!bridge) return;
@@ -2118,6 +2164,19 @@ export function App() {
         ...current,
         galleryFolders: event.folders,
         galleryAssets: event.assets
+      }));
+    });
+  }, [bridge]);
+
+  useEffect(() => {
+    if (!bridge?.onSnapshotChange) return;
+    // External processes (CLI / MCP) can mutate the shared state file. The main process
+    // watches that file and pushes a fresh snapshot; merge the server-owned data so the UI
+    // hot-reloads, but keep the user's in-progress draft/edit context untouched.
+    return bridge.onSnapshotChange((next) => {
+      setSnapshot((current) => ({
+        ...next,
+        draft: current.draft
       }));
     });
   }, [bridge]);
@@ -3315,6 +3374,70 @@ export function App() {
         text: copy.notices.imagesAdded(addedCount, cappedNext.length, false, referenceLimit)
       });
     }
+  }
+
+  function clearReferenceClickTimer() {
+    if (!referenceClickTimerRef.current) return;
+    window.clearTimeout(referenceClickTimerRef.current);
+    referenceClickTimerRef.current = null;
+  }
+
+  function promoteReferenceAssetToFirst(assetId: string, options: { clearMask?: boolean } = {}) {
+    const index = inputAssets.findIndex((asset) => asset.id === assetId);
+    if (index <= 0) return;
+    const target = inputAssets[index];
+    setInputAssets([target, ...inputAssets.slice(0, index), ...inputAssets.slice(index + 1)]);
+    markDraftChanged();
+    setTabMode("img2img");
+    if (options.clearMask && (maskAsset || maskDataUrl)) {
+      setMaskAsset(null);
+      setMaskDataUrl(null);
+      setMaskCheck(null);
+    }
+    setNotice({ kind: "info", text: copy.referencePromoted });
+  }
+
+  function handleReferenceTileClick(assetId: string) {
+    clearReferenceClickTimer();
+    referenceClickTimerRef.current = window.setTimeout(() => {
+      referenceClickTimerRef.current = null;
+      promoteReferenceAssetToFirst(assetId);
+    }, 180);
+  }
+
+  function openReferencePreview(assetId: string) {
+    clearReferenceClickTimer();
+    setReferencePreviewAssetId(assetId);
+    setIsReferenceMaskToolsOpen(false);
+    setReferenceMaskConfirmAssetId(null);
+  }
+
+  function closeReferencePreview() {
+    clearReferenceClickTimer();
+    setReferencePreviewAssetId(null);
+    setIsReferenceMaskToolsOpen(false);
+    setReferenceMaskConfirmAssetId(null);
+    setIsPainting(false);
+  }
+
+  function requestReferenceMaskEditor(asset: InputAsset) {
+    if (isGeneralMode) {
+      setNotice({ kind: "error", text: copy.validation.generalNoMask });
+      return;
+    }
+    if (inputAssets[0]?.id !== asset.id) {
+      setReferenceMaskConfirmAssetId(asset.id);
+      return;
+    }
+    setTabMode("img2img");
+    setIsReferenceMaskToolsOpen((current) => !current);
+  }
+
+  function confirmReferenceMaskEditor(assetId: string) {
+    promoteReferenceAssetToFirst(assetId, { clearMask: true });
+    setReferencePreviewAssetId(assetId);
+    setReferenceMaskConfirmAssetId(null);
+    setIsReferenceMaskToolsOpen(true);
   }
 
   async function selectImages() {
@@ -4644,6 +4767,29 @@ export function App() {
   }, [contextMenu]);
 
   useEffect(() => {
+    if (!isEditorFocusMode) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") toggleEditorFocusMode();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isEditorFocusMode]);
+
+  useEffect(() => {
+    // The reference source image is now always mounted, so its onLoad no longer fires
+    // when the mask canvas appears. Size the canvas explicitly when masking begins.
+    if (!isReferenceMaskToolsOpen) return;
+    const frame = window.requestAnimationFrame(() => resizeMaskCanvas());
+    return () => window.cancelAnimationFrame(frame);
+  }, [isReferenceMaskToolsOpen, referencePreviewAssetId]);
+
+  useEffect(() => {
+    // The editor surface changes width when focus mode toggles; resync the annotation canvas.
+    const frame = window.requestAnimationFrame(() => resizeAnnotationCanvas(false));
+    return () => window.cancelAnimationFrame(frame);
+  }, [isEditorFocusMode]);
+
+  useEffect(() => {
     const tooltipTarget = (target: EventTarget | null): HTMLElement | null => {
       if (!(target instanceof Element)) return null;
       return target.closest<HTMLElement>("[data-tooltip]");
@@ -4838,6 +4984,16 @@ export function App() {
     }
   }
 
+  function maskPointFromEvent(event: React.PointerEvent<HTMLCanvasElement>): { x: number; y: number } | null {
+    const canvas = maskCanvasRef.current;
+    if (!canvas) return null;
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: ((event.clientX - rect.left) / rect.width) * canvas.width,
+      y: ((event.clientY - rect.top) / rect.height) * canvas.height
+    };
+  }
+
   function startPaint(event: React.PointerEvent<HTMLCanvasElement>) {
     // Painting is what CREATES a freehand mask, so it cannot gate on requestMode === "inpaint"
     // (which only becomes true once a mask already exists). Gate on the conditions under which
@@ -4845,6 +5001,7 @@ export function App() {
     if (isGeneralMode || tabMode !== "img2img" || !sourcePreview) return;
     setIsPainting(true);
     paintedDuringStrokeRef.current = false;
+    lastMaskPointRef.current = null;
     event.currentTarget.setPointerCapture(event.pointerId);
     paintAt(event);
   }
@@ -4858,6 +5015,7 @@ export function App() {
     if (!isPainting) return;
     event.currentTarget.releasePointerCapture(event.pointerId);
     setIsPainting(false);
+    lastMaskPointRef.current = null;
     const canvas = maskCanvasRef.current;
     if (canvas && paintedDuringStrokeRef.current) {
       markDraftChanged();
@@ -4869,20 +5027,32 @@ export function App() {
   function paintAt(event: React.PointerEvent<HTMLCanvasElement>) {
     const canvas = maskCanvasRef.current;
     if (!canvas) return;
-    const rect = canvas.getBoundingClientRect();
-    const x = ((event.clientX - rect.left) / rect.width) * canvas.width;
-    const y = ((event.clientY - rect.top) / rect.height) * canvas.height;
+    const point = maskPointFromEvent(event);
+    if (!point) return;
     const context = canvas.getContext("2d");
     if (!context) return;
     context.save();
     context.globalCompositeOperation = "source-over";
     context.fillStyle = "rgba(255,255,255,0.9)";
-    context.shadowColor = "rgba(30,107,95,0.4)";
-    context.shadowBlur = brushSize * 0.2;
+    context.strokeStyle = "rgba(255,255,255,0.9)";
+    context.lineCap = "round";
+    context.lineJoin = "round";
+    context.lineWidth = brushSize;
+    const from = lastMaskPointRef.current;
+    if (from) {
+      // Connect consecutive pointer samples so a fast stroke is a continuous band
+      // rather than a row of detached dots.
+      context.beginPath();
+      context.moveTo(from.x, from.y);
+      context.lineTo(point.x, point.y);
+      context.stroke();
+    }
+    // Round cap at the current point keeps the start of the stroke and slow moves solid.
     context.beginPath();
-    context.arc(x, y, brushSize / 2, 0, Math.PI * 2);
+    context.arc(point.x, point.y, brushSize / 2, 0, Math.PI * 2);
     context.fill();
     context.restore();
+    lastMaskPointRef.current = point;
     paintedDuringStrokeRef.current = true;
   }
 
@@ -4905,26 +5075,28 @@ export function App() {
     : effectiveOpenAIImageRoute
       ? copy.imageRouteAutoUsing(openAIImageRouteLabel(copy, effectiveOpenAIImageRoute))
       : undefined;
+  const openAIImageRouteControl = openAIParams ? (
+    <label title={imageRouteTitle}>
+      <span className="route-label">
+        <span>{copy.imageRoute}</span>
+        <span className="route-info-icon" aria-label={copy.imageRouteInfo} data-tooltip={copy.imageRouteInfo} title={copy.imageRouteInfo}>
+          <Info size={12} />
+        </span>
+      </span>
+      <select
+        value={requestMode === "inpaint" ? "image-api" : openAIParams.imageRoute}
+        disabled={requestMode === "inpaint"}
+        onChange={(event) => updateOpenAIParams({ imageRoute: event.target.value as OpenAIImageRouteSelection })}
+      >
+        <option value="auto">{copy.imageRouteAutoUsing(openAIImageRouteLabel(copy, autoOpenAIImageRoute(activeConfig, requestMode)))}</option>
+        <option value="chat-completions">{copy.imageRouteChatCompletions}</option>
+        <option value="responses">{copy.imageRouteResponses}</option>
+        <option value="image-api">{copy.imageRouteImageApi}</option>
+      </select>
+    </label>
+  ) : null;
   const parameterSummary = openAIParams ? (
     <>
-      <label title={imageRouteTitle}>
-        <span className="route-label">
-          <span>{copy.imageRoute}</span>
-          <span className="route-info-icon" aria-label={copy.imageRouteInfo} data-tooltip={copy.imageRouteInfo} title={copy.imageRouteInfo}>
-            <Info size={12} />
-          </span>
-        </span>
-        <select
-          value={requestMode === "inpaint" ? "image-api" : openAIParams.imageRoute}
-          disabled={requestMode === "inpaint"}
-          onChange={(event) => updateOpenAIParams({ imageRoute: event.target.value as OpenAIImageRouteSelection })}
-        >
-          <option value="auto">{copy.imageRouteAutoUsing(openAIImageRouteLabel(copy, autoOpenAIImageRoute(activeConfig, requestMode)))}</option>
-          <option value="chat-completions">{copy.imageRouteChatCompletions}</option>
-          <option value="responses">{copy.imageRouteResponses}</option>
-          <option value="image-api">{copy.imageRouteImageApi}</option>
-        </select>
-      </label>
       <label>
         <span>{copy.size}</span>
         <select
@@ -4962,6 +5134,7 @@ export function App() {
           ))}
         </select>
       </label>
+      {showAdvanced && openAIImageRouteControl}
     </>
   ) : geminiParams ? (
     <>
@@ -5621,7 +5794,7 @@ export function App() {
 
       <PerfProfiler id="Workspace">
       <section className="workspace">
-        <div className="preview-layout" ref={previewLayoutRef}>
+        <div className={isEditorFocusMode ? "preview-layout editor-focus-mode" : "preview-layout"} ref={previewLayoutRef}>
           <ImageEditor
             copy={copy}
             language={language}
@@ -5667,7 +5840,8 @@ export function App() {
             annotationLayerStyle={annotationLayerStyle}
             cssRectForCanvasRect={cssRectForCanvasRect}
             cssSizeForCanvasUnits={cssSizeForCanvasUnits}
-            onOpenPreview={() => setIsPreviewOpen(true)}
+            isEditorFocusMode={isEditorFocusMode}
+            onOpenPreview={toggleEditorFocusMode}
             onPreviewPanStart={handlePreviewPanStart}
             onPreviewPanMove={handlePreviewPanMove}
             onPreviewPanEnd={handlePreviewPanEnd}
@@ -5852,16 +6026,50 @@ export function App() {
                     <div className="empty-inline">{copy.dropReferencesHint}</div>
                   ) : (
                     inputAssets.map((asset, index) => (
-                      <div key={asset.id} className="asset-tile">
+                      <div
+                        key={asset.id}
+                        className={[
+                          "asset-tile",
+                          "reference-thumb-tile",
+                          index === 0 ? "primary-reference" : "",
+                          index === 0 && maskPreview ? "has-mask" : ""
+                        ].filter(Boolean).join(" ")}
+                        role="button"
+                        tabIndex={0}
+                        title={copy.referenceTileHint}
+                        data-tooltip={copy.referenceTileHint}
+                        onClick={() => handleReferenceTileClick(asset.id)}
+                        onDoubleClick={() => openReferencePreview(asset.id)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            openReferencePreview(asset.id);
+                            return;
+                          }
+                          if (event.key === " ") {
+                            event.preventDefault();
+                            promoteReferenceAssetToFirst(asset.id);
+                          }
+                        }}
+                      >
                         {assetSource(asset) && <img src={assetSource(asset)} alt={asset.name} />}
-                        <button type="button" className="tile-remove" onClick={() => removeInputAsset(asset.id)} aria-label={copy.delete} data-tooltip={copy.delete}>
+                        <button
+                          type="button"
+                          className="tile-remove"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            removeInputAsset(asset.id);
+                          }}
+                          aria-label={copy.delete}
+                          data-tooltip={copy.delete}
+                        >
                           <X size={14} />
                         </button>
-                        <div>
+                        <div className="reference-thumb-meta">
                           <strong>{index === 0 ? copy.source : `${copy.reference} ${index + 1}`}</strong>
                           <span>{asset.name}</span>
-                          <small>{formatBytes(asset.sizeBytes)}</small>
                         </div>
+                        {index === 0 && maskPreview && <span className="reference-mask-badge">{copy.mask}</span>}
                       </div>
                     ))
                   )}
@@ -5889,72 +6097,6 @@ export function App() {
               </>
             )}
 
-            {tabMode === "img2img" && !isGeneralMode && (
-              <div className="mask-editor">
-                <div className="mask-header">
-                  <div>
-                    <h3>
-                      {copy.mask} <span className="mask-optional">{copy.maskOptional}</span>
-                    </h3>
-                    <p>{maskDescription}</p>
-                  </div>
-                  <div className="brush-controls">
-                    <Eraser size={16} />
-                    <span className="range-tooltip" data-tooltip={copy.maskBrushSize}>
-                      <input
-                        type="range"
-                        min="16"
-                        max="180"
-                        value={brushSize}
-                        aria-label={copy.maskBrushSize}
-                        onChange={(event) => {
-                          markDraftChanged();
-                          setBrushSize(Number(event.target.value));
-                        }}
-                      />
-                    </span>
-                    <button
-                      type="button"
-                      className="icon-button secondary compact-mask-button"
-                      onClick={addPaintedMask}
-                      disabled={!maskDataUrl}
-                      aria-label={copy.addPaintedMask}
-                      data-tooltip={copy.addPaintedMaskTooltip}
-                    >
-                      <Paintbrush size={15} />
-                    </button>
-                    <button type="button" className="icon-button" onClick={clearPaintedMask} aria-label={copy.clearPaintedMask} data-tooltip={copy.clearPaintedMask}>
-                      <X size={15} />
-                    </button>
-                  </div>
-                </div>
-                <div className={sourcePreview ? "mask-canvas-wrap has-source" : "mask-canvas-wrap"}>
-                  {sourcePreview ? (
-                    <>
-                      <img ref={sourceImageRef} src={sourcePreview} alt={copy.sourceForMask} onLoad={handleSourceImageLoad} />
-                      <canvas
-                        ref={maskCanvasRef}
-                        onPointerDown={startPaint}
-                        onPointerMove={continuePaint}
-                        onPointerUp={finishPaint}
-                        onPointerCancel={finishPaint}
-                      />
-                    </>
-                  ) : (
-                    <div className="empty-state">
-                      <Brush size={24} />
-                      <span>{copy.addSourceForMask}</span>
-                    </div>
-                  )}
-                </div>
-                {maskPreview && (
-                  <div className="mask-status">
-                    {maskCheck?.ok ? <CheckCircle2 size={15} /> : <AlertTriangle size={15} />}
-                    <span>{maskCheck?.message ?? copy.checkingMask}</span>
-                  </div>
-                )}
-              </div>
-            )}
           </section>
         </div>
       </section>
@@ -6161,11 +6303,11 @@ export function App() {
             onClick={() => setIsRightRailActionDrawerOpen((current) => !current)}
             onMouseMove={movePreviewToolbarTowardPointer}
             onMouseLeave={resetPreviewToolbarDrift}
-            aria-label={copy.parameters}
-            data-tooltip={copy.parameters}
+            aria-label={copy.moreActions}
+            data-tooltip={copy.moreActions}
             aria-expanded={isRightRailActionDrawerOpen}
           >
-            <SlidersHorizontal size={15} />
+            <MoreHorizontal size={15} />
           </button>
           <div className="right-rail-action-group" data-drift="subtle" onMouseMove={movePreviewToolbarTowardPointer} onMouseLeave={resetPreviewToolbarDrift}>
             <button
@@ -6496,18 +6638,104 @@ export function App() {
             </div>
         </DialogShell>
       )}
-      {isPreviewOpen && activePreviewSource && (
-        <DialogShell className="preview-modal-dialog" backdropClassName="preview-modal-backdrop" labelledBy="preview-modal-title" onClose={() => setIsPreviewOpen(false)}>
-          <h2 id="preview-modal-title" className="visually-hidden">{copy.resultViewer}</h2>
-          <button type="button" className="preview-modal-close icon-button tooltip-below" onClick={() => setIsPreviewOpen(false)} aria-label={copy.cancel} data-tooltip={copy.cancel}>
+      {referencePreviewAsset && referencePreviewSource && (
+        <DialogShell className="preview-modal-dialog reference-preview-dialog" backdropClassName="preview-modal-backdrop" labelledBy="reference-preview-modal-title" onClose={closeReferencePreview}>
+          <h2 id="reference-preview-modal-title" className="visually-hidden">{referencePreviewAsset.name}</h2>
+          <button type="button" className="preview-modal-close icon-button tooltip-below" onClick={closeReferencePreview} aria-label={copy.cancel} data-tooltip={copy.cancel}>
             <X size={18} />
           </button>
-          <img
-            src={activePreviewSource}
-            alt={copy.generatedResult}
-            className="preview-modal-image"
-            onContextMenu={(e) => handleImageContextMenu(e, activeImage, activeJob?.prompt ?? '')}
-          />
+          <div
+            className="preview-control-strip reference-preview-tools"
+            onMouseMove={movePreviewToolbarTowardPointer}
+            onMouseLeave={resetPreviewToolbarDrift}
+          >
+            <div className="preview-primary-actions" aria-label={copy.referenceMaskTools}>
+              <button
+                type="button"
+                className={isReferenceMaskToolsOpen ? "icon-button active" : "icon-button"}
+                disabled={isGeneralMode}
+                onClick={() => requestReferenceMaskEditor(referencePreviewAsset)}
+                aria-label={copy.addReferenceMask}
+                data-tooltip={copy.addReferenceMask}
+                aria-pressed={isReferenceMaskToolsOpen}
+              >
+                <Paintbrush size={16} />
+              </button>
+            </div>
+            {isReferenceMaskToolsOpen && sourcePreview && (
+              <div className="preview-secondary-actions reference-mask-tools" data-drift="subtle">
+                <Eraser size={15} />
+                <span className="range-tooltip" data-tooltip={copy.maskBrushSize}>
+                  <input
+                    type="range"
+                    min="16"
+                    max="180"
+                    value={brushSize}
+                    aria-label={copy.maskBrushSize}
+                    onChange={(event) => {
+                      markDraftChanged();
+                      setBrushSize(Number(event.target.value));
+                    }}
+                  />
+                </span>
+                <button
+                  type="button"
+                  className="icon-button secondary compact-mask-button"
+                  onClick={addPaintedMask}
+                  disabled={!maskDataUrl}
+                  aria-label={copy.addPaintedMask}
+                  data-tooltip={copy.addPaintedMaskTooltip}
+                >
+                  <Paintbrush size={15} />
+                </button>
+                <button type="button" className="icon-button" onClick={clearPaintedMask} aria-label={copy.clearPaintedMask} data-tooltip={copy.clearPaintedMask}>
+                  <X size={15} />
+                </button>
+              </div>
+            )}
+          </div>
+          <div className={isReferenceMaskToolsOpen && sourcePreview ? "reference-preview-stage masking" : "reference-preview-stage"}>
+            <div className="reference-preview-canvas-wrap">
+              <img
+                ref={sourceImageRef}
+                src={referencePreviewSource}
+                alt={referencePreviewAsset.name}
+                className="preview-modal-image"
+                onLoad={handleSourceImageLoad}
+              />
+              {isReferenceMaskToolsOpen && sourcePreview && (
+                <canvas
+                  ref={maskCanvasRef}
+                  className="reference-preview-mask-canvas"
+                  aria-label={maskDescription}
+                  onPointerDown={startPaint}
+                  onPointerMove={continuePaint}
+                  onPointerUp={finishPaint}
+                  onPointerCancel={finishPaint}
+                />
+              )}
+            </div>
+            {isReferenceMaskToolsOpen && maskPreview && (
+              <div className="mask-status reference-preview-mask-status">
+                {maskCheck?.ok ? <CheckCircle2 size={15} /> : <AlertTriangle size={15} />}
+                <span>{maskCheck?.message ?? copy.checkingMask}</span>
+              </div>
+            )}
+          </div>
+          {referenceMaskConfirmAsset && (
+            <div className="reference-mask-confirm" role="alertdialog" aria-labelledby="reference-mask-confirm-title" aria-modal="true">
+              <h3 id="reference-mask-confirm-title">{copy.referenceMaskConfirmTitle}</h3>
+              <p>{copy.referenceMaskConfirmBody(referenceMaskConfirmAsset.name)}</p>
+              <div className="dialog-actions">
+                <button type="button" className="secondary" onClick={() => setReferenceMaskConfirmAssetId(null)}>
+                  {copy.cancel}
+                </button>
+                <button type="button" onClick={() => confirmReferenceMaskEditor(referenceMaskConfirmAsset.id)}>
+                  {copy.referenceMaskConfirmAction}
+                </button>
+              </div>
+            </div>
+          )}
         </DialogShell>
       )}
       {contextMenu && (

--- a/src/renderer/HistoryPanel.tsx
+++ b/src/renderer/HistoryPanel.tsx
@@ -64,6 +64,7 @@ interface HistoryItemCardProps {
   resultSrc?: string;
   jobError: string | null;
   active: boolean;
+  hoverOpen: boolean;
   selected: boolean;
   batchMode: boolean;
   displayName: string;
@@ -86,6 +87,7 @@ interface HistoryItemCardProps {
   copyButtonLabel: string;
   downloadButtonLabel: string;
   onToggleSelection: (checked: boolean) => void;
+  onHoverOpen: () => void;
   onOpen: () => void;
   onImageContextMenu: (event: React.MouseEvent<HTMLElement>) => void;
   onStartEditName: () => void;
@@ -279,6 +281,7 @@ export function HistoryItemCard({
   resultSrc,
   jobError,
   active,
+  hoverOpen,
   selected,
   batchMode,
   displayName,
@@ -301,6 +304,7 @@ export function HistoryItemCard({
   copyButtonLabel,
   downloadButtonLabel,
   onToggleSelection,
+  onHoverOpen,
   onOpen,
   onImageContextMenu,
   onStartEditName,
@@ -320,8 +324,18 @@ export function HistoryItemCard({
   onToggleGalleryMenu,
   onDelete
 }: HistoryItemCardProps) {
+  const sourceLabel = job.source === "cli" ? copy.historySourceCli : job.source === "mcp" ? copy.historySourceMcp : null;
   return (
-    <article className={`${active ? "history-item active" : "history-item"} ${selected ? "selected" : ""}`}>
+    <article
+      className={[
+        "history-item",
+        active ? "active" : "",
+        hoverOpen ? "hover-open" : "",
+        selected ? "selected" : ""
+      ].filter(Boolean).join(" ")}
+      onMouseEnter={onHoverOpen}
+      onFocus={onHoverOpen}
+    >
       {batchMode && (
         <input
           className="history-entry-select"
@@ -384,6 +398,7 @@ export function HistoryItemCard({
           </div>
           <div className="history-chip-row history-tag-row" aria-label={copy.historyEditTags}>
             <span className="history-chip system-tag" title={copy.historySystemTag}>{systemTag}</span>
+            {sourceLabel && <span className="history-chip source-tag" title={copy.historySourceTag}>{sourceLabel}</span>}
             {job.tags.map((tag) => (
               <span key={tag} className="history-chip">{tag}</span>
             ))}

--- a/src/renderer/ImageEditor.tsx
+++ b/src/renderer/ImageEditor.tsx
@@ -7,9 +7,11 @@ import {
   Circle,
   Crop,
   Download,
+  Expand,
   FolderInput,
   Loader2,
   Maximize2,
+  Minimize2,
   Pencil,
   Pipette,
   RectangleHorizontal,
@@ -53,6 +55,7 @@ interface ImageEditorProps {
   previewZoomPercent: number;
   isPanning: boolean;
   isPreviewCanvasInteractive: boolean;
+  isEditorFocusMode: boolean;
   hasEditorOverlay: boolean;
   isEditingPreview: boolean;
   isCroppingPreview: boolean;
@@ -138,6 +141,7 @@ export function ImageEditor({
   previewZoomPercent,
   isPanning,
   isPreviewCanvasInteractive,
+  isEditorFocusMode,
   hasEditorOverlay,
   isEditingPreview,
   isCroppingPreview,
@@ -509,6 +513,16 @@ export function ImageEditor({
               </button>
               <button type="button" className="icon-button" disabled={previewZoom === 1 && previewPan.x === 0 && previewPan.y === 0} onClick={onResetPreviewView} aria-label={copy.resetZoom} data-tooltip={copy.resetZoom}>
                 <Maximize2 size={16} />
+              </button>
+              <button
+                type="button"
+                className={isEditorFocusMode ? "icon-button active" : "icon-button"}
+                onClick={onOpenPreview}
+                aria-label={isEditorFocusMode ? copy.exitFocusView : copy.enterFocusView}
+                data-tooltip={isEditorFocusMode ? copy.exitFocusView : copy.enterFocusView}
+                aria-pressed={isEditorFocusMode}
+              >
+                {isEditorFocusMode ? <Minimize2 size={16} /> : <Expand size={16} />}
               </button>
             </div>
           </>

--- a/src/renderer/ParameterConfigPanel.tsx
+++ b/src/renderer/ParameterConfigPanel.tsx
@@ -1,40 +1,68 @@
 import type React from "react";
-import { ChevronDown, ChevronUp, SlidersHorizontal } from "lucide-react";
+import { SlidersHorizontal, Wrench, X } from "lucide-react";
+import { DialogShell } from "./DialogShell";
 import type { UiCopy } from "./i18n";
 
-interface ParameterSectionProps {
+interface ParameterConfigLauncherProps {
   copy: UiCopy;
-  expanded: boolean;
-  summary: React.ReactNode;
-  controls: React.ReactNode;
-  onToggle: () => void;
+  quickControls: React.ReactNode;
+  onOpen: () => void;
 }
 
-export function ParameterSection({
-  copy,
-  expanded,
-  summary,
-  controls,
-  onToggle
-}: ParameterSectionProps) {
-  return (
-    <section className="tool-section">
-      <button type="button" className="section-toggle" onClick={onToggle}>
-        <span className="section-toggle-label">
-          <SlidersHorizontal size={16} />
-          <span>{copy.parameters}</span>
-        </span>
-        <span className="section-toggle-state">
-          {expanded ? copy.hide : copy.show}
-          {expanded ? <ChevronUp size={15} /> : <ChevronDown size={15} />}
-        </span>
-      </button>
+interface ParameterConfigDialogProps {
+  copy: UiCopy;
+  primaryControls: React.ReactNode;
+  controls: React.ReactNode;
+  onClose: () => void;
+}
 
-      <div className="compact-grid">
-        {summary}
+export function ParameterConfigLauncher({
+  copy,
+  quickControls,
+  onOpen
+}: ParameterConfigLauncherProps) {
+  return (
+    <section className="parameter-config-bar" aria-label={copy.parameters}>
+      <div className="parameter-config-heading">
+        <span className="section-title-label">
+          <SlidersHorizontal size={16} />
+          <strong>{copy.parameters}</strong>
+        </span>
+        <button type="button" className="icon-button secondary parameter-config-trigger" onClick={onOpen} aria-label={copy.detailedConfig} data-tooltip={copy.detailedConfig}>
+          <Wrench size={15} />
+        </button>
       </div>
 
-      {expanded && controls}
+      <div className="parameter-summary-strip" aria-label={copy.parameters}>
+        {quickControls}
+      </div>
     </section>
+  );
+}
+
+export function ParameterConfigDialog({
+  copy,
+  primaryControls,
+  controls,
+  onClose
+}: ParameterConfigDialogProps) {
+  return (
+    <DialogShell className="parameter-dialog" labelledBy="parameter-dialog-title" onClose={onClose}>
+      <header className="history-header parameter-dialog-header">
+        <div>
+          <h2 id="parameter-dialog-title">{copy.parameters}</h2>
+        </div>
+        <button type="button" className="icon-button" onClick={onClose} aria-label={copy.cancel} data-tooltip={copy.cancel}>
+          <X size={16} />
+        </button>
+      </header>
+
+      <div className="parameter-dialog-body">
+        <div className="compact-grid parameter-dialog-primary">
+          {primaryControls}
+        </div>
+        {controls}
+      </div>
+    </DialogShell>
   );
 }

--- a/src/renderer/ProviderConfigPanel.tsx
+++ b/src/renderer/ProviderConfigPanel.tsx
@@ -24,10 +24,7 @@ interface LaunchModelOption {
 
 interface ProviderSummarySectionProps {
   copy: UiCopy;
-  activeConfig: ProviderConfig;
   displayName: string;
-  providerLabel: string;
-  baseUrlSummary: string;
   discoveryText: string;
   connectionStatus: ConnectionStatus;
   connectionLabel: string;
@@ -40,11 +37,9 @@ interface LaunchSectionProps {
   copy: UiCopy;
   activeConfig: ProviderConfig;
   activeProviderKind: ProviderKind;
-  activeLaunchDisplay: string;
   launchButtons: LaunchButtonState[];
   openLaunchMenuId: FocusedLaunchId | null;
   saving: boolean;
-  providerLabelForKind: (kind: ProviderKind) => string;
   modelOptionsForLaunch: (config: ProviderConfig, launchId: FocusedLaunchId) => LaunchModelOption[];
   onToggleLaunchMenu: (launchId: FocusedLaunchId, open: boolean) => void;
   onLaunch: (button: LaunchButtonState) => void;
@@ -61,31 +56,35 @@ interface ApiConfigCardProps {
   canDelete: boolean;
   saving: boolean;
   bridgeAvailable: boolean;
-  discovering: boolean;
-  discoveringAny: boolean;
   tooltip: string;
   displayName: string;
-  providerLabel: string;
   baseUrlSummary: string;
   connectionBadge: React.ReactNode;
-  keyLabel: string;
   modelSummary: string;
   modelSummaryKind: "error" | "info";
   onUse: () => void;
   onSelect: () => void;
   onDelete: () => void;
-  onDiscover: () => void;
+}
+
+interface ApiConfigDraftCardProps {
+  copy: UiCopy;
+  name: string;
+  baseURL: string;
+  saving: boolean;
+  namePlaceholder: string;
+  baseUrlSummary: string;
+  onSelect: () => void;
+  onCancel: () => void;
 }
 
 export function LaunchSection({
   copy,
   activeConfig,
   activeProviderKind,
-  activeLaunchDisplay,
   launchButtons,
   openLaunchMenuId,
   saving,
-  providerLabelForKind,
   modelOptionsForLaunch,
   onToggleLaunchMenu,
   onLaunch,
@@ -98,7 +97,6 @@ export function LaunchSection({
           <Rocket size={16} />
           <h2>{copy.launchModels}</h2>
         </div>
-        <strong>{activeLaunchDisplay}</strong>
       </div>
       <div className="launch-strip" aria-label={copy.launchModels}>
         {launchButtons.map((button) => {
@@ -126,7 +124,7 @@ export function LaunchSection({
                   <span>{button.displayName}</span>
                   {hasModelMenu && (openLaunchMenuId === button.launchId ? <ChevronUp size={15} /> : <ChevronDown size={15} />)}
                 </span>
-                <small>{button.available ? activeModelOption?.displayName ?? (button.modelId || copy.generalFallback) : button.reason}</small>
+                <small className="launch-model-detail">{button.available ? activeModelOption?.displayName ?? (button.modelId || copy.generalFallback) : button.reason}</small>
               </button>
               {hasModelMenu && openLaunchMenuId === button.launchId && (
                 <div className="launch-model-menu" role="listbox" aria-label={`${button.displayName} ${copy.model}`}>
@@ -144,7 +142,6 @@ export function LaunchSection({
                         title={model.id}
                       >
                         <span>{model.displayName}</span>
-                        <small>{providerLabelForKind(model.providerKind)}</small>
                       </button>
                     );
                   })}
@@ -160,10 +157,7 @@ export function LaunchSection({
 
 export function ProviderSummarySection({
   copy,
-  activeConfig,
   displayName,
-  providerLabel,
-  baseUrlSummary,
   discoveryText,
   connectionStatus,
   connectionLabel,
@@ -193,14 +187,13 @@ export function ProviderSummarySection({
       </div>
 
       <button type="button" className="api-access-current" onClick={onOpen}>
-        <span>
+        <span className="api-access-current-main">
           <strong>{displayName}</strong>
-          <small>{providerLabel} · {baseUrlSummary}</small>
-          <small>
-            {activeConfig.apiKeySaved ? copy.keySaved : copy.noKeySaved} · {discoveryText}
-          </small>
+          <small className="api-access-hover-detail">{discoveryText}</small>
         </span>
-        <Wrench size={16} />
+        <span className="api-access-config-icon">
+          <Wrench size={16} />
+        </span>
       </button>
     </section>
   );
@@ -217,6 +210,7 @@ interface ApiConfigDetailProps {
   discoveringAny: boolean;
   canDelete: boolean;
   connectionErrorText: string | null;
+  kind: ProviderKind;
   name: string;
   apiKey: string;
   baseURL: string;
@@ -227,6 +221,8 @@ interface ApiConfigDetailProps {
   modelSummaryKind: "error" | "info";
   modelTooltip: string;
   modelLabel: (model: DiscoveredProviderModel) => string;
+  providerLabelForKind: (kind: ProviderKind) => string;
+  onKindChange: (kind: ProviderKind) => void;
   onNameChange: (value: string) => void;
   onApiKeyChange: (value: string) => void;
   onBaseURLChange: (value: string) => void;
@@ -235,16 +231,14 @@ interface ApiConfigDetailProps {
   onDelete: () => void;
 }
 
-interface AddApiConfigFormProps {
+interface AddApiConfigDetailProps {
   copy: UiCopy;
-  open: boolean;
   saving: boolean;
   kind: ProviderKind;
   name: string;
   baseURL: string;
   apiKey: string;
   namePlaceholder: string;
-  onToggle: () => void;
   onKindChange: (kind: ProviderKind) => void;
   onNameChange: (value: string) => void;
   onBaseURLChange: (value: string) => void;
@@ -267,6 +261,7 @@ interface ApiConfigDialogProps {
   discoveringProviderId: string | null;
   discoveringAny: boolean;
   connectionErrorText: string | null;
+  kind: ProviderKind;
   name: string;
   apiKey: string;
   baseURL: string;
@@ -283,6 +278,7 @@ interface ApiConfigDialogProps {
   displayNameForConfig: (config: ProviderConfig) => string;
   providerLabelForKind: (kind: ProviderKind) => string;
   baseUrlSummaryForConfig: (config: ProviderConfig) => string;
+  baseUrlSummaryForValue: (baseURL: string) => string;
   discoverySummaryForConfig: (config: ProviderConfig) => string;
   discoveryTooltipForConfig: (config: ProviderConfig) => string;
   modelLabel: (model: DiscoveredProviderModel) => string;
@@ -299,6 +295,7 @@ interface ApiConfigDialogProps {
   onNewApiAccessKeyChange: (value: string) => void;
   onAddApiAccess: () => void;
   onCancelAddApiAccess: () => void;
+  onKindChange: (kind: ProviderKind) => void;
   onNameChange: (value: string) => void;
   onApiKeyChange: (value: string) => void;
   onBaseURLChange: (value: string) => void;
@@ -319,6 +316,7 @@ export function ApiConfigDialog({
   discoveringProviderId,
   discoveringAny,
   connectionErrorText,
+  kind,
   name,
   apiKey,
   baseURL,
@@ -335,6 +333,7 @@ export function ApiConfigDialog({
   displayNameForConfig,
   providerLabelForKind,
   baseUrlSummaryForConfig,
+  baseUrlSummaryForValue,
   discoverySummaryForConfig,
   discoveryTooltipForConfig,
   modelLabel,
@@ -351,6 +350,7 @@ export function ApiConfigDialog({
   onNewApiAccessKeyChange,
   onAddApiAccess,
   onCancelAddApiAccess,
+  onKindChange,
   onNameChange,
   onApiKeyChange,
   onBaseURLChange,
@@ -362,26 +362,27 @@ export function ApiConfigDialog({
       copy={copy}
       config={config}
       active={active}
-      selected={config.id === selectedConfig.id}
+      selected={!addFormOpen && config.id === selectedConfig.id}
       promoted={promotedApiConfigId === config.id}
       canUse={!active}
       canDelete={active ? canDeleteActiveApiAccess : canDeleteSelectedApiAccess}
       saving={saving}
       bridgeAvailable={bridgeAvailable}
-      discovering={discoveringProviderId === config.id}
-      discoveringAny={discoveringAny}
       tooltip={discoveryTooltipForConfig(config)}
       displayName={displayNameForConfig(config)}
-      providerLabel={providerLabelForKind(config.kind)}
       baseUrlSummary={baseUrlSummaryForConfig(config)}
       connectionBadge={connectionBadgeForConfig(config)}
-      keyLabel={config.apiKeySaved ? config.apiKeyPreview ?? copy.keySaved : copy.noKeySaved}
       modelSummary={discoverySummaryForConfig(config)}
       modelSummaryKind={config.lastModelDiscoveryError ? "error" : "info"}
-      onUse={() => onUseConfig(config)}
-      onSelect={() => onSelectConfig(config)}
+      onUse={() => {
+        onCancelAddApiAccess();
+        onUseConfig(config);
+      }}
+      onSelect={() => {
+        onCancelAddApiAccess();
+        onSelectConfig(config);
+      }}
       onDelete={() => onDeleteConfig(config)}
-      onDiscover={() => onDiscoverConfig(config)}
     />
   );
 
@@ -405,17 +406,34 @@ export function ApiConfigDialog({
             {renderCard(activeConfig, true)}
             <div className="api-config-card-list" aria-label={copy.apiAccessList}>
               {inactiveConfigs.map((config) => renderCard(config, false))}
+              {addFormOpen && (
+                <ApiConfigDraftCard
+                  copy={copy}
+                  name={newApiAccessName}
+                  baseURL={newApiAccessBaseURL}
+                  saving={saving}
+                  namePlaceholder={providerLabelForKind(newApiAccessKind)}
+                  baseUrlSummary={baseUrlSummaryForValue(newApiAccessBaseURL)}
+                  onSelect={() => undefined}
+                  onCancel={onCancelAddApiAccess}
+                />
+              )}
             </div>
-            <AddApiConfigForm
+            <button type="button" className={addFormOpen ? "secondary api-config-add-button active" : "secondary api-config-add-button"} onClick={onToggleAddForm}>
+              {addFormOpen ? <X size={16} /> : <Plus size={16} />}
+              {addFormOpen ? copy.cancel : copy.addApiAccess}
+            </button>
+          </aside>
+
+          {addFormOpen ? (
+            <AddApiConfigDetail
               copy={copy}
-              open={addFormOpen}
               saving={saving}
               kind={newApiAccessKind}
               name={newApiAccessName}
               baseURL={newApiAccessBaseURL}
               apiKey={newApiAccessKey}
               namePlaceholder={providerLabelForKind(newApiAccessKind)}
-              onToggle={onToggleAddForm}
               onKindChange={onNewApiAccessKindChange}
               onNameChange={onNewApiAccessNameChange}
               onBaseURLChange={onNewApiAccessBaseURLChange}
@@ -423,99 +441,164 @@ export function ApiConfigDialog({
               onAdd={onAddApiAccess}
               onCancel={onCancelAddApiAccess}
             />
-          </aside>
-
-          <ApiConfigDetail
-            copy={copy}
-            selectedConfig={selectedConfig}
-            active={selectedConfig.id === activeConfig.id}
-            bridgeAvailable={bridgeAvailable}
-            saving={saving}
-            saved={selectedConfigSaved}
-            discovering={discoveringProviderId === selectedConfig.id}
-            discoveringAny={discoveringAny}
-            canDelete={canDeleteSelectedApiAccess}
-            connectionErrorText={connectionErrorText}
-            name={name}
-            apiKey={apiKey}
-            baseURL={baseURL}
-            namePlaceholder={providerLabelForKind(selectedConfig.kind)}
-            apiKeyPlaceholder={apiKeyPlaceholder}
-            discoveryTooltip={selectedDiscoveryText}
-            modelSummary={selectedModelSummary}
-            modelSummaryKind={selectedModelSummaryKind}
-            modelTooltip={discoveryTooltipForConfig(selectedConfig)}
-            modelLabel={modelLabel}
-            onNameChange={onNameChange}
-            onApiKeyChange={onApiKeyChange}
-            onBaseURLChange={onBaseURLChange}
-            onSubmit={onSubmit}
-            onDiscover={() => onDiscoverConfig(selectedConfig)}
-            onDelete={() => onDeleteConfig(selectedConfig)}
-          />
+          ) : (
+            <ApiConfigDetail
+              copy={copy}
+              selectedConfig={selectedConfig}
+              active={selectedConfig.id === activeConfig.id}
+              bridgeAvailable={bridgeAvailable}
+              saving={saving}
+              saved={selectedConfigSaved}
+              discovering={discoveringProviderId === selectedConfig.id}
+              discoveringAny={discoveringAny}
+              canDelete={canDeleteSelectedApiAccess}
+              connectionErrorText={connectionErrorText}
+              kind={kind}
+              name={name}
+              apiKey={apiKey}
+              baseURL={baseURL}
+              namePlaceholder={providerLabelForKind(kind)}
+              apiKeyPlaceholder={apiKeyPlaceholder}
+              discoveryTooltip={selectedDiscoveryText}
+              modelSummary={selectedModelSummary}
+              modelSummaryKind={selectedModelSummaryKind}
+              modelTooltip={discoveryTooltipForConfig(selectedConfig)}
+              modelLabel={modelLabel}
+              providerLabelForKind={providerLabelForKind}
+              onKindChange={onKindChange}
+              onNameChange={onNameChange}
+              onApiKeyChange={onApiKeyChange}
+              onBaseURLChange={onBaseURLChange}
+              onSubmit={onSubmit}
+              onDiscover={() => onDiscoverConfig(selectedConfig)}
+              onDelete={() => onDeleteConfig(selectedConfig)}
+            />
+          )}
         </div>
     </DialogShell>
   );
 }
 
-export function AddApiConfigForm({
+export function ApiConfigDraftCard({
   copy,
-  open,
+  name,
+  baseURL,
+  saving,
+  namePlaceholder,
+  baseUrlSummary,
+  onSelect,
+  onCancel
+}: ApiConfigDraftCardProps) {
+  const displayName = name.trim() || namePlaceholder || copy.apiAccessUntitled;
+  return (
+    <article className="api-config-card api-config-draft-card selected" title={copy.apiAccessDraftStatus}>
+      <button
+        type="button"
+        className="api-config-card-main"
+        onClick={onSelect}
+        aria-current="true"
+        title={copy.apiAccessDraftStatus}
+      >
+        <span className="api-config-card-title-row">
+          <span className="api-config-card-title">{displayName}</span>
+          <span className="connection-badge api-config-card-connection" data-status="checking" title={copy.apiAccessDraftStatus}>
+            <span className="connection-dot" />
+            {copy.apiAccessDraftStatus}
+          </span>
+        </span>
+        <span className="api-config-card-meta-row">
+          <span className="api-config-card-meta api-config-card-meta-url" title={baseURL}>{baseUrlSummary}</span>
+          <span className="api-config-card-models" data-kind="info">
+            {copy.apiAccessNoModels}
+          </span>
+        </span>
+      </button>
+      <div className="api-config-card-actions">
+        <button
+          type="button"
+          className="icon-button ghost"
+          onClick={onCancel}
+          disabled={saving}
+          aria-label={copy.cancel}
+          data-tooltip={copy.cancel}
+        >
+          <X size={15} />
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export function AddApiConfigDetail({
+  copy,
   saving,
   kind,
   name,
   baseURL,
   apiKey,
   namePlaceholder,
-  onToggle,
   onKindChange,
   onNameChange,
   onBaseURLChange,
   onApiKeyChange,
   onAdd,
   onCancel
-}: AddApiConfigFormProps) {
+}: AddApiConfigDetailProps) {
   return (
-    <>
-      <button type="button" className="secondary" onClick={onToggle}>
-        <Plus size={16} />
-        {copy.addApiAccess}
-      </button>
-      {open && (
-        <div className="api-access-add-form">
-          <label>
-            {copy.apiAccessKind}
-            <select value={kind} onChange={(event) => onKindChange(event.target.value as ProviderKind)}>
-              <option value="openai">OpenAI</option>
-              <option value="gemini">Gemini</option>
-              <option value="custom">Custom</option>
-            </select>
-          </label>
-          <label>
-            {copy.apiAccessName}
-            <input value={name} onChange={(event) => onNameChange(event.target.value)} placeholder={namePlaceholder} />
-          </label>
-          <label>
-            {copy.baseURL}
-            <input value={baseURL} onChange={(event) => onBaseURLChange(event.target.value)} />
-          </label>
-          <label>
-            {copy.apiKey}
-            <input type="text" autoComplete="off" value={apiKey} onChange={(event) => onApiKeyChange(event.target.value)} placeholder={copy.pasteApiKey} />
-          </label>
-          <div className="button-row">
-            <button type="button" onClick={onAdd} disabled={saving}>
-              {saving ? <Loader2 className="spin" size={16} /> : <Plus size={16} />}
-              {saving ? copy.addingApiAccess : copy.addApiAccess}
-            </button>
-            <button type="button" className="ghost" onClick={onCancel}>
-              <X size={16} />
-              {copy.cancel}
-            </button>
-          </div>
+    <form
+      className="api-config-detail api-config-add-detail api-access-add-form"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onAdd();
+      }}
+    >
+      <div className="api-config-detail-header">
+        <div className="section-title">
+          <Plus size={16} />
+          <h3>{copy.apiAccessDraftDetail}</h3>
         </div>
-      )}
-    </>
+        <span className="provider-chip-inline">{copy.apiAccessDraftStatus}</span>
+      </div>
+      <label>
+        {copy.apiAccessKind}
+        <select value={kind} onChange={(event) => onKindChange(event.target.value as ProviderKind)}>
+          <option value="openai">OpenAI</option>
+          <option value="gemini">Gemini</option>
+          <option value="custom">Custom</option>
+        </select>
+      </label>
+      <label>
+        {copy.apiAccessName}
+        <input value={name} onChange={(event) => onNameChange(event.target.value)} placeholder={namePlaceholder} />
+      </label>
+      <label>
+        {copy.apiKey}
+        <input type="text" autoComplete="off" value={apiKey} onChange={(event) => onApiKeyChange(event.target.value)} placeholder={copy.pasteApiKey} />
+      </label>
+      <label>
+        {copy.baseURL}
+        <input value={baseURL} onChange={(event) => onBaseURLChange(event.target.value)} />
+      </label>
+      <div className="button-row">
+        <button type="submit" disabled={saving}>
+          {saving ? <Loader2 className="spin" size={16} /> : <Plus size={16} />}
+          {saving ? copy.addingApiAccess : copy.addApiAccess}
+        </button>
+        <button type="button" className="ghost" onClick={onCancel}>
+          <X size={16} />
+          {copy.cancel}
+        </button>
+      </div>
+      <section className="api-model-section" aria-label={copy.apiAccessModels}>
+        <div className="section-title">
+          <LibraryBig size={16} />
+          <h3>{copy.apiAccessModels}</h3>
+        </div>
+        <p className="api-model-summary" data-kind="info">
+          {copy.apiAccessNoModels}
+        </p>
+      </section>
+    </form>
   );
 }
 
@@ -530,6 +613,7 @@ export function ApiConfigDetail({
   discoveringAny,
   canDelete,
   connectionErrorText,
+  kind,
   name,
   apiKey,
   baseURL,
@@ -540,6 +624,8 @@ export function ApiConfigDetail({
   modelSummaryKind,
   modelTooltip,
   modelLabel,
+  providerLabelForKind,
+  onKindChange,
   onNameChange,
   onApiKeyChange,
   onBaseURLChange,
@@ -569,6 +655,14 @@ export function ApiConfigDetail({
           onChange={(event) => onNameChange(event.target.value)}
           placeholder={namePlaceholder}
         />
+      </label>
+      <label>
+        {copy.apiAccessKind}
+        <select value={kind} onChange={(event) => onKindChange(event.target.value as ProviderKind)}>
+          <option value="openai">{providerLabelForKind("openai")}</option>
+          <option value="gemini">{providerLabelForKind("gemini")}</option>
+          <option value="custom">{providerLabelForKind("custom")}</option>
+        </select>
       </label>
       <label>
         {copy.apiKey}
@@ -647,20 +741,15 @@ export function ApiConfigCard({
   canDelete,
   saving,
   bridgeAvailable,
-  discovering,
-  discoveringAny,
   tooltip,
   displayName,
-  providerLabel,
   baseUrlSummary,
   connectionBadge,
-  keyLabel,
   modelSummary,
   modelSummaryKind,
   onUse,
   onSelect,
-  onDelete,
-  onDiscover
+  onDelete
 }: ApiConfigCardProps) {
   return (
     <article
@@ -670,39 +759,22 @@ export function ApiConfigCard({
         selected ? "selected" : "",
         promoted ? "promoted" : ""
       ].filter(Boolean).join(" ")}
-      title={tooltip}
+      title={copy.apiAccessEditCardTooltip}
     >
-      <button
-        type="button"
-        className="icon-button api-config-use-button"
-        onClick={active ? undefined : onUse}
-        disabled={active || !canUse || !bridgeAvailable || saving}
-        aria-label={active ? copy.currentApiAccess : copy.apiAccessUseNow}
-        data-tooltip={active ? copy.currentApiAccess : copy.apiAccessUseNow}
-      >
-        <ChevronUp size={15} />
-      </button>
       <button
         type="button"
         className="api-config-card-main"
         onClick={onSelect}
         aria-current={selected ? "true" : undefined}
-        title={tooltip}
+        title={copy.apiAccessEditCardTooltip}
       >
         <span className="api-config-card-title-row">
           <span className="api-config-card-title">{displayName}</span>
           {connectionBadge}
         </span>
         <span className="api-config-card-meta-row">
-          <span className="api-config-card-meta">{providerLabel}</span>
           <span className="api-config-card-meta api-config-card-meta-url">{baseUrlSummary}</span>
-        </span>
-        <span className="api-config-card-meta-row">
-          <span className="api-config-card-key">
-            <span className={config.apiKeySaved ? "dot ok" : "dot"} />
-            {keyLabel}
-          </span>
-          <span className="api-config-card-models" data-kind={modelSummaryKind}>
+          <span className="api-config-card-models" data-kind={modelSummaryKind} title={tooltip}>
             {modelSummary}
           </span>
         </span>
@@ -720,13 +792,13 @@ export function ApiConfigCard({
         </button>
         <button
           type="button"
-          className="icon-button"
-          onClick={onDiscover}
-          disabled={!bridgeAvailable || discoveringAny || !config.apiKeySaved}
-          aria-label={copy.discoverModels}
-          data-tooltip={copy.discoverModels}
+          className="icon-button api-config-enable-button"
+          onClick={onUse}
+          disabled={active || !canUse || !bridgeAvailable || saving}
+          aria-label={active ? copy.currentApiAccess : copy.apiAccessUseNow}
+          data-tooltip={active ? copy.currentApiAccess : copy.apiAccessUseNow}
         >
-          {discovering ? <Loader2 className="spin" size={15} /> : <Radar size={15} />}
+          <CheckCircle2 size={15} />
         </button>
       </div>
     </article>

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -90,7 +90,12 @@ export interface UiCopy {
   apiAccessDialogSummary: (count: number) => string;
   apiAccessEditHint: string;
   apiAccessUseNow: string;
+  apiAccessEditCardTooltip: string;
   apiAccessSelectedDetail: string;
+  apiAccessDraftDetail: string;
+  apiAccessDraftStatus: string;
+  apiAccessTestedStatus: string;
+  apiAccessDiscoveredStatus: string;
   apiAccessModels: string;
   apiAccessNoModels: string;
   apiAccessSaved: string;
@@ -143,6 +148,7 @@ export interface UiCopy {
   keySaved: string;
   noKeySaved: string;
   parameters: string;
+  detailedConfig: string;
   moreActions: string;
   imageRoute: string;
   imageRouteAuto: string;
@@ -330,6 +336,7 @@ export interface UiCopy {
   mask: string;
   maskDescription: string;
   guidedRegionDescription: string;
+  exactMaskRouteNotice: string;
   maskBrushSize: string;
   clearPaintedMask: string;
   sourceForMask: string;
@@ -373,6 +380,9 @@ export interface UiCopy {
   historySaveName: string;
   historySaveTags: string;
   historySystemTag: string;
+  historySourceTag: string;
+  historySourceCli: string;
+  historySourceMcp: string;
   historyImageName: string;
   historyDuration: (duration: string) => string;
   historyPageSizeMenu: string;
@@ -473,7 +483,12 @@ export const translations: Record<Language, UiCopy> = {
     apiAccessDialogSummary: (count: number) => `${count} saved config${count === 1 ? "" : "s"} · Click a card to edit it.`,
     apiAccessEditHint: "Click a card to edit it on the right.",
     apiAccessUseNow: "Use this config now",
+    apiAccessEditCardTooltip: "Click to edit config",
     apiAccessSelectedDetail: "Config details",
+    apiAccessDraftDetail: "New config",
+    apiAccessDraftStatus: "Configuring",
+    apiAccessTestedStatus: "Tested",
+    apiAccessDiscoveredStatus: "Discovered",
     apiAccessModels: "Supported models",
     apiAccessNoModels: "No models discovered yet.",
     apiAccessSaved: "Saved",
@@ -526,6 +541,7 @@ export const translations: Record<Language, UiCopy> = {
     keySaved: "Key saved",
     noKeySaved: "No key saved",
     parameters: "Parameters",
+    detailedConfig: "Detailed config",
     moreActions: "More actions",
     imageRoute: "API route",
     imageRouteAuto: "Auto",
@@ -714,6 +730,7 @@ export const translations: Record<Language, UiCopy> = {
     mask: "Mask",
     maskDescription: "Paint the area to replace. With multiple references, the mask applies to the first image.",
     guidedRegionDescription: "Use the painted region as guidance for the first image.",
+    exactMaskRouteNotice: "Mask mode uses the official Images API edit route because exact masks are only supported there. Aggregation platforms may have a lower success rate on this route.",
     maskBrushSize: "Adjust mask brush size",
     clearPaintedMask: "Clear painted mask",
     sourceForMask: "Source for mask",
@@ -757,6 +774,9 @@ export const translations: Record<Language, UiCopy> = {
     historySaveName: "Save image name",
     historySaveTags: "Save history tags",
     historySystemTag: "System tag",
+    historySourceTag: "Generation channel",
+    historySourceCli: "CLI",
+    historySourceMcp: "MCP",
     historyImageName: "Image name",
     historyDuration: (duration: string) => `Took ${duration}`,
     historyPageSizeMenu: "History page size",
@@ -921,7 +941,12 @@ export const translations: Record<Language, UiCopy> = {
     apiAccessDialogSummary: (count: number) => `${count} 个已保存配置 · 点击卡片编辑。`,
     apiAccessEditHint: "点击卡片后可在右侧编辑配置。",
     apiAccessUseNow: "立即使用该配置",
+    apiAccessEditCardTooltip: "单击编辑配置",
     apiAccessSelectedDetail: "配置信息",
+    apiAccessDraftDetail: "新增配置",
+    apiAccessDraftStatus: "正在配置",
+    apiAccessTestedStatus: "已测试",
+    apiAccessDiscoveredStatus: "已探测",
     apiAccessModels: "支持的模型",
     apiAccessNoModels: "暂未探测到模型。",
     apiAccessSaved: "已保存",
@@ -974,6 +999,7 @@ export const translations: Record<Language, UiCopy> = {
     keySaved: "Key 已保存",
     noKeySaved: "未保存 Key",
     parameters: "参数配置",
+    detailedConfig: "详细配置",
     moreActions: "更多操作",
     imageRoute: "接口路径",
     imageRouteAuto: "自动",
@@ -1162,6 +1188,7 @@ export const translations: Record<Language, UiCopy> = {
     mask: "蒙版",
     maskDescription: "涂抹需要替换的区域。多张参考图时，蒙版应用到第一张图片。",
     guidedRegionDescription: "将涂抹区域作为第一张图片的修改引导。",
+    exactMaskRouteNotice: "蒙版模式会使用官方 Images API 编辑通道，因为官方精确 mask 仅支持该通道；聚合平台在该通道下的生图成功率可能下降。",
     maskBrushSize: "调整蒙版画笔大小",
     clearPaintedMask: "清除已绘制蒙版",
     sourceForMask: "蒙版源图",
@@ -1205,6 +1232,9 @@ export const translations: Record<Language, UiCopy> = {
     historySaveName: "保存图片名称",
     historySaveTags: "保存历史标签",
     historySystemTag: "系统标签",
+    historySourceTag: "生图渠道",
+    historySourceCli: "CLI",
+    historySourceMcp: "MCP",
     historyImageName: "图片名称",
     historyDuration: (duration: string) => `耗时 ${duration}`,
     historyPageSizeMenu: "历史每页数量",

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -143,6 +143,7 @@ export interface UiCopy {
   keySaved: string;
   noKeySaved: string;
   parameters: string;
+  moreActions: string;
   imageRoute: string;
   imageRouteAuto: string;
   imageRouteAutoUsing: (route: string) => string;
@@ -314,6 +315,13 @@ export interface UiCopy {
   uploadMaskTooltip: string;
   addPaintedMask: string;
   addPaintedMaskTooltip: string;
+  addReferenceMask: string;
+  referenceMaskTools: string;
+  referenceMaskConfirmTitle: string;
+  referenceMaskConfirmBody: (name: string) => string;
+  referenceMaskConfirmAction: string;
+  referenceTileHint: string;
+  referencePromoted: string;
   clear: string;
   noReferences: string;
   dropReferencesHint: string;
@@ -406,6 +414,8 @@ export interface UiCopy {
   zoomOut: string;
   resetZoom: string;
   zoomLevel: string;
+  enterFocusView: string;
+  exitFocusView: string;
   clicked: string;
   back: string;
   editImage: string;
@@ -516,6 +526,7 @@ export const translations: Record<Language, UiCopy> = {
     keySaved: "Key saved",
     noKeySaved: "No key saved",
     parameters: "Parameters",
+    moreActions: "More actions",
     imageRoute: "API route",
     imageRouteAuto: "Auto",
     imageRouteAutoUsing: (route: string) => `Auto · ${route}`,
@@ -688,6 +699,13 @@ export const translations: Record<Language, UiCopy> = {
     uploadMaskTooltip: "Upload an existing mask image.",
     addPaintedMask: "Add as mask",
     addPaintedMaskTooltip: "Add the painted region as the active mask.",
+    addReferenceMask: "Add mask",
+    referenceMaskTools: "Reference mask tools",
+    referenceMaskConfirmTitle: "Use this image for the mask?",
+    referenceMaskConfirmBody: (name: string) => `Adding a mask to "${name}" will move it to the first reference image and replace the currently configured mask.`,
+    referenceMaskConfirmAction: "Use and add mask",
+    referenceTileHint: "Click to move this image to the first reference. Double-click to preview and add a mask.",
+    referencePromoted: "Reference image moved to the first position.",
     clear: "Clear",
     noReferences: "No reference images selected.",
     dropReferencesHint: "Drag local images, History results, or Gallery images here.",
@@ -779,6 +797,8 @@ export const translations: Record<Language, UiCopy> = {
     zoomOut: "Zoom out",
     resetZoom: "Reset zoom",
     zoomLevel: "Zoom level",
+    enterFocusView: "Expand editor",
+    exitFocusView: "Exit expanded editor",
     clicked: "Done",
     back: "Back",
     editImage: "Edit",
@@ -954,6 +974,7 @@ export const translations: Record<Language, UiCopy> = {
     keySaved: "Key 已保存",
     noKeySaved: "未保存 Key",
     parameters: "参数配置",
+    moreActions: "更多操作",
     imageRoute: "接口路径",
     imageRouteAuto: "自动",
     imageRouteAutoUsing: (route: string) => `自动 · ${route}`,
@@ -1126,6 +1147,13 @@ export const translations: Record<Language, UiCopy> = {
     uploadMaskTooltip: "上传已有蒙版图片。",
     addPaintedMask: "添加为蒙版",
     addPaintedMaskTooltip: "将已绘制区域添加为当前蒙版。",
+    addReferenceMask: "添加蒙版",
+    referenceMaskTools: "参考图蒙版工具",
+    referenceMaskConfirmTitle: "将该图作为蒙版源图？",
+    referenceMaskConfirmBody: (name: string) => `为“${name}”添加蒙版会将该图排到第 1 张参考图，并替换当前已配置的蒙版。`,
+    referenceMaskConfirmAction: "确认并添加蒙版",
+    referenceTileHint: "单击将图片排到第 1 张参考图；双击预览并可添加蒙版。",
+    referencePromoted: "已将参考图排到第 1 位。",
     clear: "清除",
     noReferences: "未选择参考图。",
     dropReferencesHint: "可拖拽本地图片、历史或图库中的图片到此处。",
@@ -1217,6 +1245,8 @@ export const translations: Record<Language, UiCopy> = {
     zoomOut: "缩小",
     resetZoom: "重置缩放",
     zoomLevel: "缩放比例",
+    enterFocusView: "放大编辑器",
+    exitFocusView: "退出放大编辑器",
     clicked: "完成",
     back: "返回",
     editImage: "编辑",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -231,6 +231,8 @@
       border-color var(--motion-fast),
       box-shadow var(--motion-fast),
       color var(--motion-fast),
+      opacity var(--motion-fast),
+      filter var(--motion-fast),
       transform var(--motion-fast);
   }
 
@@ -241,6 +243,8 @@
   }
 
   button:active:not(:disabled) {
+    filter: brightness(0.98);
+    opacity: 0.9;
     transform: translateY(1px) scale(0.985);
   }
 
@@ -754,6 +758,9 @@
     gap: 12px;
     border-top: 1px solid var(--border-subtle);
     padding-top: 16px;
+    transition:
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
   }
 
   .section-title,
@@ -790,14 +797,22 @@
   .api-access-current {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
     justify-items: stretch;
     width: 100%;
-    min-height: 58px;
+    min-height: 46px;
     border: 1px solid var(--border-subtle);
     background: var(--surface-panel);
     color: var(--text-primary);
-    padding: 10px 12px;
+    padding: 8px 10px 8px 12px;
     text-align: left;
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast),
+      filter var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
   }
 
   .api-access-current:hover:not(:disabled) {
@@ -806,9 +821,34 @@
     box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.08);
   }
 
-  .api-access-current > span,
+  .api-access-current-main,
   .api-access-item-main {
     min-width: 0;
+  }
+
+  .api-access-config-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-panel-muted);
+    color: var(--text-secondary);
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      color var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .api-access-current:hover .api-access-config-icon,
+  .api-access-current:focus-visible .api-access-config-icon {
+    border-color: var(--accent-border);
+    background: var(--accent-soft);
+    color: var(--accent);
+    transform: translateY(-1px);
   }
 
   .api-access-current strong,
@@ -831,6 +871,23 @@
     margin-top: 2px;
     color: var(--text-muted);
     font-size: 11px;
+  }
+
+  .api-access-hover-detail {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-2px);
+    transition:
+      max-height var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .api-access-current:hover .api-access-hover-detail,
+  .api-access-current:focus-visible .api-access-hover-detail {
+    max-height: 18px;
+    opacity: 1;
+    transform: translateY(0);
   }
 
   .api-access-panel,
@@ -934,7 +991,7 @@
   }
 
   .api-config-list-pane {
-    grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+    grid-template-rows: auto auto minmax(0, 1fr) auto;
     overflow: hidden;
   }
 
@@ -974,7 +1031,7 @@
 
   .api-config-card {
     display: grid;
-    grid-template-columns: 32px minmax(0, 1fr) 28px;
+    grid-template-columns: minmax(0, 1fr) 28px;
     align-items: stretch;
     column-gap: 8px;
     row-gap: 4px;
@@ -986,13 +1043,18 @@
     transition:
       background 0.16s ease,
       border-color 0.16s ease,
+      opacity 0.16s ease,
+      filter 0.16s ease,
       box-shadow 0.16s ease,
       transform 0.16s ease;
+    animation: content-fade-in 0.18s ease both;
   }
 
   .api-config-card:hover {
-    border-color: var(--border-strong);
+    border-color: var(--accent-border);
     background: var(--surface-raised);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
+    filter: none;
   }
 
   .api-config-card.active {
@@ -1006,6 +1068,22 @@
 
   .api-config-card.promoted {
     animation: api-config-promoted 0.7s ease;
+  }
+
+  .api-config-draft-card {
+    border-color: var(--accent-border);
+    background: var(--surface-raised);
+  }
+
+  .api-config-add-button {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .api-config-add-button.active {
+    border-color: var(--border-strong);
+    background: var(--surface-raised);
+    color: var(--text-primary);
   }
 
   @keyframes api-config-promoted {
@@ -1025,22 +1103,10 @@
     }
   }
 
-  .api-config-use-button,
   .api-config-card-actions .icon-button {
     width: 28px;
     height: 28px;
     min-height: 28px;
-  }
-
-  .api-config-use-button {
-    align-self: start;
-    margin-top: 3px;
-    color: var(--accent);
-  }
-
-  .api-config-use-button:disabled {
-    color: var(--text-muted);
-    opacity: 0.64;
   }
 
   .api-config-card-main {
@@ -1069,7 +1135,6 @@
   .api-config-card-title,
   .api-config-card-title-row,
   .api-config-card-meta,
-  .api-config-card-key,
   .api-config-card-models,
   .api-config-card-meta-row {
     max-width: 100%;
@@ -1105,7 +1170,6 @@
   }
 
   .api-config-card-meta,
-  .api-config-card-key,
   .api-config-card-models {
     color: var(--text-muted);
     font-size: 11px;
@@ -1114,24 +1178,19 @@
 
   .api-config-card-meta-row {
     display: grid;
-    grid-template-columns: minmax(46px, auto) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    gap: 6px;
+    gap: 10px;
     width: 100%;
   }
 
   .api-config-card-meta-url {
-    text-align: right;
-  }
-
-  .api-config-card-key {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+    text-align: left;
   }
 
   .api-config-card-models {
     color: var(--text-secondary);
+    text-align: right;
   }
 
   .api-config-card-models[data-kind="error"] {
@@ -1142,10 +1201,42 @@
     display: grid;
     align-content: center;
     gap: 6px;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateX(4px);
+    transition:
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .api-config-card:hover .api-config-card-actions,
+  .api-config-card:focus-within .api-config-card-actions {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0);
+  }
+
+  .api-config-enable-button {
+    border-color: var(--accent-border);
+    background: var(--accent);
+    color: var(--text-on-accent);
+    box-shadow: 0 8px 18px rgba(var(--accent-rgb), 0.18);
+  }
+
+  .api-config-enable-button:hover:not(:disabled) {
+    border-color: var(--accent-hover);
+    background: var(--accent-hover);
+    color: var(--text-on-accent-hover);
+    transform: translateY(-1px) scale(1.04);
   }
 
   .api-config-detail {
     overflow: auto;
+    animation: content-fade-in 0.18s ease both;
+  }
+
+  .api-config-add-detail {
+    align-content: start;
   }
 
   .api-config-detail-header h3 {
@@ -1406,9 +1497,10 @@
   .history-action-button:hover:not(:disabled),
   .section-toggle:hover:not(:disabled),
   .mode-tab:hover:not(:disabled) {
-    background: var(--surface-hover);
-    border-color: var(--border-strong);
+    background: var(--surface-raised);
+    border-color: var(--accent-border);
     color: var(--text-primary);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
   }
 
   .ghost {
@@ -1698,6 +1790,7 @@
   .history-gallery-target-menu,
   .history-page-size-menu,
   .api-config-dialog,
+  .parameter-dialog,
   .template-dialog,
   .confirm-dialog,
   .context-menu {
@@ -1712,6 +1805,29 @@
     to {
       opacity: 1;
       transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes content-fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(3px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.001ms !important;
+      animation-iteration-count: 1 !important;
+      scroll-behavior: auto !important;
+      transition-duration: 0.001ms !important;
     }
   }
 
@@ -1749,7 +1865,7 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     justify-items: start;
-    min-height: 52px;
+    min-height: 44px;
     width: 100%;
     gap: 2px;
     border: 1px solid var(--border-subtle);
@@ -1757,11 +1873,17 @@
     color: var(--text-primary);
     padding: 8px 11px;
     text-align: left;
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast),
+      transform var(--motion-fast);
   }
 
   .launch-button:hover:not(:disabled) {
     border-color: var(--accent-border);
-    background: var(--surface-panel);
+    background: var(--surface-raised);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
   }
 
   .launch-button-main {
@@ -1791,6 +1913,23 @@
   .launch-button small {
     color: var(--text-muted);
     font-size: 11px;
+  }
+
+  .launch-model-detail {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-2px);
+    transition:
+      max-height var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .launch-button:hover .launch-model-detail,
+  .launch-button:focus-visible .launch-model-detail {
+    max-height: 16px;
+    opacity: 1;
+    transform: translateY(0);
   }
 
   .launch-button.active {
@@ -1828,7 +1967,7 @@
 
   .launch-model-option {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     justify-items: start;
     min-height: 34px;
     gap: 8px;
@@ -2566,6 +2705,14 @@
     background: var(--surface-panel);
     padding: 7px;
     overflow: hidden;
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast),
+      filter var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+    animation: content-fade-in 0.18s ease both;
   }
 
   .gallery-content-grid.batch-select .gallery-item {
@@ -2575,6 +2722,14 @@
   .gallery-item.selected {
     border-color: var(--accent-border);
     background: var(--accent-soft);
+  }
+
+  .gallery-item:hover,
+  .gallery-item:focus-within {
+    border-color: var(--accent-border);
+    background: var(--surface-raised);
+    filter: none;
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
   }
 
   .gallery-content-grid.grid .gallery-item {
@@ -2776,6 +2931,19 @@
     display: grid;
     align-content: start;
     gap: 5px;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition:
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .gallery-item:hover .gallery-actions,
+  .gallery-item:focus-within .gallery-actions {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
   }
 
   @container (max-width: 300px) {
@@ -3273,7 +3441,13 @@
     padding-bottom: 8px;
   }
 
+  .right-rail-actions.tag-manager-open,
+  .right-rail.collapsed .right-rail-actions.tag-manager-open {
+    z-index: 7000;
+  }
+
   .tag-manager-menu {
+    z-index: 7100;
     width: min(310px, 82vw);
   }
 
@@ -3667,12 +3841,17 @@
     color: var(--danger);
   }
 
+  .inline-check.warning {
+    color: var(--warning);
+  }
+
   .reference-rights-reminder {
     align-items: flex-start;
     color: var(--warning);
   }
 
-  .reference-rights-reminder svg {
+  .reference-rights-reminder svg,
+  .mask-route-notice svg {
     flex: 0 0 auto;
     margin-top: 1px;
   }
@@ -3787,7 +3966,9 @@
     text-align: left;
     transition:
       background 0.16s ease,
-      color 0.16s ease;
+      color 0.16s ease,
+      opacity 0.16s ease,
+      transform 0.16s ease;
   }
 
   .mode-tab:last-child,
@@ -4536,6 +4717,268 @@
     min-height: 0;
   }
 
+  .parameter-config-bar {
+    display: grid;
+    gap: 8px;
+    min-width: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-panel);
+    padding: 9px;
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .parameter-config-bar:hover,
+  .parameter-config-bar:focus-within {
+    border-color: var(--accent-border);
+    background: var(--surface-raised);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
+  }
+
+  .parameter-config-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-width: 0;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(-2px);
+    transition:
+      max-height var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .parameter-config-bar:hover .parameter-config-heading,
+  .parameter-config-bar:focus-within .parameter-config-heading {
+    max-height: 32px;
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .parameter-config-heading strong {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 750;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .parameter-config-trigger {
+    flex: 0 0 auto;
+    width: 32px;
+    height: 32px;
+    min-height: 32px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .parameter-summary-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(116px, 1fr));
+    gap: 6px;
+    min-width: 0;
+    align-items: stretch;
+  }
+
+  .parameter-summary-chip {
+    display: grid;
+    grid-template-rows: 0 28px;
+    align-content: center;
+    align-items: center;
+    justify-items: stretch;
+    min-width: 0;
+    min-height: 46px;
+    gap: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-panel);
+    padding: 8px;
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast),
+      transform var(--motion-fast),
+      gap var(--motion-fast),
+      grid-template-rows var(--motion-fast),
+      min-height var(--motion-fast);
+  }
+
+  .parameter-summary-chip:hover,
+  .parameter-summary-chip:focus-within {
+    border-color: var(--accent-border);
+    background: var(--surface-raised);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
+  }
+
+  .parameter-config-bar:hover .parameter-summary-chip,
+  .parameter-summary-chip:focus-within {
+    grid-template-rows: 16px 30px;
+    min-height: 62px;
+    gap: 4px;
+  }
+
+  .parameter-summary-chip small,
+  .parameter-summary-chip strong {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .parameter-summary-chip small {
+    color: var(--text-muted);
+    font-size: 10.5px;
+    font-weight: 650;
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-2px);
+    transition:
+      max-height var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .parameter-config-bar:hover .parameter-summary-chip small,
+  .parameter-summary-chip:focus-within small {
+    max-height: 16px;
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .parameter-summary-chip strong {
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 750;
+  }
+
+  .parameter-quick-field {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .parameter-quick-field select,
+  .parameter-quick-field input {
+    justify-self: center;
+    width: min(100%, 104px);
+    min-width: 0;
+    max-width: 100%;
+    min-height: 26px;
+    border: 0;
+    background: transparent;
+    color: var(--text-primary);
+    padding: 0;
+    font-size: 12px;
+    font-weight: 700;
+    text-align: center;
+    text-overflow: ellipsis;
+    transition:
+      width var(--motion-fast),
+      min-height var(--motion-fast);
+  }
+
+  .parameter-config-bar:hover .parameter-quick-field select,
+  .parameter-config-bar:hover .parameter-quick-field input,
+  .parameter-quick-field:focus-within select,
+  .parameter-quick-field:focus-within input {
+    width: 100%;
+    min-height: 28px;
+  }
+
+  .parameter-quick-field select:focus-visible,
+  .parameter-quick-field input:focus-visible {
+    outline: none;
+  }
+
+  .parameter-route-field {
+    position: relative;
+  }
+
+  .parameter-route-field .route-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    max-height: 0;
+    min-width: 0;
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(-2px);
+    transition:
+      max-height var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .parameter-config-bar:hover .parameter-route-field .route-label,
+  .parameter-route-field:focus-within .route-label {
+    max-height: 16px;
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .parameter-route-field select {
+    width: min(100%, 96px);
+  }
+
+  .route-info-icon {
+    opacity: 0;
+    color: var(--text-muted);
+    transition:
+      opacity var(--motion-fast),
+      color var(--motion-fast);
+  }
+
+  .parameter-config-bar:hover .route-info-icon,
+  .parameter-summary-chip:focus-within .route-info-icon {
+    opacity: 1;
+  }
+
+  .parameter-dialog {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 14px;
+    width: min(760px, 100%);
+    height: min(620px, calc(100vh - 44px));
+    max-height: min(720px, calc(100vh - 44px));
+    min-height: 0;
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-panel);
+    box-shadow: var(--shadow-popover);
+    padding: 18px;
+  }
+
+  .parameter-dialog-body {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 12px;
+    min-height: 0;
+    overflow: auto;
+    overscroll-behavior: contain;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-panel-muted);
+    padding: 10px;
+  }
+
+  .parameter-dialog-primary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .parameter-dialog .advanced-controls {
+    align-content: start;
+    min-height: 0;
+  }
+
   .prompt-composer {
     display: grid;
     gap: 8px;
@@ -4626,9 +5069,15 @@
     gap: 8px;
   }
 
+  .run-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+
   .prompt-template-button {
     justify-content: center;
-    width: 100%;
     max-width: 100%;
   }
 
@@ -4650,19 +5099,13 @@
   }
 
   .primary-run {
+    flex: 1 1 auto;
+    width: auto;
     min-width: 0;
     min-height: 40px;
   }
 
-  .run-row {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    align-items: center;
-    gap: 8px;
-  }
-
   .run-row button {
-    width: 100%;
     min-width: 0;
     overflow: hidden;
     min-height: 40px;
@@ -4670,39 +5113,101 @@
     padding-right: 8px;
   }
 
+  .prompt-template-button,
+  .prompt-copy-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 40px;
+    width: 40px;
+    gap: 0;
+    padding: 0;
+    transition:
+      flex-basis var(--motion-fast),
+      width var(--motion-fast),
+      padding var(--motion-fast),
+      gap var(--motion-fast),
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast);
+  }
+
+  .prompt-template-button .button-label,
+  .prompt-template-button .button-count,
+  .prompt-copy-button .button-label {
+    max-width: 0;
+    opacity: 0;
+    transform: translateX(-4px);
+    pointer-events: none;
+    transition:
+      max-width var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast),
+      padding var(--motion-fast),
+      border-color var(--motion-fast);
+  }
+
+  .prompt-template-button .button-count {
+    border-left-color: transparent;
+    padding-left: 0;
+  }
+
+  .prompt-template-button:hover,
+  .prompt-template-button:focus-visible {
+    flex-basis: min(190px, 42%);
+    width: min(190px, 42%);
+    gap: 8px;
+    padding: 0 8px;
+  }
+
+  .prompt-copy-button:hover,
+  .prompt-copy-button:focus-visible {
+    flex-basis: min(160px, 36%);
+    width: min(160px, 36%);
+    gap: 8px;
+    padding: 0 8px;
+  }
+
+  .prompt-template-button:hover .button-label,
+  .prompt-template-button:focus-visible .button-label,
+  .prompt-template-button:hover .button-count,
+  .prompt-template-button:focus-visible .button-count,
+  .prompt-copy-button:hover .button-label,
+  .prompt-copy-button:focus-visible .button-label {
+    max-width: 120px;
+    opacity: 1;
+    transform: translateX(0);
+    pointer-events: auto;
+  }
+
+  .prompt-template-button:hover .button-count,
+  .prompt-template-button:focus-visible .button-count {
+    border-left-color: var(--border-subtle);
+    padding-left: 8px;
+  }
+
   .asset-tools {
     container-type: inline-size;
     flex-wrap: wrap;
   }
 
-  .prompt-actions.secondary-actions-icon-only .run-row {
-    grid-template-columns: minmax(0, 1fr) 40px 40px;
-  }
-
-  .prompt-actions.secondary-actions-icon-only .prompt-template-button,
-  .prompt-actions.secondary-actions-icon-only .prompt-copy-button {
+  .prompt-actions.secondary-actions-icon-only .prompt-template-button:not(:hover):not(:focus-visible),
+  .prompt-actions.secondary-actions-icon-only .prompt-copy-button:not(:hover):not(:focus-visible) {
     width: 40px;
     padding: 0;
   }
 
-  .prompt-actions.secondary-actions-icon-only .prompt-template-button .button-label,
-  .prompt-actions.secondary-actions-icon-only .prompt-template-button .button-count,
-  .prompt-actions.secondary-actions-icon-only .prompt-copy-button .button-label {
-    display: none;
-  }
-
-  .prompt-actions.primary-run-icon-only .primary-run .button-label {
-    display: none;
-  }
-
-  .prompt-actions.secondary-actions-icon-only.primary-run-icon-only .run-row {
-    grid-template-columns: 40px 40px 40px;
-    justify-content: flex-start;
+  .prompt-actions.secondary-actions-icon-only .prompt-template-button:not(:hover):not(:focus-visible) .button-label,
+  .prompt-actions.secondary-actions-icon-only .prompt-template-button:not(:hover):not(:focus-visible) .button-count,
+  .prompt-actions.secondary-actions-icon-only .prompt-copy-button:not(:hover):not(:focus-visible) .button-label {
+    max-width: 0;
+    opacity: 0;
   }
 
   .prompt-actions.primary-run-icon-only .primary-run {
-    width: 40px;
-    padding: 0;
+    width: auto;
+    padding-left: 8px;
+    padding-right: 8px;
   }
 
   @container (max-width: 300px) {
@@ -5083,8 +5588,9 @@
   }
 
   .history-sort-option:hover:not(:disabled) {
-    border-color: var(--border-strong);
-    background: var(--surface-hover);
+    border-color: var(--accent-border);
+    background: var(--surface-raised);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
   }
 
   .history-sort-option.active {
@@ -5158,6 +5664,14 @@
     border-radius: var(--radius-lg);
     background: var(--surface-panel);
     padding: 8px;
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast),
+      filter var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+    animation: content-fade-in 0.18s ease both;
   }
 
   .history-list.batch-select .history-item {
@@ -5186,10 +5700,19 @@
   }
 
   .history-item.active,
+  .history-item.hover-open,
   .history-item.selected {
     border-color: var(--accent-border);
     background: var(--surface-raised);
     box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.1);
+  }
+
+  .history-item:hover,
+  .history-item:focus-within {
+    border-color: var(--accent-border);
+    background: var(--surface-raised);
+    filter: none;
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.07);
   }
 
   .history-preview {
@@ -5342,6 +5865,13 @@
     color: var(--accent);
   }
 
+  .history-chip.source-tag {
+    border-color: var(--success-border);
+    background: var(--success-soft);
+    color: var(--success);
+    font-weight: 700;
+  }
+
   .history-add-tag-anchor {
     position: relative;
     display: inline-flex;
@@ -5360,12 +5890,26 @@
     font-weight: 400;
     line-height: 1;
     cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition:
+      opacity var(--motion-fast),
+      border-color var(--motion-fast),
+      color var(--motion-fast),
+      background var(--motion-fast);
   }
 
   .history-add-tag-button:hover,
   .history-add-tag-button:focus-visible {
     border-color: var(--accent-border);
     color: var(--accent);
+  }
+
+  .history-item.hover-open .history-add-tag-button,
+  .history-item:hover .history-add-tag-button,
+  .history-item:focus-within .history-add-tag-button {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .gallery-tag-row .gallery-add-tag-button {
@@ -5434,6 +5978,19 @@
   .history-copy .history-error {
     color: var(--danger);
     -webkit-line-clamp: 2;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition:
+      max-height var(--motion-fast),
+      opacity var(--motion-fast);
+  }
+
+  .history-item.hover-open .history-error,
+  .history-item:hover .history-error,
+  .history-item:focus-within .history-error {
+    max-height: 3em;
+    opacity: 1;
   }
 
   .history-actions {
@@ -5443,6 +6000,24 @@
     grid-template-columns: repeat(5, minmax(0, 1fr));
     justify-content: stretch;
     gap: 6px;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition:
+      max-height var(--motion-fast),
+      opacity var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .history-item.hover-open .history-actions,
+  .history-item:hover .history-actions,
+  .history-item:focus-within .history-actions {
+    max-height: 48px;
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
   }
 
   .history-actions .history-action-button {
@@ -5884,9 +6459,7 @@
       padding: 5px 8px;
     }
 
-    .api-access-current small,
-    .launch-title strong,
-    .launch-button small {
+    .launch-title strong {
       display: none;
     }
 
@@ -5939,10 +6512,8 @@
       gap: 8px;
     }
 
-    .compact-grid,
-    .advanced-controls,
-    .api-access-current small,
-    .launch-button small {
+    .sidebar .compact-grid,
+    .sidebar .advanced-controls {
       display: none;
     }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -4263,6 +4263,7 @@
   }
 
   .preview-modal-dialog {
+    position: relative;
     display: grid;
     place-items: center;
     max-width: 100%;
@@ -4283,6 +4284,96 @@
     top: 18px;
     right: 18px;
     z-index: 31;
+  }
+
+  .reference-preview-dialog {
+    width: min(1120px, 96vw);
+    height: min(840px, 94vh);
+  }
+
+  .reference-preview-dialog .preview-modal-image {
+    max-width: min(95vw, 1080px);
+    max-height: 88vh;
+  }
+
+  .reference-preview-tools {
+    z-index: 40;
+  }
+
+  .reference-mask-tools {
+    max-width: min(92vw, 620px);
+    flex-wrap: wrap;
+  }
+
+  .reference-mask-tools input[type="range"] {
+    width: min(180px, 30vw);
+  }
+
+  .reference-preview-stage {
+    display: grid;
+    gap: 10px;
+    place-items: center;
+    max-width: 96vw;
+    max-height: 92vh;
+  }
+
+  .reference-preview-canvas-wrap {
+    position: relative;
+    display: inline-flex;
+    min-height: 0;
+    line-height: 0;
+  }
+
+  .reference-preview-canvas-wrap .preview-modal-image {
+    display: block;
+  }
+
+  .reference-preview-mask-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    cursor: crosshair;
+    touch-action: none;
+  }
+
+  .reference-preview-stage.masking .reference-preview-canvas-wrap {
+    box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.55);
+    border-radius: 4px;
+  }
+
+  .reference-preview-mask-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .reference-mask-confirm {
+    position: absolute;
+    inset: 50% auto auto 50%;
+    z-index: 80;
+    display: grid;
+    gap: 12px;
+    width: min(360px, calc(100% - 34px));
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--surface-floating-radius);
+    background: var(--surface-floating);
+    box-shadow: var(--shadow-popover);
+    padding: 16px;
+    transform: translate(-50%, -50%);
+    backdrop-filter: blur(14px);
+  }
+
+  .reference-mask-confirm h3 {
+    font-size: 15px;
+  }
+
+  .reference-mask-confirm p {
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.45;
   }
 
   .empty-state,
@@ -4629,9 +4720,11 @@
   .reference-grid {
     position: relative;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
-    gap: 10px;
-    min-height: clamp(132px, 24vh, 220px);
+    grid-template-columns: repeat(auto-fill, minmax(82px, 106px));
+    align-content: start;
+    justify-content: start;
+    gap: 8px;
+    min-height: 112px;
     max-height: 100%;
     overflow: auto;
     border: 1px dashed var(--border-strong);
@@ -4646,7 +4739,7 @@
   .reference-grid > .empty-inline {
     display: grid;
     grid-column: 1 / -1;
-    min-height: clamp(108px, 20vh, 196px);
+    min-height: 96px;
     place-items: center;
     text-align: center;
   }
@@ -4718,12 +4811,43 @@
     padding: 8px;
   }
 
+  .reference-thumb-tile {
+    width: 100%;
+    min-height: 0;
+    gap: 5px;
+    padding: 6px;
+    cursor: pointer;
+    transition:
+      border-color 0.14s ease,
+      box-shadow 0.14s ease,
+      transform 0.14s ease,
+      background 0.14s ease;
+  }
+
+  .reference-thumb-tile:hover,
+  .reference-thumb-tile:focus-visible {
+    border-color: var(--accent-border);
+    background: var(--accent-soft);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.08);
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  .reference-thumb-tile.primary-reference {
+    border-color: var(--accent-border);
+  }
+
   .asset-tile img {
     width: 100%;
     aspect-ratio: 4 / 3;
     object-fit: cover;
     border-radius: var(--radius-md);
     background: var(--surface-panel-muted);
+  }
+
+  .reference-thumb-tile img {
+    aspect-ratio: 1;
+    border-radius: var(--radius-md);
   }
 
   .asset-tile div {
@@ -4748,6 +4872,37 @@
   .asset-tile small {
     color: var(--text-muted);
     font-size: 11px;
+  }
+
+  .reference-thumb-meta {
+    line-height: 1.2;
+  }
+
+  .reference-thumb-meta strong {
+    font-size: 11px;
+  }
+
+  .reference-thumb-meta span {
+    font-size: 10px;
+  }
+
+  .reference-mask-badge {
+    position: absolute;
+    left: 8px;
+    top: 8px;
+    max-width: calc(100% - 44px);
+    overflow: hidden;
+    border: 1px solid rgba(var(--accent-rgb), 0.28);
+    border-radius: 999px;
+    background: rgba(var(--accent-rgb), 0.9);
+    color: #ffffff;
+    padding: 2px 6px;
+    font-size: 10px;
+    font-weight: 750;
+    line-height: 1.2;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    box-shadow: 0 6px 14px rgba(var(--accent-rgb), 0.18);
   }
 
   .tile-remove {

--- a/src/renderer/useHistoryListModel.ts
+++ b/src/renderer/useHistoryListModel.ts
@@ -54,7 +54,7 @@ export function useHistoryListModel({
       : statusMatched.filter((job) => {
           const modelDetails = modelDetailsForJob(job);
           const systemTag = systemTagLabelForMode(job.mode, language);
-          const haystack = `${displayNameForJob(job)} ${job.tags.join(" ")} ${systemTag} ${job.prompt} ${job.mode} ${job.status} ${job.error ?? ""} ${job.createdAt} ${modelDetails.searchText}`.toLowerCase();
+          const haystack = `${displayNameForJob(job)} ${job.tags.join(" ")} ${systemTag} ${job.source ?? ""} ${job.prompt} ${job.mode} ${job.status} ${job.error ?? ""} ${job.createdAt} ${modelDetails.searchText}`.toLowerCase();
           return haystack.includes(query);
         });
     const sorted = [...matched];

--- a/src/shared/package-config.test.ts
+++ b/src/shared/package-config.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
 import packageJson from "../../package.json";
 import updateManifest from "../../docs/updates/latest.json";
 
@@ -41,5 +43,25 @@ describe("package release configuration", () => {
   it("uses an assisted Windows installer so users can choose the install path", () => {
     expect(packageJson.build.nsis.oneClick).toBe(false);
     expect(packageJson.build.nsis.allowToChangeInstallationDirectory).toBe(true);
+  });
+
+  it("ships CLI launchers that do not require Node.js in installed packages", () => {
+    const shellLauncherPath = path.resolve("build/cli/crossgen");
+    const cmdLauncherPath = path.resolve("build/cli/crossgen.cmd");
+    const shellLauncher = readFileSync(shellLauncherPath, "utf8");
+    const cmdLauncher = readFileSync(cmdLauncherPath, "utf8");
+
+    expect(statSync(shellLauncherPath).mode & 0o111).toBeGreaterThan(0);
+    expect(shellLauncher).toContain('exec "$CROSSGEN_APP_EXECUTABLE" --cli "$@"');
+    expect(shellLauncher).toContain('exec "$CROSSGEN_APP_EXECUTABLE" "$@"');
+    expect(shellLauncher).toContain("CROSSGEN_DATA_DIR");
+    expect(shellLauncher).not.toMatch(/\bnode\b/);
+    expect(shellLauncher).not.toContain("dist/cli/crossgen.js");
+
+    expect(cmdLauncher).toContain('"%CROSSGEN_APP_EXECUTABLE%" --cli %*');
+    expect(cmdLauncher).toContain('"%CROSSGEN_APP_EXECUTABLE%" %*');
+    expect(cmdLauncher).toContain("CROSSGEN_DATA_DIR");
+    expect(cmdLauncher).not.toMatch(/\bnode\b/i);
+    expect(cmdLauncher).not.toContain("dist\\cli\\crossgen.js");
   });
 });

--- a/src/shared/package-config.test.ts
+++ b/src/shared/package-config.test.ts
@@ -51,7 +51,9 @@ describe("package release configuration", () => {
     const shellLauncher = readFileSync(shellLauncherPath, "utf8");
     const cmdLauncher = readFileSync(cmdLauncherPath, "utf8");
 
-    expect(statSync(shellLauncherPath).mode & 0o111).toBeGreaterThan(0);
+    if (process.platform !== "win32") {
+      expect(statSync(shellLauncherPath).mode & 0o111).toBeGreaterThan(0);
+    }
     expect(shellLauncher).toContain('exec "$CROSSGEN_APP_EXECUTABLE" --cli "$@"');
     expect(shellLauncher).toContain('exec "$CROSSGEN_APP_EXECUTABLE" "$@"');
     expect(shellLauncher).toContain("CROSSGEN_DATA_DIR");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -325,6 +325,7 @@ export interface GenerationJob {
   id: string;
   name: string;
   tags: string[];
+  source?: QueueSource;
   providerKind: ProviderKind;
   providerId: string;
   launchId: FocusedLaunchId;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -424,6 +424,8 @@ export type CrossGenJsonErrorCode =
   | "LOCK_TIMEOUT"
   | "PATH_NOT_ALLOWED"
   | "ASSET_NOT_FOUND"
+  | "FOLDER_ALREADY_EXISTS"
+  | "FOLDER_NOT_FOUND"
   | "JOB_NOT_FOUND"
   | "INVALID_ARGUMENT"
   | "UNKNOWN_ERROR";
@@ -606,4 +608,5 @@ export interface AppBridge {
   clearHistory: () => Promise<GenerationJob[]>;
   onJobEvent: (callback: (event: JobProgressEvent) => void) => () => void;
   onGalleryEvent: (callback: (event: GallerySyncEvent) => void) => () => void;
+  onSnapshotChange: (callback: (snapshot: AppSnapshot) => void) => () => void;
 }


### PR DESCRIPTION
## Summary
- Stabilize v0.3.1 CLI/MCP queue recovery so desktop startup does not falsely fail active CLI/MCP jobs.
- Preserve and surface History generation source for desktop/CLI/MCP jobs.
- Add GPT Image 2 exact-mask route warning and lock mask mode to Images API with clear UI coverage.
- Harden API config save/discovery UX, parameter dialog layout, rail/card hover behavior, stale lock handling, and packaged CLI/MCP smoke assertions.

## Verification
- pnpm test
- pnpm typecheck
- pnpm build:renderer
- pnpm verify:queue-concurrency-smoke
- pnpm verify:cli-mcp-smoke
- pnpm verify:agent-integration-smoke

## Release Note
This PR prepares the 0.3.1 release candidate only. Public final release still requires product-owner installable package acceptance.