### PR TITLE
feat: productize v0.3.3 agent access

### DIFF
--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -1,11 +1,20 @@
 # CrossGen Known Limitations
 
-Last updated: 2026-07-30 for v0.3.2 release-candidate validation.
+Last updated: 2026-08-20 for v0.3.3 agent-access development.
 
 This document tracks the current user-facing limits for the released app,
 release-candidate validation, and agent runtime surfaces.
 
 ## Active Limitations
+
+0. **Agent access is local and process-scoped**
+   - The desktop Agent access panel and `doctor --agent` report the
+     executable, launcher, PATH, data directory, queue worker, and permission
+     state visible to the current CrossGen process.
+   - PATH repair is advisory: CrossGen provides a copyable command but never
+     edits shell startup files or injects a system PATH entry.
+   - MCP hosts should call the current packaged CrossGen executable directly
+     with `--mcp`; they do not need a global `crossgen` link.
 
 1. **Generation requires network access and a provider API key**
    - CrossGen does not ship an offline image model or local GPU runtime in

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -9,8 +9,8 @@ release-candidate validation, and agent runtime surfaces.
 
 0. **Agent access is local and process-scoped**
    - The desktop Agent access panel and `doctor --agent` report the
-     executable, launcher, PATH, data directory, queue worker, and permission
-     state visible to the current CrossGen process.
+     executable, launcher, PATH, data directory, queue worker, permission,
+     and usable API-key state visible to the current CrossGen process.
    - PATH repair is advisory: CrossGen provides a copyable command but never
      edits shell startup files or injects a system PATH entry.
    - MCP hosts should call the current packaged CrossGen executable directly

--- a/docs/cli-mcp.md
+++ b/docs/cli-mcp.md
@@ -62,6 +62,12 @@ may run CrossGen from another directory or keep multiple builds. CrossGen should
 not edit shell startup files automatically. If `~/.local/bin` is not on `PATH`,
 show the status and let the user copy the needed shell configuration manually.
 
+The desktop Agent access panel can enable or disable the managed user-level
+launcher without touching shell files. On Windows it uses a marked shim at
+`%LOCALAPPDATA%\CrossGen\bin\crossgen.cmd`; that directory still needs to be on
+the user's `PATH` for a new terminal command to resolve. Existing unmanaged
+files are never overwritten.
+
 MCP does not require this link. MCP client configuration should call the CrossGen
 app executable directly.
 
@@ -82,7 +88,8 @@ machine-readable `data` includes:
 - `dataDir`, `statePath`, `stateFound`
 - `activeProvider`, `apiKeyAvailable`
 - `liveWorkerHost`, `liveWorkerHosts`, `queueConfig`
-- `cli.status`, `cli.commandPath`, `cli.launcherPath`, `cli.launcherExists`
+- `cli.status`, `cli.commandPath`, `cli.launcherPath`, `cli.launcherExists`,
+  `cli.linkPath`, `cli.linkExists`, and `cli.linkManaged`
 - `cli.linkCommand`, `cli.unlinkCommand`, and `cli.repairHint`
 - direct MCP command/args and all Codex, Claude Code, and Cursor mode snippets
 - stable `permissions`, `knownLimitations`, and `nextActions`
@@ -200,6 +207,11 @@ client's configuration: Codex uses a TOML `[mcp_servers.crossgen]` block;
 Claude Code and Cursor use a JSON `mcpServers.crossgen` object. The desktop
 Agent access panel presents the same snippets and uses the current app
 executable; it never assumes `/Applications/CrossGen.app`.
+
+When CrossGen is running from the source tree, the generated `args` also include
+the repository app path before `--mcp`; this keeps copied MCP configuration
+usable with the Electron development runtime. Packaged installs keep the
+short direct form: `<CrossGen executable> --mcp`.
 
 Modes:
 

--- a/docs/cli-mcp.md
+++ b/docs/cli-mcp.md
@@ -2,6 +2,12 @@
 
 CrossGen exposes the same local app state to terminal workflows and MCP hosts. The CLI defaults to read-only inspection unless a command asks for explicit confirmation with `--yes`.
 
+The desktop app also exposes an **Agent access** section in the left sidebar.
+It shows the current CLI status, packaged launcher path, direct MCP executable,
+data/state paths, active provider, live queue workers, copyable diagnostics, and
+client-specific MCP configuration snippets. It never edits shell startup files
+or the system `PATH` automatically.
+
 ## Runtime
 
 Desktop use does not require CLI or MCP setup. Open the CrossGen app, configure
@@ -69,7 +75,30 @@ crossgen provider list --json
 crossgen models list --json
 ```
 
-`doctor --agent` reports readiness without disclosing saved API keys. `asset path` is the only command that returns a local absolute asset path, and it requires `--yes`.
+`doctor --agent` reports readiness without disclosing saved API keys. Its
+machine-readable `data` includes:
+
+- `runtimeKind`, `appExecutable`, `packagedExecutable`
+- `dataDir`, `statePath`, `stateFound`
+- `activeProvider`, `apiKeyAvailable`
+- `liveWorkerHost`, `liveWorkerHosts`, `queueConfig`
+- `cli.status`, `cli.commandPath`, `cli.launcherPath`, `cli.launcherExists`
+- `cli.linkCommand`, `cli.unlinkCommand`, and `cli.repairHint`
+- direct MCP command/args and all Codex, Claude Code, and Cursor mode snippets
+- stable `permissions`, `knownLimitations`, and `nextActions`
+
+CLI status values are explicit:
+
+- `ready`: `crossgen` resolves to the current packaged launcher.
+- `not-found`: no `crossgen` command is visible on the current process `PATH`.
+- `stale`: a `crossgen` link exists but points to a missing target.
+- `custom`: a `crossgen` command exists but points to another installation.
+- `launcher-missing`: the packaged app does not contain its launcher.
+- `development`: the current process is a source-tree/dev runtime.
+
+The status is diagnostic only. CrossGen suggests a repair command but does not
+modify shell files or inject a `PATH` entry. `asset path` is the only command
+that returns a local absolute asset path, and it requires `--yes`.
 
 ## Generate Flow
 
@@ -154,6 +183,8 @@ the current CrossGen executable and pass `--mcp`. Generate client configuration:
 crossgen mcp config --client codex --mode readonly --json
 crossgen mcp config --client codex --mode write --json
 crossgen mcp config --client codex --mode generate --json
+crossgen mcp config --client claude-code --mode readonly --json
+crossgen mcp config --client cursor --mode readonly --json
 ```
 
 The server process is started directly from the app executable:
@@ -161,6 +192,14 @@ The server process is started directly from the app executable:
 ```bash
 /path/to/CrossGen --mcp
 ```
+
+The generated object contains `client`, `mode`, `transport`, `command`, `args`,
+`env`, `format`, `config`, `snippet`, `permissions`, `supportedModes`, and an
+optional generate-mode warning. The `snippet` is ready to paste into the
+client's configuration: Codex uses a TOML `[mcp_servers.crossgen]` block;
+Claude Code and Cursor use a JSON `mcpServers.crossgen` object. The desktop
+Agent access panel presents the same snippets and uses the current app
+executable; it never assumes `/Applications/CrossGen.app`.
 
 Modes:
 

--- a/docs/release/v0.3.3-agent-access-evidence.md
+++ b/docs/release/v0.3.3-agent-access-evidence.md
@@ -15,6 +15,7 @@ This evidence covers the `v0.3.3` Agent Access and contract-stability work:
 - `doctor --agent` compatibility fields and extended diagnostics;
 - Codex / Claude Code / Cursor MCP configuration discovery;
 - copyable CLI/MCP commands and manual repair guidance;
+- explicit enable/disable for the user-level CLI link or Windows shim;
 - image-core regression protection.
 
 The image generation, edit, inpaint, Gallery, queue, and partial-streaming
@@ -68,6 +69,10 @@ The focused test evidence covers:
 - image generation, edit, Gallery, and queue regression suites.
 - direct packaged App executable and packaged no-Node launcher behavior on
   macOS arm64.
+- managed POSIX link and Windows shim create/remove behavior, including
+  refusal to overwrite unmanaged files.
+- development-runtime MCP config includes the Electron app path before
+  `--mcp`, so copied config works from the source tree as well as packaged apps.
 
 ## Release Gates Still Pending
 

--- a/docs/release/v0.3.3-agent-access-evidence.md
+++ b/docs/release/v0.3.3-agent-access-evidence.md
@@ -1,0 +1,84 @@
+# CrossGen v0.3.3 Agent Access Evidence
+
+> Status: development evidence draft. This file does not authorize a public
+> release or update-manifest promotion.
+>
+> Updated: 2026-08-20
+
+## Scope
+
+This evidence covers the `v0.3.3` Agent Access and contract-stability work:
+
+- desktop Agent Access panel;
+- CLI launcher, PATH, and moved-app diagnostics;
+- shared `AgentRuntimeStatus` contract;
+- `doctor --agent` compatibility fields and extended diagnostics;
+- Codex / Claude Code / Cursor MCP configuration discovery;
+- copyable CLI/MCP commands and manual repair guidance;
+- image-core regression protection.
+
+The image generation, edit, inpaint, Gallery, queue, and partial-streaming
+paths remain image-only and are not changed by this work.
+
+## Implemented Evidence
+
+| Area | Evidence |
+| --- | --- |
+| Agent runtime contract | `src/main/services/agentRuntime.ts` and `src/shared/types.ts` |
+| Desktop entry | `src/renderer/AgentAccessPanel.tsx`, `src/renderer/App.tsx` |
+| Electron bridge | `src/preload/preload.ts`, `app:getAgentRuntimeStatus` IPC |
+| CLI compatibility | `doctor --agent` keeps `cliExecutable`, `mcpCommand`, and `recommendedArgs` |
+| PATH diagnostics | `ready`, `not-found`, `stale`, `custom`, `launcher-missing`, `development` |
+| MCP clients | `codex`, `claude-code`, `cursor`; `readonly`, `write`, `generate` |
+| Documentation | `docs/cli-mcp.md`, `docs/KNOWN_LIMITATIONS.md` |
+
+## Commands Passed
+
+These commands passed on the development branch on 2026-08-20:
+
+```bash
+pnpm typecheck
+pnpm verify:cli-mcp-smoke
+pnpm verify:agent-integration-smoke
+pnpm verify:image-core-regression-smoke
+pnpm verify:release-evidence
+pnpm vitest run src/main/services/agentRuntime.test.ts src/renderer/App.smoke.test.tsx
+```
+
+The macOS arm64 unpacked candidate built at
+`release/mac-arm64/CrossGen.app` also passed the packaged smoke paths on
+2026-08-20:
+
+```bash
+CROSSGEN_APP_EXECUTABLE="$PWD/release/mac-arm64/CrossGen.app/Contents/MacOS/CrossGen" pnpm verify:cli-mcp-smoke
+CROSSGEN_APP_EXECUTABLE="$PWD/release/mac-arm64/CrossGen.app/Contents/MacOS/CrossGen" pnpm verify:agent-integration-smoke
+CROSSGEN_SMOKE_CLI_COMMAND="$PWD/release/mac-arm64/CrossGen.app/Contents/Resources/cli/crossgen" \
+CROSSGEN_SMOKE_MCP_COMMAND="$PWD/release/mac-arm64/CrossGen.app/Contents/Resources/cli/crossgen" \
+pnpm verify:agent-integration-smoke
+```
+
+The focused test evidence covers:
+
+- packaged launcher resolution and ready PATH links;
+- stale-link detection and manual repair command generation;
+- development-runtime behavior;
+- Agent Access panel discovery and copy actions;
+- legacy doctor fields and new runtime fields;
+- MCP mode permissions and confirmation semantics;
+- image generation, edit, Gallery, and queue regression suites.
+- direct packaged App executable and packaged no-Node launcher behavior on
+  macOS arm64.
+
+## Release Gates Still Pending
+
+This draft intentionally does not claim the following:
+
+1. an exact `v0.3.3` package has been built and installed (the current
+   candidate is still package version `0.3.2`);
+2. native Windows and Linux package smoke for the exact candidate;
+3. real provider acceptance for the exact candidate;
+4. product-owner approval;
+5. public release, GitHub Latest promotion, or update-manifest promotion.
+
+Those gates must be recorded against the exact candidate commit and package
+hash before changing the package version or publishing `v0.3.3`.

--- a/scripts/verify-agent-integration-smoke.mjs
+++ b/scripts/verify-agent-integration-smoke.mjs
@@ -240,6 +240,13 @@ async function verifyMcpConfig(dataDir) {
       assert(payload.data.transport === "stdio", "mcp config must use stdio transport.");
       assert(Array.isArray(payload.data.args) && payload.data.args.includes("--mcp"), "mcp config did not include --mcp args.");
       assert(payload.data.env?.CROSSGEN_MCP_MODE === mode, "mcp config did not set CROSSGEN_MCP_MODE.");
+      assert(payload.data.format === (client === "codex" ? "codex-toml" : "json"), `mcp config returned wrong format for ${client}.`);
+      assert(typeof payload.data.snippet === "string" && payload.data.snippet.includes("--mcp"), `mcp config ${client} ${mode} did not include a copyable snippet.`);
+      if (client === "codex") {
+        assert(payload.data.snippet.includes("[mcp_servers.crossgen]"), "Codex config snippet must be TOML.");
+      } else {
+        assert(payload.data.snippet.includes("\"mcpServers\""), `${client} config snippet must use mcpServers JSON.`);
+      }
       assert(JSON.stringify(payload.data.permissions) === JSON.stringify(expectedPermissions(mode)), `mcp config returned wrong permissions for ${mode}.`);
       assert(JSON.stringify(payload.data.supportedModes) === JSON.stringify(modes), "mcp config returned unexpected supportedModes.");
       if (mode === "generate") {
@@ -297,6 +304,12 @@ async function verifyMcpModeTools(dataDir) {
 async function verifyDoctor(dataDir) {
   const payload = await runCli(dataDir, ["doctor", "--agent", "--json"]);
   assertCliOk(payload, "doctor --agent");
+  assert(payload.data.schemaVersion === 1, "doctor did not report schemaVersion 1.");
+  assert(payload.data.cli?.commandName === "crossgen", "doctor did not report crossgen command name.");
+  assert(typeof payload.data.cli?.status === "string", "doctor did not report CLI status.");
+  assert(typeof payload.data.cli?.repairHint === "string", "doctor did not report CLI repairHint.");
+  assert(Array.isArray(payload.data.mcp?.configs) && payload.data.mcp.configs.length === clients.length * modes.length, "doctor did not report MCP configs for all clients and modes.");
+  assert(payload.data.commands?.doctor?.includes("doctor --agent --json"), "doctor did not report agent doctor command.");
   assert(payload.data.permissions?.mcpDefaultMode === "readonly", "doctor did not report readonly MCP default.");
   assert(payload.data.permissions?.paidGenerationRequiresConfirmation === true, "doctor did not report generation confirmation.");
   assert(payload.data.permissions?.pathDisclosureRequiresConfirmation === true, "doctor did not report path disclosure confirmation.");

--- a/scripts/verify-agent-integration-smoke.mjs
+++ b/scripts/verify-agent-integration-smoke.mjs
@@ -308,6 +308,7 @@ async function verifyDoctor(dataDir) {
   assert(payload.data.cli?.commandName === "crossgen", "doctor did not report crossgen command name.");
   assert(typeof payload.data.cli?.status === "string", "doctor did not report CLI status.");
   assert(typeof payload.data.cli?.repairHint === "string", "doctor did not report CLI repairHint.");
+  assert("linkPath" in payload.data.cli && "linkExists" in payload.data.cli && "linkManaged" in payload.data.cli, "doctor did not report managed CLI link state.");
   assert(Array.isArray(payload.data.mcp?.configs) && payload.data.mcp.configs.length === clients.length * modes.length, "doctor did not report MCP configs for all clients and modes.");
   assert(payload.data.commands?.doctor?.includes("doctor --agent --json"), "doctor did not report agent doctor command.");
   assert(payload.data.permissions?.mcpDefaultMode === "readonly", "doctor did not report readonly MCP default.");

--- a/scripts/verify-release-evidence.test.mjs
+++ b/scripts/verify-release-evidence.test.mjs
@@ -87,22 +87,20 @@ describe("release evidence verifier", () => {
     expect(result.stdout).not.toContain("Pending required gate(s):");
   });
 
-  it("validates the default v0.3.2 ledger with pending release gates", async () => {
+  it("validates the approved default v0.3.2 ledger", async () => {
     const result = await run([]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Release evidence validated:");
-    expect(result.stdout).toContain("Pending required gate(s):");
-    expect(result.stdout).toContain("product-owner-acceptance");
+    expect(result.stdout).toContain("Release evidence validated: 19/19 required gate(s) passed.");
+    expect(result.stdout).not.toContain("Pending required gate(s):");
   });
 
-  it("fails --require-complete for the pending v0.3.2 ledger", async () => {
+  it("passes --require-complete for the approved v0.3.2 ledger", async () => {
     const result = await run(["--require-complete"]);
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("Required release evidence gates are not passed");
-    expect(result.stderr).toContain("product-owner-acceptance");
-    expect(result.stderr).toContain("update-manifest-assets");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Release evidence validated: 19/19 required gate(s) passed.");
+    expect(result.stdout).not.toContain("Pending required gate(s):");
   });
 
   it("rejects v0.3.1 evidence as default evidence after the package version advances", async () => {

--- a/src/cli/readonly.test.ts
+++ b/src/cli/readonly.test.ts
@@ -380,4 +380,16 @@ describe("readonly CLI builders", () => {
       generateModeWarning: "Generate mode can submit image generation/edit requests. MCP generate hosts start queue execution and tools may pass waitMs for short completion waits."
     });
   });
+
+  it("preserves development runtime arguments in client-ready MCP config", () => {
+    const config = buildCliMcpConfig({
+      client: "cursor",
+      mode: "readonly",
+      command: "/opt/electron",
+      args: ["/workspace/image2tools", "--mcp"]
+    });
+
+    expect(config.args).toEqual(["/workspace/image2tools", "--mcp"]);
+    expect(config.snippet).toContain("\"args\": [\n        \"/workspace/image2tools\",\n        \"--mcp\"\n      ]");
+  });
 });

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -2,6 +2,8 @@ import { listProviderModelCapabilitySummaries } from "../core/modelCapabilities.
 import { DEFAULT_QUEUE_RUNTIME_CONFIG, normalizeQueueRuntimeConfig } from "../core/queueConfig.js";
 import { buildQueueSnapshot, buildQueueTaskSummary, type BuildQueueSnapshotOptions } from "../core/queueSnapshot.js";
 import type {
+  AgentMcpClientName,
+  AgentMcpMode,
   GalleryAsset,
   GalleryFolder,
   GenerationJob,
@@ -58,9 +60,9 @@ export interface CliGalleryListOptions {
   query?: string;
 }
 
-export type McpClientName = "codex" | "claude-code" | "cursor";
+export type McpClientName = AgentMcpClientName;
 
-export type McpMode = "readonly" | "write" | "generate";
+export type McpMode = AgentMcpMode;
 
 function activeProvider(state: ReadonlyAppState): ReadonlyProviderConfig | undefined {
   return state.providers.find((provider) => provider.id === state.activeProviderId) ?? state.providers[0];
@@ -461,6 +463,25 @@ export function buildCliAssetInspect(state: ReadonlyAppState | null, assetId: st
 export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMode; command: string }) {
   const args = ["--mcp"];
   const effectiveMode: McpMode = options.mode;
+  const server = {
+    command: options.command,
+    args,
+    env: {
+      CROSSGEN_MCP_MODE: effectiveMode
+    }
+  };
+  const clientConfig = options.client === "codex"
+    ? { mcp_servers: { crossgen: server } }
+    : { mcpServers: { crossgen: server } };
+  const format: "codex-toml" | "json" = options.client === "codex" ? "codex-toml" : "json";
+  const snippet = options.client === "codex"
+    ? [
+        "[mcp_servers.crossgen]",
+        `command = ${JSON.stringify(options.command)}`,
+        `args = [${args.map((arg) => JSON.stringify(arg)).join(", ")}]`,
+        `env = { CROSSGEN_MCP_MODE = ${JSON.stringify(effectiveMode)} }`
+      ].join("\n")
+    : JSON.stringify(clientConfig, null, 2);
   return {
     client: options.client,
     requestedMode: options.mode,
@@ -468,9 +489,10 @@ export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMod
     transport: "stdio",
     command: options.command,
     args,
-    env: {
-      CROSSGEN_MCP_MODE: effectiveMode
-    },
+    env: server.env,
+    format,
+    config: clientConfig,
+    snippet,
     permissions: {
       readonly: true,
       write: effectiveMode === "write" || effectiveMode === "generate",

--- a/src/cli/readonly.ts
+++ b/src/cli/readonly.ts
@@ -460,8 +460,8 @@ export function buildCliAssetInspect(state: ReadonlyAppState | null, assetId: st
   };
 }
 
-export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMode; command: string }) {
-  const args = ["--mcp"];
+export function buildCliMcpConfig(options: { client: McpClientName; mode: McpMode; command: string; args?: string[] }) {
+  const args = options.args?.length ? [...options.args] : ["--mcp"];
   const effectiveMode: McpMode = options.mode;
   const server = {
     command: options.command,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -153,7 +153,11 @@ import { fetchWithTimeout } from "./services/openaiImageAdapter.js";
 import { probeOpenAIImageRouting } from "./services/openaiImageRouting.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
-import { buildAgentRuntimeStatus } from "./services/agentRuntime.js";
+import {
+  buildAgentRuntimeStatus,
+  disableAgentCliLink,
+  enableAgentCliLink
+} from "./services/agentRuntime.js";
 import { buildProviderConfigForSave, providerDisplayName } from "./services/providerConfigSave.js";
 import { canRunRequestWithConfig } from "./services/providerRequestMatch.js";
 import { assertManagedRegularFile, assertManagedRegularFileInRoots, collectOwnedJobFilePaths, historyAssetReadRoots, normalizeManagedAssetPath, resolveManagedFileName } from "./services/assetOwnership.js";
@@ -1583,12 +1587,33 @@ async function handleGetAgentRuntimeStatus() {
           activeModelId: activeProvider.activeModelId
         }
       : null,
-    apiKeyAvailable: activeProvider ? envApiKeyAvailable(activeProvider.kind) || savedApiKeyPresentForCli(activeProvider) : false,
+    apiKeyAvailable: activeProvider ? envApiKeyAvailable(activeProvider.kind) || savedApiKeyAvailableForCli(activeProvider) : false,
     liveWorkerHosts: queue.workerHosts.filter((host) => Date.parse(host.leaseExpiresAt) > Date.now()).length,
     queueConfig: buildCliQueueConfig(state),
     envPath: process.env.PATH,
-    homeDir: homedir()
+    homeDir: homedir(),
+    appRuntimeArgs: app.isPackaged ? [] : [app.getAppPath()]
   });
+}
+
+async function handleEnableAgentCli(): Promise<Awaited<ReturnType<typeof handleGetAgentRuntimeStatus>>> {
+  const status = await handleGetAgentRuntimeStatus();
+  await enableAgentCliLink({
+    launcherPath: status.cli.launcherPath,
+    linkPath: status.cli.linkPath,
+    platform: process.platform
+  });
+  return handleGetAgentRuntimeStatus();
+}
+
+async function handleDisableAgentCli(): Promise<Awaited<ReturnType<typeof handleGetAgentRuntimeStatus>>> {
+  const status = await handleGetAgentRuntimeStatus();
+  await disableAgentCliLink({
+    launcherPath: status.cli.launcherPath,
+    linkPath: status.cli.linkPath,
+    platform: process.platform
+  });
+  return handleGetAgentRuntimeStatus();
 }
 
 function snapshotFromState(state: AppStateFile): AppSnapshot {
@@ -5418,8 +5443,12 @@ function envApiKeyAvailable(kind: StoredProviderConfig["kind"]): boolean {
   return getProviderEnvKeyNames(kind).some((name) => Boolean(process.env[name]?.trim()));
 }
 
-function savedApiKeyPresentForCli(config: StoredProviderConfig): boolean {
-  return Boolean(config.encryptedApiKey);
+function savedApiKeyAvailableForCli(config: StoredProviderConfig): boolean {
+  try {
+    return Boolean(decryptApiKey(config)?.trim());
+  } catch {
+    return false;
+  }
 }
 
 async function runCliCommandMode(args: string[]): Promise<number> {
@@ -5450,7 +5479,8 @@ async function runCliCommandMode(args: string[]): Promise<number> {
       const data = buildCliMcpConfig({
         client: normalizeCliMcpClient(getCliOption(args, "--client")),
         mode: normalizeCliMcpMode(getCliOption(args, "--mode")),
-        command: process.execPath
+        command: process.execPath,
+        args: [...(app.isPackaged ? [] : [app.getAppPath()]), "--mcp"]
       });
       writeCliJson(cliSuccess(requestId, correlationId, data));
       return 0;
@@ -5927,6 +5957,8 @@ async function runCliCommandMode(args: string[]): Promise<number> {
 function registerIpcHandlers(): void {
   ipcMain.handle("app:getSnapshot", () => runGalleryOperation(handleGetSnapshot));
   ipcMain.handle("app:getAgentRuntimeStatus", handleGetAgentRuntimeStatus);
+  ipcMain.handle("app:enableAgentCli", handleEnableAgentCli);
+  ipcMain.handle("app:disableAgentCli", handleDisableAgentCli);
   ipcMain.handle("config:save", handleSaveConfig);
   ipcMain.handle("provider:add", handleAddProvider);
   ipcMain.handle("provider:switch", handleSwitchProvider);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,6 +13,7 @@ import {
 import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, readFileSync, watch, type FSWatcher } from "node:fs";
 import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
@@ -152,6 +153,7 @@ import { fetchWithTimeout } from "./services/openaiImageAdapter.js";
 import { probeOpenAIImageRouting } from "./services/openaiImageRouting.js";
 import { getImageProviderAdapterForRequest, unsupportedImageProviderMessage } from "./services/imageProviderAdapters.js";
 import { discoverModelsAcrossProviders, sanitizeModelDiscoveryError } from "./services/modelDiscovery.js";
+import { buildAgentRuntimeStatus } from "./services/agentRuntime.js";
 import { buildProviderConfigForSave, providerDisplayName } from "./services/providerConfigSave.js";
 import { canRunRequestWithConfig } from "./services/providerRequestMatch.js";
 import { assertManagedRegularFile, assertManagedRegularFileInRoots, collectOwnedJobFilePaths, historyAssetReadRoots, normalizeManagedAssetPath, resolveManagedFileName } from "./services/assetOwnership.js";
@@ -1556,6 +1558,37 @@ async function handleGetSnapshot(): Promise<AppSnapshot> {
 
 async function handleGetQueueSnapshot(): Promise<QueueSnapshot> {
   return buildDesktopQueueSnapshot();
+}
+
+async function handleGetAgentRuntimeStatus() {
+  const state = await readExistingStateForCli();
+  const queue = await readExistingQueueForCli();
+  const activeProvider = state ? state.providers.find((provider) => provider.id === state.activeProviderId) ?? state.providers[0] : undefined;
+  return buildAgentRuntimeStatus({
+    appVersion: getAppVersion(),
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+    appExecutable: process.execPath,
+    resourcesPath: process.resourcesPath,
+    dataDir: app.getPath("userData"),
+    statePath: getStatePath(),
+    stateFound: Boolean(state),
+    activeProvider: activeProvider
+      ? {
+          id: activeProvider.id,
+          kind: activeProvider.kind,
+          name: activeProvider.name,
+          enabled: activeProvider.enabled,
+          activeLaunchId: activeProvider.activeLaunchId,
+          activeModelId: activeProvider.activeModelId
+        }
+      : null,
+    apiKeyAvailable: activeProvider ? envApiKeyAvailable(activeProvider.kind) || savedApiKeyPresentForCli(activeProvider) : false,
+    liveWorkerHosts: queue.workerHosts.filter((host) => Date.parse(host.leaseExpiresAt) > Date.now()).length,
+    queueConfig: buildCliQueueConfig(state),
+    envPath: process.env.PATH,
+    homeDir: homedir()
+  });
 }
 
 function snapshotFromState(state: AppStateFile): AppSnapshot {
@@ -5424,46 +5457,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
     }
 
     if (command === "doctor" && hasCliFlag(args, "--agent")) {
-      const state = await readExistingStateForCli();
-      const queueConfig = buildCliQueueConfig(state);
-      const activeProvider = state ? state.providers.find((provider) => provider.id === state.activeProviderId) ?? state.providers[0] : undefined;
-      const data = {
-        appVersion: getAppVersion(),
-        cliExecutable: process.execPath,
-        packagedExecutable: app.isPackaged ? process.execPath : null,
-        mcpCommand: process.execPath,
-        recommendedArgs: ["--mcp"],
-        dataDir: app.getPath("userData"),
-        statePath: getStatePath(),
-        stateFound: Boolean(state),
-        activeProvider: activeProvider
-          ? {
-              id: activeProvider.id,
-              kind: activeProvider.kind,
-              name: activeProvider.name,
-              enabled: activeProvider.enabled,
-              activeLaunchId: activeProvider.activeLaunchId,
-              activeModelId: activeProvider.activeModelId
-            }
-          : null,
-        apiKeyAvailable: activeProvider ? envApiKeyAvailable(activeProvider.kind) || savedApiKeyPresentForCli(activeProvider) : false,
-        liveWorkerHost: false,
-        queueConfig,
-        permissions: {
-          cliMode: "readonly",
-          mcpDefaultMode: "readonly",
-          writeModeRequiresExplicitEnable: true,
-          generateModeRequiresExplicitEnable: true,
-          paidGenerationRequiresConfirmation: true,
-          pathDisclosureRequiresConfirmation: true
-        },
-        knownLimitations: [
-          "CLI/MCP command mode currently exposes readonly discovery, queue inspection/cancellation, Gallery asset management, and generation/edit tools.",
-          "CLI --wait/default command mode can execute the queued job in the current process. MCP generate mode starts a background queue worker and supports waitMs.",
-          "Agent generation submit/edit tools require explicit confirmation because they may create paid provider requests when a worker executes them."
-        ]
-      };
-      writeCliJson(cliSuccess(requestId, correlationId, data));
+      writeCliJson(cliSuccess(requestId, correlationId, { ...await handleGetAgentRuntimeStatus() }));
       return 0;
     }
 
@@ -5932,6 +5926,7 @@ async function runCliCommandMode(args: string[]): Promise<number> {
 
 function registerIpcHandlers(): void {
   ipcMain.handle("app:getSnapshot", () => runGalleryOperation(handleGetSnapshot));
+  ipcMain.handle("app:getAgentRuntimeStatus", handleGetAgentRuntimeStatus);
   ipcMain.handle("config:save", handleSaveConfig);
   ipcMain.handle("provider:add", handleAddProvider);
   ipcMain.handle("provider:switch", handleSwitchProvider);

--- a/src/main/services/agentRuntime.test.ts
+++ b/src/main/services/agentRuntime.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { buildAgentRuntimeStatus } from "./agentRuntime.js";
+import { buildAgentRuntimeStatus, disableAgentCliLink, enableAgentCliLink } from "./agentRuntime.js";
 
 const queueConfig = {
   maxGlobalRunning: 1,
@@ -85,7 +85,8 @@ describe("agent runtime status", () => {
     const status = buildAgentRuntimeStatus(options(root, {
       isPackaged: false,
       envPath: "",
-      liveWorkerHosts: 0
+      liveWorkerHosts: 0,
+      appRuntimeArgs: [path.join(root, "app")]
     }));
 
     expect(status.runtimeKind).toBe("development");
@@ -93,6 +94,51 @@ describe("agent runtime status", () => {
     expect(status.cli.launcherPath).toBeNull();
     expect(status.liveWorkerHost).toBe(false);
     expect(status.nextActions.join("\n")).toContain("pnpm build:main");
+    expect(status.mcp.args).toEqual([path.join(root, "app"), "--mcp"]);
+    expect(status.commands.version).toContain(`'${path.join(root, "app")}' --cli`);
     expect(status.mcp.configs.find((config) => config.client === "cursor" && config.mode === "generate")?.snippet).toContain("--mcp");
+  });
+
+  it("creates and removes only a managed POSIX CLI link", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "crossgen-agent-link-"));
+    const launcher = path.join(root, "resources", "cli", "crossgen");
+    const link = path.join(root, "home", ".local", "bin", "crossgen");
+    await mkdir(path.dirname(launcher), { recursive: true });
+    await writeFile(launcher, "#!/bin/sh\n", { mode: 0o755 });
+
+    await enableAgentCliLink({ launcherPath: launcher, linkPath: link, platform: "darwin" });
+    expect((await lstat(link)).isSymbolicLink()).toBe(true);
+
+    await disableAgentCliLink({ launcherPath: launcher, linkPath: link, platform: "darwin" });
+    await expect(lstat(link)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("writes a marked Windows shim and refuses unmanaged files", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "crossgen-agent-link-"));
+    const appExecutable = path.join(root, "CrossGen.exe");
+    const launcher = path.join(root, "resources", "cli", "crossgen.cmd");
+    const homeDir = path.join(root, "home");
+    const link = path.join(homeDir, "AppData", "Local", "CrossGen", "bin", "crossgen.cmd");
+    await mkdir(path.dirname(launcher), { recursive: true });
+    await writeFile(appExecutable, "binary");
+    await writeFile(launcher, "@echo off\r\n");
+
+    await enableAgentCliLink({ launcherPath: launcher, linkPath: link, platform: "win32" });
+    expect(await readFile(link, "utf8")).toContain("CrossGen managed CLI shim v1");
+    const status = buildAgentRuntimeStatus(options(root, {
+      platform: "win32",
+      appExecutable,
+      resourcesPath: path.join(root, "resources"),
+      envPath: path.dirname(link),
+      homeDir
+    }));
+    expect(status.cli.linkExists).toBe(true);
+    expect(status.cli.linkManaged).toBe(true);
+    await disableAgentCliLink({ launcherPath: launcher, linkPath: link, platform: "win32" });
+    await expect(lstat(link)).rejects.toMatchObject({ code: "ENOENT" });
+
+    await mkdir(path.dirname(link), { recursive: true });
+    await writeFile(link, "custom");
+    await expect(enableAgentCliLink({ launcherPath: launcher, linkPath: link, platform: "win32" })).rejects.toThrow("refusing to overwrite");
   });
 });

--- a/src/main/services/agentRuntime.test.ts
+++ b/src/main/services/agentRuntime.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildAgentRuntimeStatus } from "./agentRuntime.js";
+
+const queueConfig = {
+  maxGlobalRunning: 1,
+  providerConcurrency: {}
+};
+
+function options(root: string, patch: Record<string, unknown> = {}) {
+  const resourcesPath = path.join(root, "resources");
+  return {
+    appVersion: "0.3.3",
+    isPackaged: true,
+    platform: "darwin" as NodeJS.Platform,
+    appExecutable: path.join(root, "CrossGen.app", "Contents", "MacOS", "CrossGen"),
+    resourcesPath,
+    dataDir: path.join(root, "data"),
+    statePath: path.join(root, "data", "image2tools-state.v1.json"),
+    stateFound: true,
+    activeProvider: {
+      id: "provider-1",
+      kind: "openai" as const,
+      name: "OpenAI",
+      enabled: true,
+      activeLaunchId: "gpt-image-2" as const,
+      activeModelId: "gpt-image-2"
+    },
+    apiKeyAvailable: true,
+    liveWorkerHosts: 1,
+    queueConfig,
+    envPath: "",
+    homeDir: path.join(root, "home"),
+    ...patch
+  };
+}
+
+describe("agent runtime status", () => {
+  it("reports a packaged launcher and a ready PATH link", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "crossgen-agent-runtime-"));
+    const launcher = path.join(root, "resources", "cli", "crossgen");
+    const link = path.join(root, "home", ".local", "bin", "crossgen");
+    await mkdir(path.dirname(launcher), { recursive: true });
+    await mkdir(path.dirname(link), { recursive: true });
+    await writeFile(launcher, "#!/bin/sh\n", { mode: 0o755 });
+    await symlink(launcher, link);
+
+    const status = buildAgentRuntimeStatus(options(root, { envPath: path.dirname(link) }));
+
+    expect(status.runtimeKind).toBe("packaged");
+    expect(status.cli.status).toBe("ready");
+    expect(status.cli.commandPath).toBe(link);
+    expect(status.cli.commandTarget).toBe(launcher);
+    expect(status.cli.launcherExists).toBe(true);
+    expect(status.mcp.args).toEqual(["--mcp"]);
+    expect(status.mcp.configs).toHaveLength(9);
+    expect(status.mcp.configs.find((config) => config.client === "codex")?.format).toBe("codex-toml");
+    expect(status.mcp.configs.find((config) => config.client === "codex")?.snippet).toContain("[mcp_servers.crossgen]");
+    expect(status.mcp.configs.find((config) => config.client === "cursor")?.snippet).toContain("\"mcpServers\"");
+    expect(status.queueConfig.maxGlobalRunning).toBe(1);
+    expect(status.nextActions.length).toBeGreaterThan(0);
+  });
+
+  it("reports a stale link and emits a manual repair command without touching PATH", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "crossgen-agent-runtime-"));
+    const launcher = path.join(root, "resources", "cli", "crossgen");
+    const link = path.join(root, "home", ".local", "bin", "crossgen");
+    await mkdir(path.dirname(launcher), { recursive: true });
+    await mkdir(path.dirname(link), { recursive: true });
+    await writeFile(launcher, "#!/bin/sh\n", { mode: 0o755 });
+    await symlink(path.join(root, "missing", "crossgen"), link);
+
+    const status = buildAgentRuntimeStatus(options(root, { envPath: path.dirname(link) }));
+
+    expect(status.cli.status).toBe("stale");
+    expect(status.cli.linkCommand).toContain("ln -sfn");
+    expect(status.cli.linkCommand).toContain(launcher);
+    expect(status.cli.repairHint).toContain("broken link");
+  });
+
+  it("keeps development mode explicit and still exposes direct MCP configuration", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "crossgen-agent-runtime-"));
+    const status = buildAgentRuntimeStatus(options(root, {
+      isPackaged: false,
+      envPath: "",
+      liveWorkerHosts: 0
+    }));
+
+    expect(status.runtimeKind).toBe("development");
+    expect(status.cli.status).toBe("development");
+    expect(status.cli.launcherPath).toBeNull();
+    expect(status.liveWorkerHost).toBe(false);
+    expect(status.nextActions.join("\n")).toContain("pnpm build:main");
+    expect(status.mcp.configs.find((config) => config.client === "cursor" && config.mode === "generate")?.snippet).toContain("--mcp");
+  });
+});

--- a/src/main/services/agentRuntime.ts
+++ b/src/main/services/agentRuntime.ts
@@ -1,0 +1,287 @@
+import { accessSync, constants, existsSync, lstatSync, readlinkSync, realpathSync } from "node:fs";
+import path from "node:path";
+import type {
+  AgentActiveProviderStatus,
+  AgentCliCommandStatus,
+  AgentMcpClientName,
+  AgentMcpMode,
+  AgentRuntimeStatus
+} from "../../shared/types.js";
+import { buildCliMcpConfig, buildCliQueueConfig } from "../../cli/readonly.js";
+
+interface BuildAgentRuntimeStatusOptions {
+  appVersion: string;
+  isPackaged: boolean;
+  platform: NodeJS.Platform;
+  appExecutable: string;
+  resourcesPath: string;
+  dataDir: string;
+  statePath: string;
+  stateFound: boolean;
+  activeProvider: AgentActiveProviderStatus | null;
+  apiKeyAvailable: boolean;
+  liveWorkerHosts: number;
+  queueConfig: ReturnType<typeof buildCliQueueConfig>;
+  envPath?: string;
+  homeDir?: string;
+}
+
+interface PathCommandCandidate {
+  path: string;
+  target: string | null;
+  broken: boolean;
+}
+
+const MCP_CLIENTS: AgentMcpClientName[] = ["codex", "claude-code", "cursor"];
+const MCP_MODES: AgentMcpMode[] = ["readonly", "write", "generate"];
+
+export function buildAgentRuntimeStatus(options: BuildAgentRuntimeStatusOptions): AgentRuntimeStatus {
+  const runtimeKind = options.isPackaged ? "packaged" : "development";
+  const launcherPath = runtimeKind === "packaged" ? packagedCliLauncherPath(options.resourcesPath, options.platform) : null;
+  const launcherExists = Boolean(launcherPath && fileExecutable(launcherPath, options.platform));
+  const pathEntries = pathEntriesFromEnv(options.envPath);
+  const commandCandidate = findCrossgenOnPath(pathEntries, options.platform);
+  const status = resolveCliStatus({
+    runtimeKind,
+    commandCandidate,
+    launcherPath,
+    launcherExists,
+    platform: options.platform
+  });
+  const cliPrefix = preferredCliPrefix({
+    status,
+    commandCandidate,
+    launcherPath,
+    launcherExists,
+    appExecutable: options.appExecutable,
+    platform: options.platform
+  });
+  const linkCommand = buildLinkCommand(launcherPath, options.homeDir, options.platform);
+  const unlinkCommand = buildUnlinkCommand(options.homeDir, options.platform);
+  const repairHint = cliRepairHint(status);
+
+  return {
+    schemaVersion: 1,
+    appVersion: options.appVersion,
+    runtimeKind,
+    cliExecutable: options.appExecutable,
+    mcpCommand: options.appExecutable,
+    recommendedArgs: ["--mcp"],
+    appExecutable: options.appExecutable,
+    packagedExecutable: options.isPackaged ? options.appExecutable : null,
+    dataDir: options.dataDir,
+    statePath: options.statePath,
+    stateFound: options.stateFound,
+    activeProvider: options.activeProvider,
+    apiKeyAvailable: options.apiKeyAvailable,
+    liveWorkerHost: options.liveWorkerHosts > 0,
+    liveWorkerHosts: options.liveWorkerHosts,
+    queueConfig: options.queueConfig,
+    cli: {
+      commandName: "crossgen",
+      status,
+      commandPath: commandCandidate?.path ?? null,
+      commandTarget: commandCandidate?.target ?? null,
+      launcherPath,
+      launcherExists,
+      pathEntryCount: pathEntries.length,
+      linkCommand,
+      unlinkCommand,
+      repairHint
+    },
+    mcp: {
+      command: options.appExecutable,
+      args: ["--mcp"],
+      defaultMode: "readonly",
+      configs: MCP_CLIENTS.flatMap((client) =>
+        MCP_MODES.map((mode) => {
+          const config = buildCliMcpConfig({ client, mode, command: options.appExecutable });
+          return {
+            client,
+            mode,
+            format: config.format,
+            json: JSON.stringify(config, null, 2),
+            snippet: config.snippet
+          };
+        })
+      )
+    },
+    commands: {
+      version: `${cliPrefix} --version --json`,
+      doctor: `${cliPrefix} doctor --agent --json`,
+      configStatus: `${cliPrefix} config status --json`,
+      modelsList: `${cliPrefix} models list --json`,
+      queueStatus: `${cliPrefix} queue status --json`,
+      mcpCodexReadonly: `${cliPrefix} mcp config --client codex --mode readonly --json`,
+      mcpCodexGenerate: `${cliPrefix} mcp config --client codex --mode generate --json`
+    },
+    permissions: {
+      cliMode: "readonly",
+      mcpDefaultMode: "readonly",
+      writeModeRequiresExplicitEnable: true,
+      generateModeRequiresExplicitEnable: true,
+      paidGenerationRequiresConfirmation: true,
+      pathDisclosureRequiresConfirmation: true
+    },
+    knownLimitations: [
+      "MCP hosts should call the current CrossGen app executable directly with --mcp; they do not need the CLI link.",
+      "The packaged CLI launcher does not require Node.js, npm, pnpm, or a global package.",
+      "PATH detection only reports the environment visible to the current CrossGen process.",
+      "Async generation requires a live worker host: the desktop app, MCP generate mode, or a waiting CLI worker.",
+      "Without a live worker, queued async generation returns NO_LIVE_QUEUE_WORKER instead of pretending it will continue in the background.",
+      "CLI --wait executes the queued job in the current process; MCP generate mode can keep a worker alive and supports short waitMs completion waits.",
+      "Generate mode can submit paid provider requests and requires explicit confirmation."
+    ],
+    nextActions: nextActionsForStatus(status)
+  };
+}
+
+function packagedCliLauncherPath(resourcesPath: string, platform: NodeJS.Platform): string {
+  return path.join(resourcesPath, "cli", platform === "win32" ? "crossgen.cmd" : "crossgen");
+}
+
+function pathEntriesFromEnv(envPath = ""): string[] {
+  return envPath.split(path.delimiter).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function executableNames(platform: NodeJS.Platform): string[] {
+  return platform === "win32" ? ["crossgen.cmd", "crossgen.exe", "crossgen"] : ["crossgen"];
+}
+
+function findCrossgenOnPath(pathEntries: string[], platform: NodeJS.Platform): PathCommandCandidate | null {
+  for (const directory of pathEntries) {
+    for (const name of executableNames(platform)) {
+      const candidate = path.join(directory, name);
+      const inspected = inspectPathCommand(candidate, platform);
+      if (inspected) return inspected;
+    }
+  }
+  return null;
+}
+
+function inspectPathCommand(candidate: string, platform: NodeJS.Platform): PathCommandCandidate | null {
+  try {
+    const stats = lstatSync(candidate);
+    if (stats.isSymbolicLink()) {
+      const rawTarget = readlinkSync(candidate);
+      const target = path.isAbsolute(rawTarget) ? rawTarget : path.resolve(path.dirname(candidate), rawTarget);
+      return { path: candidate, target, broken: !existsSync(target) };
+    }
+    if (!fileExecutable(candidate, platform)) return null;
+    return { path: candidate, target: candidate, broken: false };
+  } catch {
+    return null;
+  }
+}
+
+function fileExecutable(filePath: string, platform: NodeJS.Platform): boolean {
+  try {
+    accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveCliStatus(input: {
+  runtimeKind: AgentRuntimeStatus["runtimeKind"];
+  commandCandidate: PathCommandCandidate | null;
+  launcherPath: string | null;
+  launcherExists: boolean;
+  platform: NodeJS.Platform;
+}): AgentCliCommandStatus {
+  if (input.runtimeKind === "development") return "development";
+  if (!input.launcherExists) return "launcher-missing";
+  if (!input.commandCandidate) return "not-found";
+  if (input.commandCandidate.broken) return "stale";
+  if (input.launcherPath && sameFile(input.commandCandidate.target ?? input.commandCandidate.path, input.launcherPath, input.platform)) {
+    return "ready";
+  }
+  return "custom";
+}
+
+function sameFile(left: string, right: string, platform: NodeJS.Platform): boolean {
+  const leftResolved = realPathOrSelf(left);
+  const rightResolved = realPathOrSelf(right);
+  return normalizePathForCompare(leftResolved, platform) === normalizePathForCompare(rightResolved, platform);
+}
+
+function realPathOrSelf(filePath: string): string {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+function normalizePathForCompare(filePath: string, platform: NodeJS.Platform): string {
+  const normalized = path.normalize(filePath);
+  return platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function preferredCliPrefix(input: {
+  status: AgentCliCommandStatus;
+  commandCandidate: PathCommandCandidate | null;
+  launcherPath: string | null;
+  launcherExists: boolean;
+  appExecutable: string;
+  platform: NodeJS.Platform;
+}): string {
+  if (input.status === "ready") return "crossgen";
+  if (input.launcherPath && input.launcherExists) return quoteShellArg(input.launcherPath, input.platform);
+  return `${quoteShellArg(input.appExecutable, input.platform)} --cli`;
+}
+
+function buildLinkCommand(launcherPath: string | null, homeDir: string | undefined, platform: NodeJS.Platform): string | null {
+  if (!launcherPath || platform === "win32") return null;
+  const target = homeDir ? path.join(homeDir, ".local", "bin", "crossgen") : "~/.local/bin/crossgen";
+  return `mkdir -p ${quoteShellArg(path.dirname(target), platform)} && ln -sfn ${quoteShellArg(launcherPath, platform)} ${quoteShellArg(target, platform)}`;
+}
+
+function buildUnlinkCommand(homeDir: string | undefined, platform: NodeJS.Platform): string | null {
+  if (platform === "win32") return null;
+  const target = homeDir ? path.join(homeDir, ".local", "bin", "crossgen") : "~/.local/bin/crossgen";
+  return `rm ${quoteShellArg(target, platform)}`;
+}
+
+function quoteShellArg(value: string, platform: NodeJS.Platform): string {
+  if (platform === "win32") return `"${value.replace(/"/g, '\\"')}"`;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function cliRepairHint(status: AgentCliCommandStatus): string {
+  switch (status) {
+    case "ready":
+      return "`crossgen` resolves to the packaged launcher for this CrossGen install.";
+    case "development":
+      return "Development runtime detected. Use the app executable with --cli, or build/package before validating the no-Node launcher.";
+    case "launcher-missing":
+      return "The packaged CLI launcher was not found in the current app resources.";
+    case "not-found":
+      return "`crossgen` was not found on PATH. MCP can still call the app executable directly.";
+    case "stale":
+      return "`crossgen` appears to be a broken link. Recreate it from the current app location.";
+    case "custom":
+      return "`crossgen` exists on PATH but does not point to the current packaged launcher.";
+  }
+}
+
+function nextActionsForStatus(status: AgentCliCommandStatus): string[] {
+  const common = [
+    "Use the MCP config command for the target agent client and selected permission mode.",
+    "Use generate mode only when the agent should be allowed to submit paid image work."
+  ];
+  if (status === "ready" || status === "custom") return common;
+  if (status === "development") {
+    return [
+      "Run pnpm build:main before using the repository CLI wrapper in development.",
+      "Validate packaged no-Node CLI behavior from a packaged candidate before release.",
+      ...common
+    ];
+  }
+  return [
+    "Copy the repair command if you want a global `crossgen` shell command.",
+    "MCP setup can skip PATH and call the current app executable directly with --mcp.",
+    ...common
+  ];
+}

--- a/src/main/services/agentRuntime.ts
+++ b/src/main/services/agentRuntime.ts
@@ -1,4 +1,5 @@
-import { accessSync, constants, existsSync, lstatSync, readlinkSync, realpathSync } from "node:fs";
+import { accessSync, constants, existsSync, lstatSync, readFileSync, readlinkSync, realpathSync } from "node:fs";
+import { promises as fs } from "node:fs";
 import path from "node:path";
 import type {
   AgentActiveProviderStatus,
@@ -24,12 +25,14 @@ interface BuildAgentRuntimeStatusOptions {
   queueConfig: ReturnType<typeof buildCliQueueConfig>;
   envPath?: string;
   homeDir?: string;
+  appRuntimeArgs?: string[];
 }
 
 interface PathCommandCandidate {
   path: string;
   target: string | null;
   broken: boolean;
+  managed: boolean;
 }
 
 const MCP_CLIENTS: AgentMcpClientName[] = ["codex", "claude-code", "cursor"];
@@ -54,11 +57,28 @@ export function buildAgentRuntimeStatus(options: BuildAgentRuntimeStatusOptions)
     launcherPath,
     launcherExists,
     appExecutable: options.appExecutable,
-    platform: options.platform
+    platform: options.platform,
+    runtimeArgs: options.appRuntimeArgs
   });
   const linkCommand = buildLinkCommand(launcherPath, options.homeDir, options.platform);
   const unlinkCommand = buildUnlinkCommand(options.homeDir, options.platform);
   const repairHint = cliRepairHint(status);
+  const appRuntimeArgs = options.appRuntimeArgs?.filter((arg) => arg.trim()) ?? [];
+  const mcpArgs = [...appRuntimeArgs, "--mcp"];
+  const linkPath = agentCliLinkPath(options.homeDir, options.platform);
+  const managedLinkCandidate = linkPath ? inspectPathCommand(linkPath, options.platform) : null;
+  const linkExists = Boolean(managedLinkCandidate);
+  const linkManaged = Boolean(
+    linkPath &&
+      launcherPath &&
+      managedLinkCandidate &&
+      !managedLinkCandidate.broken &&
+      (options.platform === "win32"
+        ? managedLinkCandidate.managed &&
+          Boolean(managedLinkCandidate.target) &&
+          sameFile(managedLinkCandidate.target ?? "", launcherPath ?? "", options.platform)
+        : sameFile(managedLinkCandidate.target ?? managedLinkCandidate.path, launcherPath ?? "", options.platform))
+  );
 
   return {
     schemaVersion: 1,
@@ -84,6 +104,9 @@ export function buildAgentRuntimeStatus(options: BuildAgentRuntimeStatusOptions)
       commandTarget: commandCandidate?.target ?? null,
       launcherPath,
       launcherExists,
+      linkPath,
+      linkExists,
+      linkManaged,
       pathEntryCount: pathEntries.length,
       linkCommand,
       unlinkCommand,
@@ -91,11 +114,11 @@ export function buildAgentRuntimeStatus(options: BuildAgentRuntimeStatusOptions)
     },
     mcp: {
       command: options.appExecutable,
-      args: ["--mcp"],
+      args: mcpArgs,
       defaultMode: "readonly",
       configs: MCP_CLIENTS.flatMap((client) =>
         MCP_MODES.map((mode) => {
-          const config = buildCliMcpConfig({ client, mode, command: options.appExecutable });
+          const config = buildCliMcpConfig({ client, mode, command: options.appExecutable, args: mcpArgs });
           return {
             client,
             mode,
@@ -136,6 +159,120 @@ export function buildAgentRuntimeStatus(options: BuildAgentRuntimeStatusOptions)
   };
 }
 
+export function agentCliLinkPath(homeDir: string | undefined, platform: NodeJS.Platform): string | null {
+  if (!homeDir) return null;
+  return platform === "win32"
+    ? path.join(homeDir, "AppData", "Local", "CrossGen", "bin", "crossgen.cmd")
+    : path.join(homeDir, ".local", "bin", "crossgen");
+}
+
+export async function enableAgentCliLink(options: {
+  launcherPath: string | null;
+  linkPath: string | null;
+  platform: NodeJS.Platform;
+}): Promise<void> {
+  if (!options.launcherPath || !options.linkPath) {
+    throw new Error("The packaged CrossGen CLI launcher is not available.");
+  }
+
+  await fs.mkdir(path.dirname(options.linkPath), { recursive: true });
+  if (options.platform === "win32") {
+    const existing = await fs.readFile(options.linkPath, "utf8").catch((error: unknown) => {
+      if (isFileNotFoundError(error)) return null;
+      throw error;
+    });
+    if (existing !== null && !isManagedWindowsShim(existing)) {
+      throw new Error(`CrossGen CLI link already exists at ${options.linkPath}; refusing to overwrite it.`);
+    }
+    await fs.writeFile(options.linkPath, windowsShimContent(options.launcherPath), "utf8");
+    return;
+  }
+
+  const existing = await fs.lstat(options.linkPath).catch((error: unknown) => {
+    if (isFileNotFoundError(error)) return null;
+    throw error;
+  });
+  if (existing) {
+    if (existing.isSymbolicLink()) {
+      const rawTarget = await fs.readlink(options.linkPath);
+      const target = path.isAbsolute(rawTarget) ? rawTarget : path.resolve(path.dirname(options.linkPath), rawTarget);
+      if (sameFile(target, options.launcherPath, options.platform)) return;
+      if (!existsSync(target)) {
+        await fs.unlink(options.linkPath);
+        await fs.symlink(options.launcherPath, options.linkPath, "file");
+        return;
+      }
+    }
+    throw new Error(`CrossGen CLI link already exists at ${options.linkPath}; refusing to overwrite it.`);
+  }
+  await fs.symlink(options.launcherPath, options.linkPath, "file");
+}
+
+export async function disableAgentCliLink(options: {
+  launcherPath: string | null;
+  linkPath: string | null;
+  platform: NodeJS.Platform;
+}): Promise<void> {
+  if (!options.linkPath) return;
+
+  if (options.platform === "win32") {
+    const existing = await fs.readFile(options.linkPath, "utf8").catch((error: unknown) => {
+      if (isFileNotFoundError(error)) return null;
+      throw error;
+    });
+    if (existing === null) return;
+    if (!isManagedWindowsShim(existing)) {
+      throw new Error(`The file at ${options.linkPath} is not a CrossGen-managed CLI shim.`);
+    }
+    const target = windowsShimTarget(existing);
+    if (options.launcherPath && target && !sameFile(target, options.launcherPath, options.platform)) {
+      throw new Error(`The CLI shim at ${options.linkPath} does not point to this CrossGen installation.`);
+    }
+    await fs.unlink(options.linkPath);
+    return;
+  }
+
+  const existing = await fs.lstat(options.linkPath).catch((error: unknown) => {
+    if (isFileNotFoundError(error)) return null;
+    throw error;
+  });
+  if (!existing) return;
+  if (!existing.isSymbolicLink()) {
+    throw new Error(`The file at ${options.linkPath} is not a CrossGen-managed CLI link.`);
+  }
+  const rawTarget = await fs.readlink(options.linkPath);
+  const target = path.isAbsolute(rawTarget) ? rawTarget : path.resolve(path.dirname(options.linkPath), rawTarget);
+  if (!options.launcherPath || !sameFile(target, options.launcherPath, options.platform)) {
+    throw new Error(`The CLI link at ${options.linkPath} does not point to this CrossGen installation.`);
+  }
+  await fs.unlink(options.linkPath);
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && (error as { code?: unknown }).code === "ENOENT");
+}
+
+function isManagedWindowsShim(content: string): boolean {
+  return content.includes("CrossGen managed CLI shim v1");
+}
+
+function windowsShimTarget(content: string): string | null {
+  const match = /^set "CROSSGEN_LAUNCHER=(.*)"$/m.exec(content);
+  return match ? match[1].replace(/%%/g, "%") : null;
+}
+
+function windowsShimContent(launcherPath: string): string {
+  const escapedLauncherPath = launcherPath.replace(/%/g, "%%").replace(/"/g, "\"\"");
+  return [
+    "@echo off",
+    "rem CrossGen managed CLI shim v1",
+    `set "CROSSGEN_LAUNCHER=${escapedLauncherPath}"`,
+    "\"%CROSSGEN_LAUNCHER%\" %*",
+    "exit /b %ERRORLEVEL%",
+    ""
+  ].join("\r\n");
+}
+
 function packagedCliLauncherPath(resourcesPath: string, platform: NodeJS.Platform): string {
   return path.join(resourcesPath, "cli", platform === "win32" ? "crossgen.cmd" : "crossgen");
 }
@@ -165,12 +302,26 @@ function inspectPathCommand(candidate: string, platform: NodeJS.Platform): PathC
     if (stats.isSymbolicLink()) {
       const rawTarget = readlinkSync(candidate);
       const target = path.isAbsolute(rawTarget) ? rawTarget : path.resolve(path.dirname(candidate), rawTarget);
-      return { path: candidate, target, broken: !existsSync(target) };
+      return { path: candidate, target, broken: !existsSync(target), managed: false };
     }
     if (!fileExecutable(candidate, platform)) return null;
-    return { path: candidate, target: candidate, broken: false };
+    const managed = platform === "win32" && isManagedWindowsShimFile(candidate);
+    return {
+      path: candidate,
+      target: managed ? windowsShimTarget(readFileSync(candidate, "utf8")) ?? candidate : candidate,
+      broken: false,
+      managed
+    };
   } catch {
     return null;
+  }
+}
+
+function isManagedWindowsShimFile(filePath: string): boolean {
+  try {
+    return isManagedWindowsShim(readFileSync(filePath, "utf8"));
+  } catch {
+    return false;
   }
 }
 
@@ -226,21 +377,26 @@ function preferredCliPrefix(input: {
   launcherExists: boolean;
   appExecutable: string;
   platform: NodeJS.Platform;
+  runtimeArgs?: string[];
 }): string {
   if (input.status === "ready") return "crossgen";
   if (input.launcherPath && input.launcherExists) return quoteShellArg(input.launcherPath, input.platform);
-  return `${quoteShellArg(input.appExecutable, input.platform)} --cli`;
+  return [
+    quoteShellArg(input.appExecutable, input.platform),
+    ...(input.runtimeArgs ?? []).map((arg) => quoteShellArg(arg, input.platform)),
+    "--cli"
+  ].join(" ");
 }
 
 function buildLinkCommand(launcherPath: string | null, homeDir: string | undefined, platform: NodeJS.Platform): string | null {
   if (!launcherPath || platform === "win32") return null;
-  const target = homeDir ? path.join(homeDir, ".local", "bin", "crossgen") : "~/.local/bin/crossgen";
+  const target = agentCliLinkPath(homeDir, platform) ?? "~/.local/bin/crossgen";
   return `mkdir -p ${quoteShellArg(path.dirname(target), platform)} && ln -sfn ${quoteShellArg(launcherPath, platform)} ${quoteShellArg(target, platform)}`;
 }
 
 function buildUnlinkCommand(homeDir: string | undefined, platform: NodeJS.Platform): string | null {
   if (platform === "win32") return null;
-  const target = homeDir ? path.join(homeDir, ".local", "bin", "crossgen") : "~/.local/bin/crossgen";
+  const target = agentCliLinkPath(homeDir, platform) ?? "~/.local/bin/crossgen";
   return `rm ${quoteShellArg(target, platform)}`;
 }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type {
   AppBridge,
   AppSnapshot,
+  AgentRuntimeStatus,
   DownloadRequest,
   EditedImageDownloadRequest,
   EditedGalleryImageInput,
@@ -19,6 +20,7 @@ import type {
 
 const bridge: AppBridge = {
   getSnapshot: () => ipcRenderer.invoke("app:getSnapshot"),
+  getAgentRuntimeStatus: () => ipcRenderer.invoke("app:getAgentRuntimeStatus") as Promise<AgentRuntimeStatus>,
   saveConfig: (input: ProviderConfigInput) => ipcRenderer.invoke("config:save", input),
   addProvider: (input: ProviderConfigInput) => ipcRenderer.invoke("provider:add", input),
   switchProvider: (providerId: string) => ipcRenderer.invoke("provider:switch", providerId),

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -21,6 +21,8 @@ import type {
 const bridge: AppBridge = {
   getSnapshot: () => ipcRenderer.invoke("app:getSnapshot"),
   getAgentRuntimeStatus: () => ipcRenderer.invoke("app:getAgentRuntimeStatus") as Promise<AgentRuntimeStatus>,
+  enableAgentCli: () => ipcRenderer.invoke("app:enableAgentCli") as Promise<AgentRuntimeStatus>,
+  disableAgentCli: () => ipcRenderer.invoke("app:disableAgentCli") as Promise<AgentRuntimeStatus>,
   saveConfig: (input: ProviderConfigInput) => ipcRenderer.invoke("config:save", input),
   addProvider: (input: ProviderConfigInput) => ipcRenderer.invoke("provider:add", input),
   switchProvider: (providerId: string) => ipcRenderer.invoke("provider:switch", providerId),

--- a/src/renderer/AgentAccessPanel.tsx
+++ b/src/renderer/AgentAccessPanel.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Clipboard, ExternalLink, KeyRound, Loader2, Wrench, X } from "lucide-react";
+import { CheckCircle2, Clipboard, ExternalLink, KeyRound, Link2, Loader2, Unlink2, Wrench, X } from "lucide-react";
 import type { AgentRuntimeStatus } from "../shared/types";
 import type { UiCopy } from "./i18n";
 
@@ -6,8 +6,11 @@ interface AgentAccessPanelProps {
   copy: UiCopy;
   status: AgentRuntimeStatus | null;
   loading: boolean;
+  cliActionLoading: boolean;
   onClose: () => void;
   onCopy: (value: string) => void;
+  onEnableCli: () => void;
+  onDisableCli: () => void;
 }
 
 function valueOrFallback(value: string | null | undefined): string {
@@ -39,7 +42,7 @@ export function AgentAccessSection({ copy, status, loading, onOpen }: { copy: Ui
   );
 }
 
-export function AgentAccessDialog({ copy, status, loading, onClose, onCopy }: AgentAccessPanelProps) {
+export function AgentAccessDialog({ copy, status, loading, cliActionLoading, onClose, onCopy, onEnableCli, onDisableCli }: AgentAccessPanelProps) {
   const copyValue = (value: string | null | undefined) => {
     if (value) onCopy(value);
   };
@@ -105,7 +108,31 @@ export function AgentAccessDialog({ copy, status, loading, onClose, onCopy }: Ag
               <span>{copy.agentAccessState}</span>
               <code title={status.statePath}>{status.statePath}</code>
             </div>
+            <div className="agent-access-path-row">
+              <span>{copy.agentAccessCliLinkPath}</span>
+              <code title={status.cli.linkPath ?? undefined}>{valueOrFallback(status.cli.linkPath)}</code>
+            </div>
           </div>
+
+          {status.runtimeKind === "packaged" && status.cli.launcherExists && (
+            <section className="agent-access-cli-toggle">
+              <div>
+                <h3>{copy.agentAccessCliToggleTitle}</h3>
+                <p className="muted">{copy.agentAccessCliToggleDescription}</p>
+              </div>
+              {status.cli.linkManaged ? (
+                <button type="button" className="secondary" onClick={onDisableCli} disabled={cliActionLoading}>
+                  {cliActionLoading ? <Loader2 className="spin" size={15} /> : <Unlink2 size={15} />}
+                  {copy.agentAccessDisableCli}
+                </button>
+              ) : (
+                <button type="button" className="secondary" onClick={onEnableCli} disabled={cliActionLoading}>
+                  {cliActionLoading ? <Loader2 className="spin" size={15} /> : <Link2 size={15} />}
+                  {copy.agentAccessEnableCli}
+                </button>
+              )}
+            </section>
+          )}
 
           <section className="agent-access-command-group">
             <div className="agent-access-subtitle-row">

--- a/src/renderer/AgentAccessPanel.tsx
+++ b/src/renderer/AgentAccessPanel.tsx
@@ -1,0 +1,158 @@
+import { CheckCircle2, Clipboard, ExternalLink, KeyRound, Loader2, Wrench, X } from "lucide-react";
+import type { AgentRuntimeStatus } from "../shared/types";
+import type { UiCopy } from "./i18n";
+
+interface AgentAccessPanelProps {
+  copy: UiCopy;
+  status: AgentRuntimeStatus | null;
+  loading: boolean;
+  onClose: () => void;
+  onCopy: (value: string) => void;
+}
+
+function valueOrFallback(value: string | null | undefined): string {
+  return value?.trim() || "-";
+}
+
+export function AgentAccessSection({ copy, status, loading, onOpen }: { copy: UiCopy; status: AgentRuntimeStatus | null; loading: boolean; onOpen: () => void }) {
+  const statusLabel = loading ? copy.agentAccessLoading : status ? copy.agentAccessCliStatus(status.cli.status) : copy.agentAccessNoConfig;
+  return (
+    <section className="tool-section agent-access-section">
+      <div className="section-title agent-access-title-row">
+        <div className="section-title-label">
+          <KeyRound size={16} />
+          <h2>{copy.agentAccessTitle}</h2>
+        </div>
+        <span className="agent-access-status" data-status={status?.cli.status ?? "unknown"}>
+          {loading ? <Loader2 className="spin" size={13} /> : status?.cli.status === "ready" ? <CheckCircle2 size={13} /> : <Wrench size={13} />}
+          {statusLabel}
+        </span>
+      </div>
+      <button type="button" className="agent-access-current" onClick={onOpen} disabled={loading}>
+        <span className="agent-access-current-main">
+          <strong>{status ? copy.agentAccessCliStatus(status.cli.status) : copy.agentAccessTitle}</strong>
+          <small>{copy.agentAccessSubtitle}</small>
+        </span>
+        <ExternalLink size={15} />
+      </button>
+    </section>
+  );
+}
+
+export function AgentAccessDialog({ copy, status, loading, onClose, onCopy }: AgentAccessPanelProps) {
+  const copyValue = (value: string | null | undefined) => {
+    if (value) onCopy(value);
+  };
+  const activeProvider = status?.activeProvider;
+  const providerSummary = activeProvider
+    ? copy.agentAccessProviderSummary(activeProvider.name ?? activeProvider.id, activeProvider.kind, activeProvider.activeModelId ?? "-")
+    : "-";
+
+  return (
+    <div className="agent-access-dialog">
+      <div className="agent-access-dialog-header">
+        <div>
+          <h2 id="agent-access-dialog-title">{copy.agentAccessDialogTitle}</h2>
+          <p>{copy.agentAccessDialogDescription}</p>
+        </div>
+        <button type="button" className="icon-button" onClick={onClose} aria-label={copy.close} data-tooltip={copy.close}>
+          <X size={17} />
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="agent-access-loading" role="status">
+          <Loader2 className="spin" size={16} />
+          <span>{copy.agentAccessLoading}</span>
+        </div>
+      ) : !status ? (
+        <p className="muted">{copy.agentAccessNoConfig}</p>
+      ) : (
+        <>
+          <div className="agent-access-summary-grid">
+            <div className="agent-access-summary-item">
+              <span>{copy.agentAccessCliCommand}</span>
+              <strong>{copy.agentAccessCliStatus(status.cli.status)}</strong>
+            </div>
+            <div className="agent-access-summary-item">
+              <span>{copy.agentAccessActiveProvider}</span>
+              <strong>{providerSummary}</strong>
+            </div>
+            <div className="agent-access-summary-item">
+              <span>{copy.agentAccessApiKey}</span>
+              <strong>{status.apiKeyAvailable ? copy.agentAccessYes : copy.agentAccessNo}</strong>
+            </div>
+            <div className="agent-access-summary-item">
+              <span>{copy.agentAccessWorkers}</span>
+              <strong>{copy.agentAccessWorkerCount(status.liveWorkerHosts)}</strong>
+            </div>
+          </div>
+
+          <div className="agent-access-paths">
+            <div className="agent-access-path-row">
+              <span>{copy.agentAccessMcpDirect}</span>
+              <code title={status.mcp.command}>{valueOrFallback(status.mcp.command)}</code>
+            </div>
+            <div className="agent-access-path-row">
+              <span>{copy.agentAccessLauncher}</span>
+              <code title={status.cli.launcherPath ?? undefined}>{valueOrFallback(status.cli.launcherPath)}</code>
+            </div>
+            <div className="agent-access-path-row">
+              <span>{copy.agentAccessDataDir}</span>
+              <code title={status.dataDir}>{status.dataDir}</code>
+            </div>
+            <div className="agent-access-path-row">
+              <span>{copy.agentAccessState}</span>
+              <code title={status.statePath}>{status.statePath}</code>
+            </div>
+          </div>
+
+          <section className="agent-access-command-group">
+            <div className="agent-access-subtitle-row">
+              <h3>{copy.agentAccessCommands}</h3>
+              <span className="muted">{status.cli.repairHint}</span>
+            </div>
+            {[status.commands.version, status.commands.doctor, status.commands.configStatus, status.commands.modelsList, status.commands.queueStatus].map((command) => (
+              <div className="agent-access-copy-row" key={command}>
+                <code>{command}</code>
+                <button type="button" className="icon-button secondary" onClick={() => copyValue(command)} aria-label={copy.copyCommand} data-tooltip={copy.copyCommand}>
+                  <Clipboard size={15} />
+                </button>
+              </div>
+            ))}
+          </section>
+
+          <section className="agent-access-command-group">
+            <div className="agent-access-subtitle-row">
+              <h3>{copy.agentAccessMcpConfigs}</h3>
+              <span className="muted">{copy.agentAccessModeReadonly} / {copy.agentAccessModeWrite} / {copy.agentAccessModeGenerate}</span>
+            </div>
+            {status.mcp.configs.map((config) => (
+              <div className="agent-access-copy-row" key={`${config.client}:${config.mode}`}>
+                <span className="agent-access-config-label">{config.client} · {config.mode} · {config.format}</span>
+                <button type="button" className="icon-button secondary" onClick={() => copyValue(config.snippet)} aria-label={copy.copyConfig} data-tooltip={copy.copyConfig}>
+                  <Clipboard size={15} />
+                </button>
+              </div>
+            ))}
+          </section>
+
+          {status.cli.linkCommand && status.cli.status !== "ready" && (
+            <section className="agent-access-repair">
+              <div className="agent-access-subtitle-row">
+                <h3><Wrench size={15} /> {copy.agentAccessRepair}</h3>
+                <span className="muted">{status.cli.repairHint}</span>
+              </div>
+              <div className="agent-access-copy-row">
+                <code>{status.cli.linkCommand}</code>
+                <button type="button" className="icon-button secondary" onClick={() => copyValue(status.cli.linkCommand)} aria-label={copy.copyCommand} data-tooltip={copy.copyCommand}>
+                  <Clipboard size={15} />
+                </button>
+              </div>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -2761,79 +2761,86 @@ function createBridge(initialSnapshot: AppSnapshot, initialQueueSnapshot: QueueS
     queueSnapshotListeners.forEach((listener) => listener(next));
   };
 
+  const getAgentRuntimeStatus = vi.fn(async (): Promise<AgentRuntimeStatus> => ({
+    schemaVersion: 1,
+    appVersion: currentSnapshot.appVersion,
+    runtimeKind: "development",
+    cliExecutable: "/tmp/CrossGen",
+    mcpCommand: "/tmp/CrossGen",
+    recommendedArgs: ["--mcp"],
+    appExecutable: "/tmp/CrossGen",
+    packagedExecutable: null,
+    dataDir: "/tmp/crossgen",
+    statePath: "/tmp/crossgen/state.json",
+    stateFound: true,
+    activeProvider: {
+      id: activeConfig().id,
+      kind: activeConfig().kind,
+      name: activeConfig().name,
+      enabled: activeConfig().enabled,
+      activeLaunchId: activeConfig().activeLaunchId,
+      activeModelId: activeConfig().activeModelId
+    },
+    apiKeyAvailable: activeConfig().apiKeySaved,
+    liveWorkerHost: currentQueueSnapshot.workers.online > 0,
+    liveWorkerHosts: currentQueueSnapshot.workers.online,
+    queueConfig: {
+      maxGlobalRunning: currentQueueSnapshot.concurrency.maxGlobal,
+      providerConcurrency: currentQueueSnapshot.concurrency.providerConcurrency
+    },
+    cli: {
+      commandName: "crossgen",
+      status: "development",
+      commandPath: null,
+      commandTarget: null,
+      launcherPath: null,
+      launcherExists: false,
+      linkPath: null,
+      linkExists: false,
+      linkManaged: false,
+      pathEntryCount: 0,
+      linkCommand: null,
+      unlinkCommand: null,
+      repairHint: "Development runtime detected."
+    },
+    mcp: {
+      command: "/tmp/CrossGen",
+      args: ["--mcp"],
+      defaultMode: "readonly",
+      configs: [{
+        client: "codex",
+        mode: "readonly",
+        format: "codex-toml",
+        json: "{}",
+        snippet: "[mcp_servers.crossgen]"
+      }]
+    },
+    commands: {
+      version: "crossgen --version --json",
+      doctor: "crossgen doctor --agent --json",
+      configStatus: "crossgen config status --json",
+      modelsList: "crossgen models list --json",
+      queueStatus: "crossgen queue status --json",
+      mcpCodexReadonly: "crossgen mcp config --client codex --mode readonly --json",
+      mcpCodexGenerate: "crossgen mcp config --client codex --mode generate --json"
+    },
+    permissions: {
+      cliMode: "readonly",
+      mcpDefaultMode: "readonly",
+      writeModeRequiresExplicitEnable: true,
+      generateModeRequiresExplicitEnable: true,
+      paidGenerationRequiresConfirmation: true,
+      pathDisclosureRequiresConfirmation: true
+    },
+    knownLimitations: ["MCP generate mode requires explicit confirmation."],
+    nextActions: ["Use readonly mode by default."]
+  }));
+
   return {
     getSnapshot: vi.fn(async () => currentSnapshot),
-    getAgentRuntimeStatus: vi.fn(async (): Promise<AgentRuntimeStatus> => ({
-      schemaVersion: 1,
-      appVersion: currentSnapshot.appVersion,
-      runtimeKind: "development",
-      cliExecutable: "/tmp/CrossGen",
-      mcpCommand: "/tmp/CrossGen",
-      recommendedArgs: ["--mcp"],
-      appExecutable: "/tmp/CrossGen",
-      packagedExecutable: null,
-      dataDir: "/tmp/crossgen",
-      statePath: "/tmp/crossgen/state.json",
-      stateFound: true,
-      activeProvider: {
-        id: activeConfig().id,
-        kind: activeConfig().kind,
-        name: activeConfig().name,
-        enabled: activeConfig().enabled,
-        activeLaunchId: activeConfig().activeLaunchId,
-        activeModelId: activeConfig().activeModelId
-      },
-      apiKeyAvailable: activeConfig().apiKeySaved,
-      liveWorkerHost: currentQueueSnapshot.workers.online > 0,
-      liveWorkerHosts: currentQueueSnapshot.workers.online,
-      queueConfig: {
-        maxGlobalRunning: currentQueueSnapshot.concurrency.maxGlobal,
-        providerConcurrency: currentQueueSnapshot.concurrency.providerConcurrency
-      },
-      cli: {
-        commandName: "crossgen",
-        status: "development",
-        commandPath: null,
-        commandTarget: null,
-        launcherPath: null,
-        launcherExists: false,
-        pathEntryCount: 0,
-        linkCommand: null,
-        unlinkCommand: null,
-        repairHint: "Development runtime detected."
-      },
-      mcp: {
-        command: "/tmp/CrossGen",
-        args: ["--mcp"],
-        defaultMode: "readonly",
-        configs: [{
-          client: "codex",
-          mode: "readonly",
-          format: "codex-toml",
-          json: "{}",
-          snippet: "[mcp_servers.crossgen]"
-        }]
-      },
-      commands: {
-        version: "crossgen --version --json",
-        doctor: "crossgen doctor --agent --json",
-        configStatus: "crossgen config status --json",
-        modelsList: "crossgen models list --json",
-        queueStatus: "crossgen queue status --json",
-        mcpCodexReadonly: "crossgen mcp config --client codex --mode readonly --json",
-        mcpCodexGenerate: "crossgen mcp config --client codex --mode generate --json"
-      },
-      permissions: {
-        cliMode: "readonly",
-        mcpDefaultMode: "readonly",
-        writeModeRequiresExplicitEnable: true,
-        generateModeRequiresExplicitEnable: true,
-        paidGenerationRequiresConfirmation: true,
-        pathDisclosureRequiresConfirmation: true
-      },
-      knownLimitations: ["MCP generate mode requires explicit confirmation."],
-      nextActions: ["Use readonly mode by default."]
-    })),
+    getAgentRuntimeStatus,
+    enableAgentCli: vi.fn(async () => getAgentRuntimeStatus()),
+    disableAgentCli: vi.fn(async () => getAgentRuntimeStatus()),
     getQueueSnapshot: vi.fn(async () => currentQueueSnapshot),
     saveConfig: vi.fn(async (input) => {
       const config = configById(input.providerId);

--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 import type {
+  AgentRuntimeStatus,
   AppBridge,
   AppSnapshot,
   GenerationJob,
@@ -68,6 +69,19 @@ describe("renderer multi-model smoke", () => {
     expect(document.body.textContent).toContain("Browser preview: Electron IPC is unavailable.");
     await click(apiAccessCurrentButton());
     expect(buttonByText("Discover models").disabled).toBe(true);
+  });
+
+  it("exposes a dedicated agent access entry with copyable CLI and MCP details", async () => {
+    await renderApp(snapshot());
+
+    expect(document.body.textContent).toContain("Agent access");
+    await click(agentAccessCurrentButton());
+
+    expect(document.body.textContent).toContain("Agent access");
+    expect(document.body.textContent).toContain("crossgen doctor --agent --json");
+    await click(document.querySelector<HTMLButtonElement>(".agent-access-copy-row button")!);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("crossgen --version --json");
   });
 
   it("adds hover tooltips to compactable prompt action buttons", async () => {
@@ -2749,6 +2763,77 @@ function createBridge(initialSnapshot: AppSnapshot, initialQueueSnapshot: QueueS
 
   return {
     getSnapshot: vi.fn(async () => currentSnapshot),
+    getAgentRuntimeStatus: vi.fn(async (): Promise<AgentRuntimeStatus> => ({
+      schemaVersion: 1,
+      appVersion: currentSnapshot.appVersion,
+      runtimeKind: "development",
+      cliExecutable: "/tmp/CrossGen",
+      mcpCommand: "/tmp/CrossGen",
+      recommendedArgs: ["--mcp"],
+      appExecutable: "/tmp/CrossGen",
+      packagedExecutable: null,
+      dataDir: "/tmp/crossgen",
+      statePath: "/tmp/crossgen/state.json",
+      stateFound: true,
+      activeProvider: {
+        id: activeConfig().id,
+        kind: activeConfig().kind,
+        name: activeConfig().name,
+        enabled: activeConfig().enabled,
+        activeLaunchId: activeConfig().activeLaunchId,
+        activeModelId: activeConfig().activeModelId
+      },
+      apiKeyAvailable: activeConfig().apiKeySaved,
+      liveWorkerHost: currentQueueSnapshot.workers.online > 0,
+      liveWorkerHosts: currentQueueSnapshot.workers.online,
+      queueConfig: {
+        maxGlobalRunning: currentQueueSnapshot.concurrency.maxGlobal,
+        providerConcurrency: currentQueueSnapshot.concurrency.providerConcurrency
+      },
+      cli: {
+        commandName: "crossgen",
+        status: "development",
+        commandPath: null,
+        commandTarget: null,
+        launcherPath: null,
+        launcherExists: false,
+        pathEntryCount: 0,
+        linkCommand: null,
+        unlinkCommand: null,
+        repairHint: "Development runtime detected."
+      },
+      mcp: {
+        command: "/tmp/CrossGen",
+        args: ["--mcp"],
+        defaultMode: "readonly",
+        configs: [{
+          client: "codex",
+          mode: "readonly",
+          format: "codex-toml",
+          json: "{}",
+          snippet: "[mcp_servers.crossgen]"
+        }]
+      },
+      commands: {
+        version: "crossgen --version --json",
+        doctor: "crossgen doctor --agent --json",
+        configStatus: "crossgen config status --json",
+        modelsList: "crossgen models list --json",
+        queueStatus: "crossgen queue status --json",
+        mcpCodexReadonly: "crossgen mcp config --client codex --mode readonly --json",
+        mcpCodexGenerate: "crossgen mcp config --client codex --mode generate --json"
+      },
+      permissions: {
+        cliMode: "readonly",
+        mcpDefaultMode: "readonly",
+        writeModeRequiresExplicitEnable: true,
+        generateModeRequiresExplicitEnable: true,
+        paidGenerationRequiresConfirmation: true,
+        pathDisclosureRequiresConfirmation: true
+      },
+      knownLimitations: ["MCP generate mode requires explicit confirmation."],
+      nextActions: ["Use readonly mode by default."]
+    })),
     getQueueSnapshot: vi.fn(async () => currentQueueSnapshot),
     saveConfig: vi.fn(async (input) => {
       const config = configById(input.providerId);
@@ -3284,6 +3369,12 @@ function launchModelOption(name: string): HTMLButtonElement {
 function apiAccessCurrentButton(): HTMLButtonElement {
   const button = document.querySelector<HTMLButtonElement>(".api-access-current");
   if (!button) throw new Error("Current API config button was not found.");
+  return button;
+}
+
+function agentAccessCurrentButton(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(".agent-access-current");
+  if (!button) throw new Error("Current agent access button was not found.");
   return button;
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1247,6 +1247,7 @@ export function App() {
   });
   const [agentRuntimeStatus, setAgentRuntimeStatus] = useState<AgentRuntimeStatus | null>(null);
   const [isAgentRuntimeLoading, setIsAgentRuntimeLoading] = useState(Boolean(bridge));
+  const [isAgentCliActionLoading, setIsAgentCliActionLoading] = useState(false);
   const [isAgentAccessOpen, setIsAgentAccessOpen] = useState(false);
   const [isLoadingSnapshot, setIsLoadingSnapshot] = useState(false);
   const [isSavingConfig, setIsSavingConfig] = useState(false);
@@ -2616,6 +2617,20 @@ export function App() {
       setNotice({ kind: "error", text: normalizeNotice(error) });
     } finally {
       setIsAgentRuntimeLoading(false);
+    }
+  }
+
+  async function setAgentCliEnabled(enabled: boolean) {
+    if (!bridge) return;
+    setIsAgentCliActionLoading(true);
+    try {
+      const nextStatus = enabled ? await bridge.enableAgentCli() : await bridge.disableAgentCli();
+      setAgentRuntimeStatus(nextStatus);
+      setNotice({ kind: "success", text: enabled ? copy.agentAccessCliEnabled : copy.agentAccessCliDisabled });
+    } catch (error) {
+      setNotice({ kind: "error", text: normalizeNotice(error) });
+    } finally {
+      setIsAgentCliActionLoading(false);
     }
   }
 
@@ -7261,8 +7276,11 @@ export function App() {
             copy={copy}
             status={agentRuntimeStatus}
             loading={isAgentRuntimeLoading}
+            cliActionLoading={isAgentCliActionLoading}
             onClose={() => setIsAgentAccessOpen(false)}
             onCopy={(value) => void copyAgentAccessText(value)}
+            onEnableCli={() => void setAgentCliEnabled(true)}
+            onDisableCli={() => void setAgentCliEnabled(false)}
           />
         </DialogShell>
       )}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -69,6 +69,7 @@ import {
 } from "../shared/validation";
 import type {
   AppSnapshot,
+  AgentRuntimeStatus,
   FocusedLaunchId,
   GalleryAsset,
   GalleryFolder,
@@ -119,6 +120,7 @@ import {
 import { PromptComposer } from "./PromptComposer";
 import { ImageEditor } from "./ImageEditor";
 import { DialogShell } from "./DialogShell";
+import { AgentAccessDialog, AgentAccessSection } from "./AgentAccessPanel";
 import { HistoryFilterToolbar, HistoryFloatingPager, HistoryItemCard, HistoryListShell } from "./HistoryPanel";
 import { ApiConfigDialog, LaunchSection, ProviderSummarySection } from "./ProviderConfigPanel";
 import { ParameterConfigDialog, ParameterConfigLauncher } from "./ParameterConfigPanel";
@@ -1243,6 +1245,9 @@ export function App() {
     kind: bridge ? "info" : "error",
     text: bridge ? copy.notices.ready : copy.notices.browserPreview
   });
+  const [agentRuntimeStatus, setAgentRuntimeStatus] = useState<AgentRuntimeStatus | null>(null);
+  const [isAgentRuntimeLoading, setIsAgentRuntimeLoading] = useState(Boolean(bridge));
+  const [isAgentAccessOpen, setIsAgentAccessOpen] = useState(false);
   const [isLoadingSnapshot, setIsLoadingSnapshot] = useState(false);
   const [isSavingConfig, setIsSavingConfig] = useState(false);
   const [discoveringProviderId, setDiscoveringProviderId] = useState<string | null>(null);
@@ -2417,6 +2422,7 @@ export function App() {
 
   useEffect(() => {
     void refreshSnapshot();
+    void refreshAgentRuntimeStatus();
   }, []);
 
   useEffect(() => {
@@ -2593,6 +2599,23 @@ export function App() {
       setNotice({ kind: "error", text: normalizeNotice(error) });
     } finally {
       setIsLoadingSnapshot(false);
+    }
+  }
+
+  async function refreshAgentRuntimeStatus() {
+    if (!bridge) {
+      setAgentRuntimeStatus(null);
+      setIsAgentRuntimeLoading(false);
+      return;
+    }
+    setIsAgentRuntimeLoading(true);
+    try {
+      setAgentRuntimeStatus(await bridge.getAgentRuntimeStatus());
+    } catch (error) {
+      setAgentRuntimeStatus(null);
+      setNotice({ kind: "error", text: normalizeNotice(error) });
+    } finally {
+      setIsAgentRuntimeLoading(false);
     }
   }
 
@@ -4326,6 +4349,15 @@ export function App() {
       await navigator.clipboard.writeText(value);
       flashButton(feedbackId);
       setNotice({ kind: "success", text: copy.imagePathCopied });
+    } catch {
+      setNotice({ kind: "error", text: copy.notices.clipboardUnavailable });
+    }
+  }
+
+  async function copyAgentAccessText(value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      setNotice({ kind: "success", text: copy.agentAccessCopied });
     } catch {
       setNotice({ kind: "error", text: copy.notices.clipboardUnavailable });
     }
@@ -6327,6 +6359,16 @@ export function App() {
           onOpen={() => openApiConfigDialog(activeConfig)}
         />
 
+        <AgentAccessSection
+          copy={copy}
+          status={agentRuntimeStatus}
+          loading={isAgentRuntimeLoading}
+          onOpen={() => {
+            setIsAgentAccessOpen(true);
+            void refreshAgentRuntimeStatus();
+          }}
+        />
+
         <LaunchSection
           copy={copy}
           activeConfig={activeConfig}
@@ -7211,6 +7253,17 @@ export function App() {
                 {galleryFolderDialog.mode === "create" ? copy.galleryFolderCreate : copy.galleryFolderRename}
               </button>
             </div>
+        </DialogShell>
+      )}
+      {isAgentAccessOpen && (
+        <DialogShell className="agent-access-modal" labelledBy="agent-access-dialog-title" onClose={() => setIsAgentAccessOpen(false)}>
+          <AgentAccessDialog
+            copy={copy}
+            status={agentRuntimeStatus}
+            loading={isAgentRuntimeLoading}
+            onClose={() => setIsAgentAccessOpen(false)}
+            onCopy={(value) => void copyAgentAccessText(value)}
+          />
         </DialogShell>
       )}
       {storageDialogKind && (

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -119,6 +119,7 @@ export interface UiCopy {
   queue: QueueCopy;
   language: string;
   theme: string;
+  close: string;
   themeSystem: string;
   themeLight: string;
   themeDark: string;
@@ -157,6 +158,35 @@ export interface UiCopy {
   apiAccessUntitled: string;
   apiAccessKind: string;
   apiAccessBaseURLSummary: string;
+  agentAccessTitle: string;
+  agentAccessSubtitle: string;
+  agentAccessOpen: string;
+  agentAccessDialogTitle: string;
+  agentAccessDialogDescription: string;
+  agentAccessCliCommand: string;
+  agentAccessLauncher: string;
+  agentAccessMcpDirect: string;
+  agentAccessDataDir: string;
+  agentAccessState: string;
+  agentAccessActiveProvider: string;
+  agentAccessApiKey: string;
+  agentAccessWorkers: string;
+  agentAccessCommands: string;
+  agentAccessMcpConfigs: string;
+  agentAccessRepair: string;
+  agentAccessNoConfig: string;
+  agentAccessLoading: string;
+  agentAccessCopied: string;
+  agentAccessCliStatus: (status: string) => string;
+  agentAccessWorkerCount: (count: number) => string;
+  agentAccessProviderSummary: (name: string, kind: string, model: string) => string;
+  agentAccessYes: string;
+  agentAccessNo: string;
+  agentAccessModeReadonly: string;
+  agentAccessModeWrite: string;
+  agentAccessModeGenerate: string;
+  copyCommand: string;
+  copyConfig: string;
   providerAutoDetected: string;
   apiKey: string;
   baseURL: string;
@@ -593,6 +623,7 @@ export const translations: Record<Language, UiCopy> = {
     },
     language: "Language",
     theme: "Theme",
+    close: "Close",
     themeSystem: "System",
     themeLight: "Light",
     themeDark: "Dark",
@@ -631,6 +662,42 @@ export const translations: Record<Language, UiCopy> = {
     apiAccessUntitled: "Untitled API config",
     apiAccessKind: "API type",
     apiAccessBaseURLSummary: "Base URL",
+    agentAccessTitle: "Agent access",
+    agentAccessSubtitle: "CLI and MCP entrypoints for local coding agents.",
+    agentAccessOpen: "Open agent access",
+    agentAccessDialogTitle: "Agent access",
+    agentAccessDialogDescription: "Use these commands and MCP config snippets when connecting Codex, Claude Code, Cursor, or terminal scripts to this CrossGen install.",
+    agentAccessCliCommand: "CLI command",
+    agentAccessLauncher: "Packaged launcher",
+    agentAccessMcpDirect: "MCP executable",
+    agentAccessDataDir: "Data directory",
+    agentAccessState: "State file",
+    agentAccessActiveProvider: "Active provider",
+    agentAccessApiKey: "API key",
+    agentAccessWorkers: "Queue workers",
+    agentAccessCommands: "Agent checks",
+    agentAccessMcpConfigs: "MCP config",
+    agentAccessRepair: "Repair",
+    agentAccessNoConfig: "Runtime information is not available in browser preview.",
+    agentAccessLoading: "Checking agent runtime",
+    agentAccessCopied: "Agent access text copied.",
+    agentAccessCliStatus: (status: string) => ({
+      ready: "Ready",
+      "not-found": "Not on PATH",
+      stale: "Broken link",
+      custom: "Custom command",
+      "launcher-missing": "Launcher missing",
+      development: "Development"
+    }[status] ?? status),
+    agentAccessWorkerCount: (count: number) => `${count} live worker${count === 1 ? "" : "s"}`,
+    agentAccessProviderSummary: (name: string, kind: string, model: string) => `${name} · ${kind} · ${model}`,
+    agentAccessYes: "Yes",
+    agentAccessNo: "No",
+    agentAccessModeReadonly: "Readonly",
+    agentAccessModeWrite: "Write",
+    agentAccessModeGenerate: "Generate",
+    copyCommand: "Copy command",
+    copyConfig: "Copy config",
     providerAutoDetected: "Auto-detected from API",
     apiKey: "API Key",
     baseURL: "Base URL",
@@ -1132,6 +1199,7 @@ export const translations: Record<Language, UiCopy> = {
     },
     language: "语言",
     theme: "外观",
+    close: "关闭",
     themeSystem: "跟随系统",
     themeLight: "浅色",
     themeDark: "深色",
@@ -1170,6 +1238,42 @@ export const translations: Record<Language, UiCopy> = {
     apiAccessUntitled: "未命名 API 配置",
     apiAccessKind: "API 类型",
     apiAccessBaseURLSummary: "Base URL",
+    agentAccessTitle: "Agent 接入",
+    agentAccessSubtitle: "为本地 coding agents 提供 CLI 与 MCP 入口。",
+    agentAccessOpen: "打开 Agent 接入",
+    agentAccessDialogTitle: "Agent 接入",
+    agentAccessDialogDescription: "连接 Codex、Claude Code、Cursor 或终端脚本时，使用下面的命令和 MCP 配置片段。",
+    agentAccessCliCommand: "CLI 命令",
+    agentAccessLauncher: "打包 launcher",
+    agentAccessMcpDirect: "MCP 可执行文件",
+    agentAccessDataDir: "数据目录",
+    agentAccessState: "状态文件",
+    agentAccessActiveProvider: "当前 provider",
+    agentAccessApiKey: "API Key",
+    agentAccessWorkers: "队列 worker",
+    agentAccessCommands: "Agent 检查",
+    agentAccessMcpConfigs: "MCP 配置",
+    agentAccessRepair: "修复",
+    agentAccessNoConfig: "浏览器预览模式下无法读取运行时信息。",
+    agentAccessLoading: "正在检查 Agent 运行时",
+    agentAccessCopied: "Agent 接入内容已复制。",
+    agentAccessCliStatus: (status: string) => ({
+      ready: "已就绪",
+      "not-found": "未在 PATH 中",
+      stale: "链接失效",
+      custom: "自定义命令",
+      "launcher-missing": "缺少 launcher",
+      development: "开发模式"
+    }[status] ?? status),
+    agentAccessWorkerCount: (count: number) => `${count} 个在线 worker`,
+    agentAccessProviderSummary: (name: string, kind: string, model: string) => `${name} · ${kind} · ${model}`,
+    agentAccessYes: "是",
+    agentAccessNo: "否",
+    agentAccessModeReadonly: "只读",
+    agentAccessModeWrite: "写入",
+    agentAccessModeGenerate: "生成",
+    copyCommand: "复制命令",
+    copyConfig: "复制配置",
     providerAutoDetected: "已根据 API 自动识别",
     apiKey: "API Key",
     baseURL: "Base URL",

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -166,6 +166,13 @@ export interface UiCopy {
   agentAccessCliCommand: string;
   agentAccessLauncher: string;
   agentAccessMcpDirect: string;
+  agentAccessCliLinkPath: string;
+  agentAccessCliToggleTitle: string;
+  agentAccessCliToggleDescription: string;
+  agentAccessEnableCli: string;
+  agentAccessDisableCli: string;
+  agentAccessCliEnabled: string;
+  agentAccessCliDisabled: string;
   agentAccessDataDir: string;
   agentAccessState: string;
   agentAccessActiveProvider: string;
@@ -670,6 +677,13 @@ export const translations: Record<Language, UiCopy> = {
     agentAccessCliCommand: "CLI command",
     agentAccessLauncher: "Packaged launcher",
     agentAccessMcpDirect: "MCP executable",
+    agentAccessCliLinkPath: "CLI link path",
+    agentAccessCliToggleTitle: "crossgen command",
+    agentAccessCliToggleDescription: "Create or remove only CrossGen's user-level launcher link. Shell files and PATH are never changed.",
+    agentAccessEnableCli: "Enable command",
+    agentAccessDisableCli: "Disable command",
+    agentAccessCliEnabled: "The CrossGen CLI command is enabled.",
+    agentAccessCliDisabled: "The CrossGen CLI command is disabled.",
     agentAccessDataDir: "Data directory",
     agentAccessState: "State file",
     agentAccessActiveProvider: "Active provider",
@@ -1246,6 +1260,13 @@ export const translations: Record<Language, UiCopy> = {
     agentAccessCliCommand: "CLI 命令",
     agentAccessLauncher: "打包 launcher",
     agentAccessMcpDirect: "MCP 可执行文件",
+    agentAccessCliLinkPath: "CLI 链接路径",
+    agentAccessCliToggleTitle: "crossgen 命令",
+    agentAccessCliToggleDescription: "只创建或移除 CrossGen 用户目录下的 launcher 链接，不修改 shell 文件或 PATH。",
+    agentAccessEnableCli: "启用命令",
+    agentAccessDisableCli: "停用命令",
+    agentAccessCliEnabled: "CrossGen CLI 命令已启用。",
+    agentAccessCliDisabled: "CrossGen CLI 命令已停用。",
     agentAccessDataDir: "数据目录",
     agentAccessState: "状态文件",
     agentAccessActiveProvider: "当前 provider",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -851,6 +851,231 @@
     transform: translateY(-1px);
   }
 
+  .agent-access-section {
+    gap: 10px;
+  }
+
+  .agent-access-title-row {
+    justify-content: space-between;
+  }
+
+  .agent-access-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    max-width: 160px;
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agent-access-status[data-status="ready"] {
+    color: var(--success);
+  }
+
+  .agent-access-status[data-status="stale"],
+  .agent-access-status[data-status="launcher-missing"] {
+    color: var(--warning);
+  }
+
+  .agent-access-current {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    width: 100%;
+    min-height: 46px;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-panel-muted);
+    color: var(--text-primary);
+    padding: 8px 10px 8px 12px;
+    text-align: left;
+    transition:
+      background var(--motion-fast),
+      border-color var(--motion-fast),
+      box-shadow var(--motion-fast),
+      transform var(--motion-fast);
+  }
+
+  .agent-access-current:hover:not(:disabled),
+  .agent-access-current:focus-visible:not(:disabled) {
+    border-color: var(--accent-border);
+    background: var(--surface-panel);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.08);
+    transform: translateY(-1px);
+  }
+
+  .agent-access-current-main {
+    display: grid;
+    min-width: 0;
+    gap: 2px;
+  }
+
+  .agent-access-current-main strong,
+  .agent-access-current-main small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agent-access-current-main small {
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+
+  .agent-access-modal {
+    display: grid;
+    gap: 18px;
+    width: min(720px, 100%);
+    max-height: min(820px, calc(100vh - 44px));
+    overflow: auto;
+    overscroll-behavior: contain;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-panel);
+    box-shadow: var(--shadow-popover);
+    padding: 20px;
+  }
+
+  .agent-access-dialog {
+    display: grid;
+    gap: 16px;
+  }
+
+  .agent-access-dialog-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .agent-access-dialog-header h2 {
+    margin: 0;
+  }
+
+  .agent-access-dialog-header p {
+    max-width: 620px;
+    margin-top: 8px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.45;
+  }
+
+  .agent-access-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 100px;
+    color: var(--text-muted);
+  }
+
+  .agent-access-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .agent-access-summary-item {
+    display: grid;
+    gap: 5px;
+    min-width: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-panel-muted);
+    padding: 10px;
+  }
+
+  .agent-access-summary-item span {
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+
+  .agent-access-summary-item strong {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 12px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agent-access-paths,
+  .agent-access-command-group,
+  .agent-access-repair {
+    display: grid;
+    gap: 8px;
+  }
+
+  .agent-access-paths {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-panel-muted);
+    padding: 10px;
+  }
+
+  .agent-access-path-row {
+    display: grid;
+    grid-template-columns: 130px minmax(0, 1fr);
+    align-items: start;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .agent-access-path-row span,
+  .agent-access-config-label {
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .agent-access-path-row code,
+  .agent-access-copy-row code {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 11px;
+    line-height: 1.4;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agent-access-subtitle-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .agent-access-subtitle-row h3 {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    font-size: 13px;
+  }
+
+  .agent-access-copy-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-width: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-panel-muted);
+    padding: 7px 8px 7px 10px;
+  }
+
+  .agent-access-copy-row .icon-button {
+    flex: 0 0 auto;
+  }
+
+  .agent-access-repair {
+    border-left: 3px solid var(--warning);
+    padding-left: 12px;
+  }
+
   .api-access-current strong,
   .api-access-current small,
   .api-access-item-title,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1040,6 +1040,34 @@
     white-space: nowrap;
   }
 
+  .agent-access-cli-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-panel-muted);
+    padding: 10px;
+  }
+
+  .agent-access-cli-toggle h3 {
+    margin: 0 0 4px;
+    font-size: 13px;
+  }
+
+  .agent-access-cli-toggle p {
+    margin: 0;
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .agent-access-cli-toggle button {
+    flex: 0 0 auto;
+    min-height: 32px;
+    white-space: nowrap;
+  }
+
   .agent-access-subtitle-row {
     display: flex;
     align-items: baseline;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -645,6 +645,90 @@ export interface CrossGenJsonFailure {
 
 export type CrossGenJsonResponse<TData = unknown> = CrossGenJsonSuccess<TData> | CrossGenJsonFailure;
 
+export type AgentMcpClientName = "codex" | "claude-code" | "cursor";
+export type AgentMcpMode = "readonly" | "write" | "generate";
+
+export type AgentCliCommandStatus =
+  | "ready"
+  | "not-found"
+  | "stale"
+  | "custom"
+  | "launcher-missing"
+  | "development";
+
+export interface AgentActiveProviderStatus {
+  id: string;
+  kind: ProviderKind;
+  name?: string;
+  enabled: boolean;
+  activeLaunchId?: FocusedLaunchId;
+  activeModelId?: string;
+}
+
+export interface AgentMcpConfigSnippet {
+  client: AgentMcpClientName;
+  mode: AgentMcpMode;
+  format: "codex-toml" | "json";
+  json: string;
+  snippet: string;
+}
+
+export interface AgentRuntimeStatus {
+  schemaVersion: 1;
+  appVersion: string;
+  runtimeKind: "development" | "packaged";
+  cliExecutable: string;
+  mcpCommand: string;
+  recommendedArgs: ["--mcp"];
+  appExecutable: string;
+  packagedExecutable: string | null;
+  dataDir: string;
+  statePath: string;
+  stateFound: boolean;
+  activeProvider: AgentActiveProviderStatus | null;
+  apiKeyAvailable: boolean;
+  liveWorkerHost: boolean;
+  liveWorkerHosts: number;
+  queueConfig: QueueRuntimeConfig;
+  cli: {
+    commandName: "crossgen";
+    status: AgentCliCommandStatus;
+    commandPath: string | null;
+    commandTarget: string | null;
+    launcherPath: string | null;
+    launcherExists: boolean;
+    pathEntryCount: number;
+    linkCommand: string | null;
+    unlinkCommand: string | null;
+    repairHint: string;
+  };
+  mcp: {
+    command: string;
+    args: ["--mcp"];
+    defaultMode: AgentMcpMode;
+    configs: AgentMcpConfigSnippet[];
+  };
+  commands: {
+    version: string;
+    doctor: string;
+    configStatus: string;
+    modelsList: string;
+    queueStatus: string;
+    mcpCodexReadonly: string;
+    mcpCodexGenerate: string;
+  };
+  permissions: {
+    cliMode: "readonly";
+    mcpDefaultMode: "readonly";
+    writeModeRequiresExplicitEnable: boolean;
+    generateModeRequiresExplicitEnable: boolean;
+    paidGenerationRequiresConfirmation: boolean;
+    pathDisclosureRequiresConfirmation: boolean;
+  };
+  knownLimitations: string[];
+  nextActions: string[];
+}
+
 export interface JobProgressEvent {
   jobId: string;
   queueId?: string;
@@ -752,6 +836,7 @@ export interface UpdateInstallResult {
 
 export interface AppBridge {
   getSnapshot: () => Promise<AppSnapshot>;
+  getAgentRuntimeStatus: () => Promise<AgentRuntimeStatus>;
   saveConfig: (input: ProviderConfigInput) => Promise<ProviderConfig>;
   addProvider: (input: ProviderConfigInput) => Promise<AppSnapshot>;
   switchProvider: (providerId: string) => Promise<AppSnapshot>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -697,6 +697,9 @@ export interface AgentRuntimeStatus {
     commandTarget: string | null;
     launcherPath: string | null;
     launcherExists: boolean;
+    linkPath: string | null;
+    linkExists: boolean;
+    linkManaged: boolean;
     pathEntryCount: number;
     linkCommand: string | null;
     unlinkCommand: string | null;
@@ -704,7 +707,7 @@ export interface AgentRuntimeStatus {
   };
   mcp: {
     command: string;
-    args: ["--mcp"];
+    args: string[];
     defaultMode: AgentMcpMode;
     configs: AgentMcpConfigSnippet[];
   };
@@ -837,6 +840,8 @@ export interface UpdateInstallResult {
 export interface AppBridge {
   getSnapshot: () => Promise<AppSnapshot>;
   getAgentRuntimeStatus: () => Promise<AgentRuntimeStatus>;
+  enableAgentCli: () => Promise<AgentRuntimeStatus>;
+  disableAgentCli: () => Promise<AgentRuntimeStatus>;
   saveConfig: (input: ProviderConfigInput) => Promise<ProviderConfig>;
   addProvider: (input: ProviderConfigInput) => Promise<AppSnapshot>;
   switchProvider: (providerId: string) => Promise<AppSnapshot>;


### PR DESCRIPTION
# CrossGen v0.3.3 Agent Access Evidence

> Status: development evidence draft. This file does not authorize a public
> release or update-manifest promotion.
>
> Updated: 2026-08-20

## Scope

This evidence covers the `v0.3.3` Agent Access and contract-stability work:

- desktop Agent Access panel;
- CLI launcher, PATH, and moved-app diagnostics;
- shared `AgentRuntimeStatus` contract;
- `doctor --agent` compatibility fields and extended diagnostics;
- Codex / Claude Code / Cursor MCP configuration discovery;
- copyable CLI/MCP commands and manual repair guidance;
- explicit enable/disable for the user-level CLI link or Windows shim;
- image-core regression protection.

The image generation, edit, inpaint, Gallery, queue, and partial-streaming
paths remain image-only and are not changed by this work.

## Implemented Evidence

| Area | Evidence |
| --- | --- |
| Agent runtime contract | `src/main/services/agentRuntime.ts` and `src/shared/types.ts` |
| Desktop entry | `src/renderer/AgentAccessPanel.tsx`, `src/renderer/App.tsx` |
| Electron bridge | `src/preload/preload.ts`, `app:getAgentRuntimeStatus` IPC |
| CLI compatibility | `doctor --agent` keeps `cliExecutable`, `mcpCommand`, and `recommendedArgs` |
| PATH diagnostics | `ready`, `not-found`, `stale`, `custom`, `launcher-missing`, `development` |
| MCP clients | `codex`, `claude-code`, `cursor`; `readonly`, `write`, `generate` |
| Documentation | `docs/cli-mcp.md`, `docs/KNOWN_LIMITATIONS.md` |

## Commands Passed

These commands passed on the development branch on 2026-08-20:

```bash
pnpm typecheck
pnpm verify:cli-mcp-smoke
pnpm verify:agent-integration-smoke
pnpm verify:image-core-regression-smoke
pnpm verify:release-evidence
pnpm vitest run src/main/services/agentRuntime.test.ts src/renderer/App.smoke.test.tsx
```

The macOS arm64 unpacked candidate built at
`release/mac-arm64/CrossGen.app` also passed the packaged smoke paths on
2026-08-20:

```bash
CROSSGEN_APP_EXECUTABLE="$PWD/release/mac-arm64/CrossGen.app/Contents/MacOS/CrossGen" pnpm verify:cli-mcp-smoke
CROSSGEN_APP_EXECUTABLE="$PWD/release/mac-arm64/CrossGen.app/Contents/MacOS/CrossGen" pnpm verify:agent-integration-smoke
CROSSGEN_SMOKE_CLI_COMMAND="$PWD/release/mac-arm64/CrossGen.app/Contents/Resources/cli/crossgen" \
CROSSGEN_SMOKE_MCP_COMMAND="$PWD/release/mac-arm64/CrossGen.app/Contents/Resources/cli/crossgen" \
pnpm verify:agent-integration-smoke
```

The focused test evidence covers:

- packaged launcher resolution and ready PATH links;
- stale-link detection and manual repair command generation;
- development-runtime behavior;
- Agent Access panel discovery and copy actions;
- legacy doctor fields and new runtime fields;
- MCP mode permissions and confirmation semantics;
- image generation, edit, Gallery, and queue regression suites.
- direct packaged App executable and packaged no-Node launcher behavior on
  macOS arm64.
- managed POSIX link and Windows shim create/remove behavior, including
  refusal to overwrite unmanaged files.
- development-runtime MCP config includes the Electron app path before
  `--mcp`, so copied config works from the source tree as well as packaged apps.

## Release Gates Still Pending

This draft intentionally does not claim the following:

1. an exact `v0.3.3` package has been built and installed (the current
   candidate is still package version `0.3.2`);
2. native Windows and Linux package smoke for the exact candidate;
3. real provider acceptance for the exact candidate;
4. product-owner approval;
5. public release, GitHub Latest promotion, or update-manifest promotion.

Those gates must be recorded against the exact candidate commit and package
hash before changing the package version or publishing `v0.3.3`.
