### PR TITLE
docs: add community contribution pathways

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Report a reproducible problem in the desktop app, CLI, or MCP server
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Remove API keys, private images, local paths, and sensitive provider responses before submitting.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - Desktop app
+        - JSON CLI
+        - MCP server
+        - Packaging or installation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: CrossGen version
+      placeholder: "For example: v0.3.1"
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating system
+      options:
+        - macOS arm64
+        - Windows x64
+        - Linux x64
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open...
+        2. Run...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Sanitized diagnostics
+      description: Include relevant JSON output or logs only after removing credentials and private data.
+      render: shell
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and pull requests.
+          required: true
+        - label: I removed API keys, private images, local paths, and other sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Workflow questions and ideas
+    url: https://github.com/Bliveren/CrossGen/discussions
+    about: Ask questions, share workflows, or discuss an idea before scoping an issue.
+  - name: Security vulnerability
+    url: https://github.com/Bliveren/CrossGen/security/advisories/new
+    about: Report security issues privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Propose a focused improvement to the desktop, CLI, or MCP workflow
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - Desktop app
+        - JSON CLI
+        - MCP server
+        - Shared core workflow
+        - Packaging or installation
+        - Documentation
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the workflow problem before proposing a solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: agent-contract
+    attributes:
+      label: CLI or MCP contract
+      description: If relevant, include the desired JSON command, MCP tool, permission mode, and confirmation behavior.
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and pull requests.
+          required: true
+        - label: I have not included credentials, private images, or other sensitive data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Summary
+
+Describe the focused problem and the user-visible result.
+
+## Surface
+
+- [ ] Desktop app
+- [ ] JSON CLI
+- [ ] MCP server
+- [ ] Shared core or persistence
+- [ ] Packaging, release, or documentation
+
+## Validation
+
+List the commands you actually ran and their results.
+
+```text
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+## Evidence
+
+Add screenshots for renderer changes and sanitized JSON examples for CLI or MCP contract changes.
+
+## Checklist
+
+- [ ] The change is focused and includes tests for behavior changes.
+- [ ] English and Chinese documentation are synchronized when user-facing behavior changes.
+- [ ] No API keys, private images, local state, logs, or build artifacts are included.
+- [ ] Real-provider checks were not run without explicit cost approval.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to CrossGen
+
+Thanks for helping improve CrossGen. Contributions that make the desktop, CLI, or MCP image workflow more reliable and easier to use are welcome.
+
+## Before You Start
+
+- Search existing issues and pull requests before opening a new one.
+- Use [GitHub Discussions](https://github.com/Bliveren/CrossGen/discussions) for workflow ideas, usage questions, and early proposals.
+- Use an issue for reproducible bugs or a scoped feature request.
+- Never include API keys, private images, local state files, or provider responses that may contain credentials.
+- For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) instead of opening a public issue.
+
+## Development Setup
+
+Requirements:
+
+- Node.js compatible with the version used by CI
+- pnpm 10
+- macOS, Windows, or Linux
+
+```bash
+pnpm install
+pnpm dev:electron
+```
+
+Run the standard validation before submitting a pull request:
+
+```bash
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Focused checks are also available:
+
+```bash
+pnpm verify:cli-mcp-smoke
+pnpm verify:agent-integration-smoke
+pnpm verify:mock-api
+pnpm verify:mock-gemini-api
+pnpm verify:mock-model-discovery
+```
+
+Mock checks do not spend provider credits. Do not run real-provider gates without explicit cost approval and local credentials.
+
+## Pull Requests
+
+1. Keep each pull request focused on one problem.
+2. Add or update tests for behavior changes.
+3. Update English and Chinese documentation together when user-facing behavior changes.
+4. Describe the user impact and list the checks you actually ran.
+5. Add screenshots for renderer changes and JSON examples for CLI or MCP contract changes.
+6. Do not commit build output, release artifacts, local state, logs, or secrets.
+
+By submitting a contribution, you agree that it is licensed under the repository's [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -267,6 +267,15 @@ CrossGen is maintained by [Nowo](https://www.nowo.com/) and [Corgnitor](https://
 
 Join the CrossGen community on [Discord](https://discord.gg/XphwmYtY) for feedback, release discussion, and workflow ideas.
 
+## Community and Contributions
+
+- Ask usage questions, share workflows, and discuss early ideas in [GitHub Discussions](https://github.com/Bliveren/CrossGen/discussions).
+- Report reproducible problems or scoped requests with the [issue templates](https://github.com/Bliveren/CrossGen/issues/new/choose).
+- Read [CONTRIBUTING.md](./CONTRIBUTING.md) before submitting code or documentation.
+- Report vulnerabilities privately according to [SECURITY.md](./SECURITY.md).
+
+New contributors can start with [`good first issue`](https://github.com/Bliveren/CrossGen/labels/good%20first%20issue) or [`help wanted`](https://github.com/Bliveren/CrossGen/labels/help%20wanted) tasks.
+
 ## Technical Notes
 
 CrossGen is an Electron + React + Tailwind desktop app. The app focuses on local-first workflows and supports OpenAI, Gemini, and compatible image providers.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -275,6 +275,15 @@ CrossGen 由 [诺惟 Nowo](https://www.nowo.com/) 与 [核炬科技 Corgnitor](h
 
 欢迎加入 [CrossGen Discord 社区](https://discord.gg/XphwmYtY)，反馈问题、讨论版本和交流生图工作流。
 
+## 社区与贡献
+
+- 使用问题、工作流分享和早期想法请前往 [GitHub Discussions](https://github.com/Bliveren/CrossGen/discussions)。
+- 可复现问题或边界明确的需求请使用 [Issue 模板](https://github.com/Bliveren/CrossGen/issues/new/choose)。
+- 提交代码或文档前，请先阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)。
+- 安全漏洞请按 [SECURITY.md](./SECURITY.md) 私下报告，不要创建公开 Issue。
+
+新贡献者可从 [`good first issue`](https://github.com/Bliveren/CrossGen/labels/good%20first%20issue) 或 [`help wanted`](https://github.com/Bliveren/CrossGen/labels/help%20wanted) 任务开始。
+
 ## 技术说明
 
 CrossGen 使用 Electron、React 和 Tailwind 构建。本节面向开发、测试和发布维护人员；普通用户下载安装包即可使用。


### PR DESCRIPTION
## Summary

- add focused bug, feature, and pull request templates for Desktop, JSON CLI, and MCP work
- add contribution setup, validation, security, and real-provider cost boundaries
- add bilingual README routes to Discussions, issues, security reporting, and newcomer labels
- enable GitHub Discussions for questions, workflow sharing, and early proposals

## Why

CrossGen now explains the product and v0.3.1 Agent path well, but the repository community profile had no contribution guide or templates. This makes qualified visitors easier to convert into feedback and contributions without exposing API keys or private image data.

## Validation

- `git diff --check`
- parsed all three issue-template YAML files with Ruby Psych
- verified Discussions through GitHub GraphQL and public browser readback
- verified issue chooser, private security advisory, newcomer labels, and Discord links

No runtime code changed.