### PR TITLE
Skip final release jobs for RC tags

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -18,6 +18,7 @@ jobs:
   linux-appimage:
     name: Build and publish Linux AppImage
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name, '-rc.') }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -18,6 +18,7 @@ jobs:
   windows-installer:
     name: Build and publish Windows installer
     runs-on: windows-latest
+    if: ${{ !contains(github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name, '-rc.') }}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- Skip Linux and Windows final asset-publishing release jobs when the tag contains `-rc.`.
- Prevent release-candidate tags from running final evidence-gated asset publication or changing release assets.

## Verification
- Diff-only workflow guard; main CI will validate repository checks on this PR.

## Release Note
This keeps v0.3.1 release candidates separate from final v0.3.1 publication and product-owner acceptance gates.