### PR TITLE
docs: close out v0.3.4 implementation status

### DIFF
--- a/docs/release/v0.3.4-preflight.md
+++ b/docs/release/v0.3.4-preflight.md
@@ -1,8 +1,8 @@
 # CrossGen v0.3.4 Release Preflight
 
-> Status: implementation and AIHub operation gates complete; final external release gates pending
+> Status: v0.3.4 implementation merged; final external release gates pending
 > Updated: 2026-09-04
-> Candidate branch: `codex/v0.3.4-applink`
+> Merged implementation: `origin/main@27ca684a01e313181e28fdf5c52bec2b79eb3428` (PR #212)
 > Candidate code SHA: `0c96763334b5fc1556428836cbaffc7770c95cad`
 > Release evidence ledger SHA: `72b9c05b2c8625c1b8240998ddf1c25a65bfd52d`
 > Scope: Media Foundation + AppLink provider import
@@ -79,8 +79,8 @@ public Release assets. Local evidence also includes the exact-candidate signed
 macOS arm64 DMG/ZIP, Developer ID codesign verification, AppLink compatibility
 fixtures, media migration rollback fault injection, media-aware UI boundaries,
 and CLI/MCP metadata redaction.
-The latest PR CI run `33909291500` on remote HEAD
-`8e9d9578a6217ca0bf33afbc35684262240de1eb` independently re-ran build/mock,
+The latest PR CI run `33910543882` on merge-parent head
+`0fc927b2c2b63e9334ce2e2f2da1946a5b02ee43` independently re-ran build/mock,
 macOS, Windows, and Linux package jobs and all four completed successfully; its
 pull-request workflow intentionally did not retain duplicate package artifacts.
 


### PR DESCRIPTION
## Summary
- record v0.3.4 implementation merge at main@27ca684
- align preflight with the latest CI run 33910543882
- keep product acceptance and public release assets as explicit external gates

## Validation
- pnpm build
- pnpm lint
- pnpm verify:release-evidence:v0.3.4
- pnpm verify:mock-api
- pnpm verify:mock-gemini-api
- pnpm verify:mock-model-discovery
- pnpm verify:cli-mcp-smoke
- pnpm verify:agent-integration-smoke