### PR TITLE
feat: expand GPT Image 2 sizes and fix themed parameter selects

### DIFF
--- a/src/renderer/App.smoke.test.tsx
+++ b/src/renderer/App.smoke.test.tsx
@@ -23,6 +23,7 @@ import {
   DEFAULT_GEMINI_IMAGE_PARAMS,
   DEFAULT_IMAGE_PARAMS
 } from "../shared/validation";
+import { GPT_IMAGE_2_SIZE_PRESET_VALUES } from "../shared/imageSizePresets";
 import {
   GEMINI_3_PRO_IMAGE_MODEL_ID,
   GPT_IMAGE_2_LAUNCH_ID,
@@ -149,6 +150,13 @@ describe("renderer multi-model smoke", () => {
     expect(css).toMatch(/\.right-rail\.collapsed \.right-rail-action-group\s*{[^}]*z-index:\s*6100/s);
   });
 
+  it("keeps the primary parameter dropdowns readable in both themes", () => {
+    const css = readFileSync("src/renderer/styles.css", "utf8");
+
+    expect(css).toMatch(/\.parameter-config-bar \.parameter-quick-field select\s*{[^}]*background-color:\s*var\(--surface-panel\)[^}]*color:\s*var\(--text-primary\)[^}]*color-scheme:\s*inherit/s);
+    expect(css).toMatch(/\.parameter-config-bar \.parameter-quick-field select option,\s*\.parameter-config-bar \.parameter-quick-field select optgroup\s*{[^}]*background-color:\s*var\(--surface-panel\)[^}]*color:\s*var\(--text-primary\)/s);
+  });
+
   it("disables all launch buttons before an API key is saved", async () => {
     const defaultConfig = providerConfig({ apiKeySaved: false, discoveredModels: [] });
     await renderApp(snapshot({ providers: [defaultConfig], activeProviderId: defaultConfig.id }));
@@ -221,6 +229,41 @@ describe("renderer multi-model smoke", () => {
           stream: false,
           partialImages: 0
         })
+      })
+    );
+  });
+
+  it("offers the full size preset matrix and edits a validated custom size", async () => {
+    const bridge = await renderApp(snapshot());
+    const quickSizeSelect = document.querySelector<HTMLSelectElement>('.parameter-config-bar select[aria-label="Size"]')!;
+
+    expect([...quickSizeSelect.options].map((option) => option.value)).toEqual([
+      ...GPT_IMAGE_2_SIZE_PRESET_VALUES,
+      "custom"
+    ]);
+
+    await changeSelect(quickSizeSelect, "custom");
+
+    const dialog = document.querySelector<HTMLElement>(".parameter-dialog")!;
+    const widthInput = inputByLabel("Width", dialog);
+    const heightInput = inputByLabel("Height", dialog);
+    expect(document.activeElement).toBe(widthInput);
+
+    await changeInput(widthInput, "1000");
+    expect(dialog.textContent).toContain("multiples of 16");
+    expect(document.querySelector<HTMLButtonElement>(".primary-run")?.disabled).toBe(true);
+
+    await changeInput(widthInput, "1600");
+    await changeInput(heightInput, "912");
+    expect(dialog.textContent).toContain("Size is valid for GPT Image 2.");
+    expect(document.querySelector<HTMLButtonElement>(".primary-run")?.disabled).toBe(false);
+
+    await click(dialog.querySelector<HTMLButtonElement>('button[aria-label="Cancel"]')!);
+    await click(buttonByText("Generate", ".primary-run"));
+
+    expect(bridge.runJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ size: "1600x912" })
       })
     );
   });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -65,6 +65,10 @@ import {
   isOpenAIImageParams,
   validateGptImage2Size
 } from "../shared/validation";
+import {
+  GPT_IMAGE_2_SIZE_PRESET_GROUPS,
+  isGptImage2SizePreset
+} from "../shared/imageSizePresets";
 import type {
   AppSnapshot,
   AgentRuntimeStatus,
@@ -324,7 +328,6 @@ const StableGalleryRailPanel = memo(
     previous.dependencies.every((dependency, index) => Object.is(dependency, next.dependencies[index]))
 );
 
-const sizePresets = ["auto", "1024x1024", "1536x1024", "1024x1536", "2048x1152", "2048x2048", "3840x2160", "2160x3840"];
 const qualityOptions: ImageQuality[] = ["auto", "low", "medium", "high"];
 const formatOptions: ImageFormat[] = ["png", "jpeg", "webp"];
 const backgroundOptions: ImageBackground[] = ["auto", "opaque"];
@@ -367,6 +370,29 @@ type ThemeMode = "system" | "light" | "dark";
 
 const THEME_STORAGE_KEY = "image2tools.theme";
 const themeModeOrder: ThemeMode[] = ["system", "light", "dark"];
+
+function renderSizePresetOptions(includeTier: boolean): ReactNode {
+  return (
+    <>
+      <option value="auto">auto</option>
+      {GPT_IMAGE_2_SIZE_PRESET_GROUPS.map((group) => (
+        <optgroup key={group.aspectRatio} label={group.aspectRatio}>
+          {group.presets.map((preset) => (
+            <option key={preset.size} value={preset.size}>
+              {includeTier ? `${preset.tier} - ${preset.size}` : preset.size}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </>
+  );
+}
+
+function editableImageSizeParts(size: string): { width: string; height: string } {
+  const match = /^(\d*)x(\d*)$/i.exec(size.trim());
+  if (match) return { width: match[1] ?? "", height: match[2] ?? "" };
+  return { width: size.replace(/\D/g, ""), height: "" };
+}
 
 function getInitialThemeMode(): ThemeMode {
   const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
@@ -966,10 +992,15 @@ function paramsNotice(params: ImageParams, restoredText: string, copy: UiCopy): 
   return restoredText;
 }
 
-function updateCustomSizeFromParams(params: ImageParams, setCustomSize: (value: string) => void) {
-  if (isOpenAIImageParams(params) && !sizePresets.includes(params.size)) {
-    setCustomSize(params.size);
-  }
+function updateCustomSizeFromParams(
+  params: ImageParams,
+  setCustomSize: (value: string) => void,
+  setIsCustomSizeMode: (value: boolean) => void
+) {
+  if (!isOpenAIImageParams(params)) return;
+  const isPreset = isGptImage2SizePreset(params.size);
+  setIsCustomSizeMode(!isPreset);
+  if (!isPreset) setCustomSize(params.size);
 }
 
 function launchDefinitionForModel(modelId: string): (typeof FOCUSED_MODEL_CATALOG)[number] | undefined {
@@ -1189,6 +1220,7 @@ export function App() {
   const [newApiAccessBaseURL, setNewApiAccessBaseURL] = useState(DEFAULT_BASE_URL);
   const [newApiAccessKey, setNewApiAccessKey] = useState("");
   const [customSize, setCustomSize] = useState("2048x1152");
+  const [isCustomSizeMode, setIsCustomSizeMode] = useState(false);
   const [inputAssets, setInputAssets] = useState<InputAsset[]>([]);
   const [maskAsset, setMaskAsset] = useState<InputAsset | null>(null);
   const [maskDataUrl, setMaskDataUrl] = useState<string | null>(null);
@@ -1395,12 +1427,17 @@ export function App() {
   const primaryRunButtonRef = useRef<HTMLButtonElement | null>(null);
   const promptTemplateButtonRef = useRef<HTMLButtonElement | null>(null);
   const promptCopyButtonRef = useRef<HTMLButtonElement | null>(null);
+  const customWidthInputRef = useRef<HTMLInputElement | null>(null);
   const sidebarUtilityBarRef = useRef<HTMLElement | null>(null);
   const rightRailActionsRef = useRef<HTMLDivElement | null>(null);
   const appShellRef = useRef<HTMLElement | null>(null);
   const sidebarWidthRef = useRef(sidebarWidth);
   const historyWidthRef = useRef(historyWidth);
   const expandedHistoryWidthRef = useRef(Math.max(historyWidth, MIN_HISTORY_WIDTH));
+
+  useEffect(() => {
+    if (isParameterDialogOpen && isCustomSizeMode) customWidthInputRef.current?.focus();
+  }, [isCustomSizeMode, isParameterDialogOpen]);
 
   const activeConfig = snapshot.providers.find(p => p.id === snapshot.activeProviderId) ?? snapshot.providers[0];
   const isSidebarCompact = isSidebarCollapsed || isAutoSidebarCollapsed;
@@ -1464,7 +1501,7 @@ export function App() {
   const activeInpaintCapability = inpaintCapabilityForParams(params);
   const usesExactMask = activeInpaintCapability === "exact-mask";
   const showMaskRouteNotice = requestMode === "inpaint" && Boolean(activeInpaintCapability);
-  const sizeSelectValue = openAIParams && sizePresets.includes(openAIParams.size) ? openAIParams.size : "custom";
+  const sizeSelectValue = openAIParams && !isCustomSizeMode && isGptImage2SizePreset(openAIParams.size) ? openAIParams.size : "custom";
   const streamDisabledReason = openAIParams ? streamPartialPreviewDisabledReason(openAIParams, activeConfig, requestMode, copy) : undefined;
   const streamPartialsAllowed = openAIParams ? !streamDisabledReason : false;
   const apiKeyPlaceholder = selectedApiConfig.apiKeyPreview ?? (selectedApiConfig.apiKeySaved ? copy.savedLocally : copy.pasteApiKey);
@@ -2615,7 +2652,7 @@ export function App() {
     setPrompt(draft.prompt);
     clearPromptChips();
     setParams(restoredParams);
-    updateCustomSizeFromParams(restoredParams, setCustomSize);
+    updateCustomSizeFromParams(restoredParams, setCustomSize, setIsCustomSizeMode);
     setBaseURL(config.baseURL);
     setInputAssets(draft.inputAssets);
     setMaskAsset(isGeneralImageParams(restoredParams) ? null : draft.maskAsset ?? null);
@@ -3332,7 +3369,7 @@ export function App() {
   function syncParamsToConfig(config: ProviderConfig) {
     setParams((current) => {
       const nextParams = createParamsForConfig(config, current);
-      updateCustomSizeFromParams(nextParams, setCustomSize);
+      updateCustomSizeFromParams(nextParams, setCustomSize, setIsCustomSizeMode);
       return nextParams;
     });
   }
@@ -3577,7 +3614,7 @@ export function App() {
       setMaskAsset(null);
       setMaskDataUrl(null);
     }
-    updateCustomSizeFromParams(nextParams, setCustomSize);
+    updateCustomSizeFromParams(nextParams, setCustomSize, setIsCustomSizeMode);
     markDraftChanged();
     setIsSavingConfig(true);
     try {
@@ -4323,7 +4360,7 @@ export function App() {
     setPrompt(job.prompt);
     clearPromptChips();
     setParams(reusedParams);
-    updateCustomSizeFromParams(reusedParams, setCustomSize);
+    updateCustomSizeFromParams(reusedParams, setCustomSize, setIsCustomSizeMode);
     setBaseURL(activeConfig.baseURL);
     if (job.providerKind === activeConfig.kind) {
       setSnapshot((current) => {
@@ -5565,6 +5602,27 @@ export function App() {
   }
 
   const sizeValidation = openAIParams ? validateGptImage2Size(openAIParams.size) : null;
+  const customSizeParts = editableImageSizeParts(customSize);
+
+  function selectOpenAIImageSize(value: string, revealCustomEditor: boolean) {
+    if (value === "custom") {
+      setIsCustomSizeMode(true);
+      updateOpenAIParams({ size: customSize });
+      if (revealCustomEditor) setIsParameterDialogOpen(true);
+      return;
+    }
+    setIsCustomSizeMode(false);
+    updateOpenAIParams({ size: value });
+  }
+
+  function updateCustomSizeDimension(dimension: "width" | "height", value: string) {
+    const digits = value.replace(/\D/g, "");
+    const nextParts = { ...customSizeParts, [dimension]: digits };
+    const nextSize = `${nextParts.width}x${nextParts.height}`;
+    setCustomSize(nextSize);
+    updateOpenAIParams({ size: nextSize });
+  }
+
   const maskDescription = activeInpaintCapability === "guided-region" ? copy.guidedRegionDescription : copy.maskDescription;
   const effectiveOpenAIImageRoute = openAIParams ? selectedOpenAIImageRoute(openAIParams, activeConfig, requestMode) : null;
   const imageRouteStatusText = openAIParams ? openAIImageRouteStatusText(copy, openAIParams, activeConfig, requestMode) : undefined;
@@ -5595,24 +5653,30 @@ export function App() {
   ) : null;
   const parameterQuickControls = openAIParams ? (
     <>
-      <label className="parameter-summary-chip parameter-quick-field">
+      <div className="parameter-summary-chip parameter-quick-field">
         <small>{copy.size}</small>
-        <select
-          aria-label={copy.size}
-          value={sizeSelectValue}
-          onChange={(event) => {
-            const value = event.target.value;
-            updateOpenAIParams({ size: value === "custom" ? customSize : value });
-          }}
-        >
-          {sizePresets.map((size) => (
-            <option key={size} value={size}>
-              {size}
-            </option>
-          ))}
-          <option value="custom">{copy.custom}</option>
-        </select>
-      </label>
+        <div className="parameter-quick-size-control">
+          <select
+            aria-label={copy.size}
+            value={sizeSelectValue}
+            onChange={(event) => selectOpenAIImageSize(event.target.value, true)}
+          >
+            {renderSizePresetOptions(false)}
+            <option value="custom">{copy.custom}</option>
+          </select>
+          {sizeSelectValue === "custom" && (
+            <button
+              type="button"
+              className="icon-button parameter-custom-size-edit"
+              onClick={() => setIsParameterDialogOpen(true)}
+              aria-label={copy.editCustomSize}
+              data-tooltip={copy.editCustomSize}
+            >
+              <Pencil size={13} />
+            </button>
+          )}
+        </div>
+      </div>
       <label className="parameter-summary-chip parameter-quick-field">
         <small>{copy.quality}</small>
         <select aria-label={copy.quality} value={openAIParams.quality} onChange={(event) => updateOpenAIParams({ quality: event.target.value as ImageQuality })}>
@@ -5698,16 +5762,9 @@ export function App() {
         <span>{copy.size}</span>
         <select
           value={sizeSelectValue}
-          onChange={(event) => {
-            const value = event.target.value;
-            updateOpenAIParams({ size: value === "custom" ? customSize : value });
-          }}
+          onChange={(event) => selectOpenAIImageSize(event.target.value, false)}
         >
-          {sizePresets.map((size) => (
-            <option key={size} value={size}>
-              {size}
-            </option>
-          ))}
+          {renderSizePresetOptions(true)}
           <option value="custom">{copy.custom}</option>
         </select>
       </label>
@@ -5798,17 +5855,48 @@ export function App() {
   const advancedControls = openAIParams ? (
     <div className="advanced-controls">
       {sizeSelectValue === "custom" && (
-        <label>
-          {copy.customSize}
-          <input
-            value={customSize}
-            onChange={(event) => {
-              setCustomSize(event.target.value);
-              updateOpenAIParams({ size: event.target.value });
-            }}
-            placeholder="2048x1152"
-          />
-        </label>
+        <div className="custom-size-editor">
+          <div className="custom-size-editor-heading">
+            <strong>{copy.customSize}</strong>
+            <span>{customSize}</span>
+          </div>
+          <div className="custom-size-inputs">
+            <label>
+              <span>{copy.customWidth}</span>
+              <input
+                ref={customWidthInputRef}
+                aria-invalid={sizeValidation?.ok === false}
+                aria-describedby="custom-size-feedback custom-size-rules"
+                type="number"
+                min="16"
+                max="3840"
+                step="16"
+                value={customSizeParts.width}
+                onChange={(event) => updateCustomSizeDimension("width", event.target.value)}
+              />
+            </label>
+            <span className="custom-size-separator" aria-hidden="true">x</span>
+            <label>
+              <span>{copy.customHeight}</span>
+              <input
+                aria-invalid={sizeValidation?.ok === false}
+                aria-describedby="custom-size-feedback custom-size-rules"
+                type="number"
+                min="16"
+                max="3840"
+                step="16"
+                value={customSizeParts.height}
+                onChange={(event) => updateCustomSizeDimension("height", event.target.value)}
+              />
+            </label>
+          </div>
+          {sizeValidation && (
+            <p id="custom-size-feedback" className={sizeValidation.ok ? "inline-check ok" : "inline-check error"}>
+              {sizeValidation.ok ? copy.sizeValid : localizeValidationMessage(sizeValidation.message, copy)}
+            </p>
+          )}
+          <p id="custom-size-rules" className="custom-size-rules">{copy.customSizeRules}</p>
+        </div>
       )}
       {referenceImageModeControl}
       <label>
@@ -5896,7 +5984,7 @@ export function App() {
           onChange={(event) => updateOpenAIParams({ timeoutMs: clamp(Number(event.target.value), 30, 600) * 1000 })}
         />
       </label>
-      {sizeValidation && (
+      {sizeValidation && sizeSelectValue !== "custom" && (
         <p className={sizeValidation.ok ? "inline-check ok" : "inline-check error"}>
           {sizeValidation.ok ? copy.sizeValid : localizeValidationMessage(sizeValidation.message, copy)}
         </p>

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -394,6 +394,10 @@ export interface UiCopy {
   format: string;
   custom: string;
   customSize: string;
+  editCustomSize: string;
+  customWidth: string;
+  customHeight: string;
+  customSizeRules: string;
   compression: string;
   pngIgnoresCompression: string;
   background: string;
@@ -943,6 +947,10 @@ export const translations: Record<Language, UiCopy> = {
     format: "Format",
     custom: "custom",
     customSize: "Custom size",
+    editCustomSize: "Edit custom size",
+    customWidth: "Width",
+    customHeight: "Height",
+    customSizeRules: "Width and height must be multiples of 16. Maximum side: 3840px. Aspect ratio: up to 3:1. Total pixels: 655,360 to 8,294,400.",
     compression: "Compression",
     pngIgnoresCompression: "PNG ignores compression",
     background: "Background",
@@ -1556,6 +1564,10 @@ export const translations: Record<Language, UiCopy> = {
     format: "格式",
     custom: "自定义",
     customSize: "自定义尺寸",
+    editCustomSize: "编辑自定义尺寸",
+    customWidth: "宽度",
+    customHeight: "高度",
+    customSizeRules: "宽高均须为 16 的倍数；最长边不超过 3840px；长短边比例不超过 3:1；总像素为 655,360 至 8,294,400。",
     compression: "压缩",
     pngIgnoresCompression: "PNG 不使用压缩参数",
     background: "背景",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5815,6 +5815,19 @@
       min-height var(--motion-fast);
   }
 
+  /* Keep native select menus aligned with the active light/dark theme. */
+  .parameter-config-bar .parameter-quick-field select {
+    background-color: var(--surface-panel);
+    color: var(--text-primary);
+    color-scheme: inherit;
+  }
+
+  .parameter-config-bar .parameter-quick-field select option,
+  .parameter-config-bar .parameter-quick-field select optgroup {
+    background-color: var(--surface-panel);
+    color: var(--text-primary);
+  }
+
   .parameter-config-bar:hover .parameter-quick-field select,
   .parameter-config-bar:hover .parameter-quick-field input,
   .parameter-quick-field:focus-within select,
@@ -5826,6 +5839,27 @@
   .parameter-quick-field select:focus-visible,
   .parameter-quick-field input:focus-visible {
     outline: none;
+  }
+
+  .parameter-quick-size-control {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .parameter-quick-size-control select {
+    width: 100%;
+  }
+
+  .parameter-custom-size-edit {
+    width: 24px;
+    min-width: 24px;
+    height: 24px;
+    min-height: 24px;
+    padding: 0;
   }
 
   .parameter-route-field {
@@ -5908,6 +5942,82 @@
   .parameter-dialog .advanced-controls {
     align-content: start;
     min-height: 0;
+  }
+
+  .custom-size-editor {
+    display: grid;
+    gap: 8px;
+    min-width: 0;
+    padding: 10px 0;
+    border-top: 1px solid var(--border-subtle);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .custom-size-editor-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .custom-size-editor-heading strong {
+    color: var(--text-primary);
+    font-size: 12px;
+  }
+
+  .custom-size-editor-heading span {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-muted);
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .custom-size-inputs {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: end;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .advanced-controls .custom-size-inputs label {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+    gap: 4px;
+  }
+
+  .custom-size-inputs label > span {
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+
+  .custom-size-inputs input[aria-invalid="true"] {
+    border-color: var(--danger);
+  }
+
+  .custom-size-separator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--control-height);
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  .custom-size-editor .inline-check,
+  .custom-size-rules {
+    margin: 0;
+  }
+
+  .custom-size-rules {
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
   }
 
   .prompt-composer {

--- a/src/shared/imageSizePresets.test.ts
+++ b/src/shared/imageSizePresets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  GPT_IMAGE_2_SIZE_PRESET_GROUPS,
+  GPT_IMAGE_2_SIZE_PRESET_VALUES
+} from "./imageSizePresets";
+import { validateGptImage2Size } from "./validation";
+
+describe("GPT Image 2 size presets", () => {
+  it("keeps the requested aspect-ratio and resolution matrix", () => {
+    expect(GPT_IMAGE_2_SIZE_PRESET_GROUPS).toEqual([
+      { aspectRatio: "1:1", presets: [{ tier: "1K", size: "1024x1024" }, { tier: "2K", size: "2048x2048" }, { tier: "4K", size: "2880x2880" }] },
+      { aspectRatio: "3:2", presets: [{ tier: "1K", size: "1536x1024" }, { tier: "2K", size: "2160x1440" }, { tier: "4K", size: "3456x2304" }] },
+      { aspectRatio: "2:3", presets: [{ tier: "1K", size: "1024x1536" }, { tier: "2K", size: "1440x2160" }, { tier: "4K", size: "2304x3456" }] },
+      { aspectRatio: "16:9", presets: [{ tier: "1K", size: "1280x720" }, { tier: "2K", size: "2560x1440" }, { tier: "4K", size: "3840x2160" }] },
+      { aspectRatio: "9:16", presets: [{ tier: "1K", size: "720x1280" }, { tier: "2K", size: "1440x2560" }, { tier: "4K", size: "2160x3840" }] },
+      { aspectRatio: "4:3", presets: [{ tier: "1K", size: "1024x768" }, { tier: "2K", size: "2048x1536" }, { tier: "4K", size: "3200x2400" }] },
+      { aspectRatio: "3:4", presets: [{ tier: "1K", size: "768x1024" }, { tier: "2K", size: "1536x2048" }, { tier: "4K", size: "2400x3200" }] },
+      { aspectRatio: "21:9", presets: [{ tier: "1K", size: "1280x544" }, { tier: "2K", size: "2560x1088" }, { tier: "4K", size: "3840x1600" }] }
+    ]);
+  });
+
+  it("keeps every preset within the shared custom-size constraints", () => {
+    expect(GPT_IMAGE_2_SIZE_PRESET_VALUES).toHaveLength(25);
+    for (const size of GPT_IMAGE_2_SIZE_PRESET_VALUES) {
+      expect(validateGptImage2Size(size), size).toMatchObject({ ok: true });
+    }
+  });
+
+  it("accepts inclusive pixel boundaries and rejects each custom-size limit", () => {
+    expect(validateGptImage2Size("1024x640").ok).toBe(true);
+    expect(validateGptImage2Size("2880x2880").ok).toBe(true);
+    expect(validateGptImage2Size("3840x2160").ok).toBe(true);
+    expect(validateGptImage2Size("1024x641").ok).toBe(false);
+    expect(validateGptImage2Size("3856x2160").ok).toBe(false);
+    expect(validateGptImage2Size("3840x1264").ok).toBe(false);
+  });
+});

--- a/src/shared/imageSizePresets.ts
+++ b/src/shared/imageSizePresets.ts
@@ -1,0 +1,87 @@
+export type GptImage2ResolutionTier = "1K" | "2K" | "4K";
+
+export interface GptImage2SizePreset {
+  tier: GptImage2ResolutionTier;
+  size: string;
+}
+
+export interface GptImage2SizePresetGroup {
+  aspectRatio: string;
+  presets: readonly GptImage2SizePreset[];
+}
+
+export const GPT_IMAGE_2_SIZE_PRESET_GROUPS = [
+  {
+    aspectRatio: "1:1",
+    presets: [
+      { tier: "1K", size: "1024x1024" },
+      { tier: "2K", size: "2048x2048" },
+      { tier: "4K", size: "2880x2880" }
+    ]
+  },
+  {
+    aspectRatio: "3:2",
+    presets: [
+      { tier: "1K", size: "1536x1024" },
+      { tier: "2K", size: "2160x1440" },
+      { tier: "4K", size: "3456x2304" }
+    ]
+  },
+  {
+    aspectRatio: "2:3",
+    presets: [
+      { tier: "1K", size: "1024x1536" },
+      { tier: "2K", size: "1440x2160" },
+      { tier: "4K", size: "2304x3456" }
+    ]
+  },
+  {
+    aspectRatio: "16:9",
+    presets: [
+      { tier: "1K", size: "1280x720" },
+      { tier: "2K", size: "2560x1440" },
+      { tier: "4K", size: "3840x2160" }
+    ]
+  },
+  {
+    aspectRatio: "9:16",
+    presets: [
+      { tier: "1K", size: "720x1280" },
+      { tier: "2K", size: "1440x2560" },
+      { tier: "4K", size: "2160x3840" }
+    ]
+  },
+  {
+    aspectRatio: "4:3",
+    presets: [
+      { tier: "1K", size: "1024x768" },
+      { tier: "2K", size: "2048x1536" },
+      { tier: "4K", size: "3200x2400" }
+    ]
+  },
+  {
+    aspectRatio: "3:4",
+    presets: [
+      { tier: "1K", size: "768x1024" },
+      { tier: "2K", size: "1536x2048" },
+      { tier: "4K", size: "2400x3200" }
+    ]
+  },
+  {
+    aspectRatio: "21:9",
+    presets: [
+      { tier: "1K", size: "1280x544" },
+      { tier: "2K", size: "2560x1088" },
+      { tier: "4K", size: "3840x1600" }
+    ]
+  }
+] as const satisfies readonly GptImage2SizePresetGroup[];
+
+export const GPT_IMAGE_2_SIZE_PRESET_VALUES: readonly string[] = [
+  "auto",
+  ...GPT_IMAGE_2_SIZE_PRESET_GROUPS.flatMap((group) => group.presets.map((preset) => preset.size))
+];
+
+export function isGptImage2SizePreset(value: string): boolean {
+  return GPT_IMAGE_2_SIZE_PRESET_VALUES.includes(value);
+}


### PR DESCRIPTION
## Summary

- add 24 GPT Image 2 resolution presets across 8 aspect ratios and 1K/2K/4K tiers
- add functional custom width/height inputs with validation for multiples of 16, maximum edge, aspect ratio, and total pixel bounds
- make the main generation parameter selects follow the active light/dark theme, including native options and optgroups
- add focused tests for preset coverage, custom-size validation, and renderer behavior

## Surface

- [x] Desktop app
- [ ] JSON CLI
- [ ] MCP server
- [x] Shared core or persistence
- [x] Packaging, release, or documentation

## Validation

```text
129 related tests passed
pnpm typecheck
pnpm build:main
pnpm build:renderer
Windows package smoke test, including successful packaged app startup
```

## Package verification

- installer: `release/CrossGen-Setup.exe` (not committed)
- SHA-256: `85DFF6BB65343F5D42C567F7EB34B80A5E97B3F152B47F1D5F006E143EEC7053`
- installer is unsigned

## Checklist

- [x] The change is focused and includes tests for behavior changes.
- [x] English and Chinese user-facing strings are synchronized.
- [x] No API keys, private images, local state, logs, or build artifacts are included.
- [x] Real-provider checks were not run without explicit cost approval.